### PR TITLE
feat: auto-save journey on generation, remove manual save button

### DIFF
--- a/frontend/lib/common/config/router_config.dart
+++ b/frontend/lib/common/config/router_config.dart
@@ -88,12 +88,10 @@ class RouterConfig {
                 params['narrationAspect'] as NarrationAspect?;
             final narrationContent =
                 params['narrationContent'] as NarrationContent?;
-            final enableSave = params['enableSave'] as bool? ?? true;
             return NarrationScreen(
               place: place,
               narrationAspect: narrationAspect,
               narrationContent: narrationContent,
-              enableSave: enableSave,
             );
           },
         ),

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -106,7 +106,6 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
       extra: {
         'place': place,
         'narrationContent': widget.entry.narrationContent,
-        'enableSave': false,
       },
     );
   }

--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -75,6 +75,9 @@ class PlayerController extends StateNotifier<NarrationState> {
 
       // 更新狀態為就緒
       state = state.ready(place, aspect, content);
+
+      // 自動儲存到歷程
+      await _autoSaveToJourney(place, aspect, content, language);
     } on AppError catch (e) {
       final stateErrorType = _mapAppErrorToStateError(e.type);
       state = state.error(stateErrorType, message: e.message);
@@ -132,25 +135,23 @@ class PlayerController extends StateNotifier<NarrationState> {
     state = state.ready(place, null, content);
   }
 
-  /// 儲存導覽到歷程
-  Future<void> saveToJourney({required Language language}) async {
-    if (state.content == null || state.place == null || state.aspect == null) {
-      return;
-    }
-
+  /// 自動儲存導覽到歷程（生成完成後靜默儲存）
+  Future<void> _autoSaveToJourney(
+    Place place,
+    NarrationAspect aspect,
+    NarrationContent content,
+    Language language,
+  ) async {
     try {
       final entry = JourneyEntry.create(
-        place: state.place!,
-        aspect: state.aspect!,
-        content: state.content!,
+        place: place,
+        aspect: aspect,
+        content: content,
         language: language,
       );
-
       await _journeyRepository.save(entry);
-    } catch (e) {
-      // 這裡可以選擇透過 state 通知 UI 錯誤，或者拋出異常讓 UI 處理
-      // 為了簡單起見，我們暫時不改變 state，但理想情況下應該有 toast 通知
-      rethrow;
+    } catch (_) {
+      // 靜默失敗，不影響播放體驗
     }
   }
 

--- a/frontend/lib/features/narration/presentation/screens/narration_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/narration_screen.dart
@@ -17,14 +17,12 @@ class NarrationScreen extends ConsumerStatefulWidget {
   final Place place;
   final NarrationAspect? narrationAspect;
   final NarrationContent? narrationContent;
-  final bool enableSave;
 
   const NarrationScreen({
     super.key,
     required this.place,
     this.narrationAspect,
     this.narrationContent,
-    this.enableSave = true,
   });
 
   @override
@@ -207,7 +205,6 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
             primaryColorShadow: primaryColorShadow,
             surfaceColor: surfaceColor,
             backgroundColor: backgroundColor,
-            enableSave: widget.enableSave,
           ),
         ],
       ),

--- a/frontend/lib/features/narration/presentation/widgets/narration_control_panel.dart
+++ b/frontend/lib/features/narration/presentation/widgets/narration_control_panel.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/providers.dart';
-import 'package:context_app/features/narration/presentation/widgets/save_to_passport_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,7 +11,6 @@ class NarrationControlPanel extends ConsumerWidget {
   final Color primaryColorShadow;
   final Color surfaceColor;
   final Color backgroundColor;
-  final bool enableSave;
 
   const NarrationControlPanel({
     super.key,
@@ -21,7 +19,6 @@ class NarrationControlPanel extends ConsumerWidget {
     required this.primaryColorShadow,
     required this.surfaceColor,
     required this.backgroundColor,
-    this.enableSave = true,
   });
 
   @override
@@ -173,13 +170,6 @@ class NarrationControlPanel extends ConsumerWidget {
                 ),
 
                 const SizedBox(height: 24),
-
-                // Save Button
-                if (enableSave)
-                  SaveToPassportButton(
-                    place: place,
-                    surfaceColor: surfaceColor,
-                  ),
               ],
             ),
           ),


### PR DESCRIPTION
- PlayerController.initialize() now auto-saves to journey silently
  after content is generated, replacing the manual save flow
- Removed SaveToPassportButton and enableSave parameter from
  NarrationControlPanel, NarrationScreen, and router
- Journey card click already uses replay (initializeWithContent),
  cleaned up the unused enableSave: false param from navigation

https://claude.ai/code/session_01JUBnfczGYLfxp7wnicfJzg