### PR TITLE
Fix nav style layout overflow and simplify aspect descriptions

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -146,15 +146,15 @@
   },
   "narration_aspect": {
     "historical_background": "Historical Background",
-    "historical_background_description": "Stories about the people",
+    "historical_background_description": "People, events, and historical context",
     "architecture": "Architectural Details",
-    "architecture_description": "Symbolic meanings beyond what meets the eye",
+    "architecture_description": "Materials, techniques, and style",
     "customs": "Cultural Customs",
-    "customs_description": "What to do and why",
+    "customs_description": "Taboos, rituals, and daily practices",
     "geology": "Geological Formation",
-    "geology_description": "How the landscape was formed",
+    "geology_description": "Strata, landforms, and natural formation",
     "myths": "Legends & Stories",
-    "myths_description": "Mythical tales of the landscape"
+    "myths_description": "Folk tales and myths"
   },
   "camera": {
     "title": "Photo Recognition",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -146,15 +146,15 @@
   },
   "narration_aspect": {
     "historical_background": "歷史背景",
-    "historical_background_description": "講述「人」的故事",
+    "historical_background_description": "人物、事件、時代背景",
     "architecture": "建築細節",
-    "architecture_description": "解讀肉眼看不到的象徵意義",
+    "architecture_description": "建材、工法、建築風格",
     "customs": "文化禁忌與習俗",
-    "customs_description": "告訴遊客該怎麼做、為什麼這麼做",
+    "customs_description": "禁忌、儀式、日常習俗",
     "geology": "地理成因",
-    "geology_description": "用簡單的比喻解釋地貌形成",
+    "geology_description": "地層、地貌、自然成因",
     "myths": "傳說故事",
-    "myths_description": "賦予山水靈性"
+    "myths_description": "民間傳說與神話"
   },
   "camera": {
     "title": "拍照辨識",

--- a/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
@@ -62,119 +62,134 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
             bottom: 0,
             left: 0,
             right: 0,
-            child: Container(
-              padding: const EdgeInsets.all(20.0),
-              decoration: const BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.bottomCenter,
-                  end: Alignment.topCenter,
-                  colors: [
-                    AppColors.backgroundDark,
-                    Color(0xCC101922),
-                    Colors.transparent,
-                  ],
-                ),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.85,
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Place Name
-                  Text(
-                    place.name,
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold,
-                    ),
+              child: Container(
+                padding: const EdgeInsets.all(20.0),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.bottomCenter,
+                    end: Alignment.topCenter,
+                    colors: [
+                      AppColors.backgroundDark,
+                      Color(0xCC101922),
+                      Colors.transparent,
+                    ],
                   ),
-                  const SizedBox(height: 8),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Place Name
+                    Text(
+                      place.name,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 32,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
 
-                  // Place Category Badge
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: place.category.color.withValues(alpha: 0.3),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: place.category.color, width: 1),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          place.category.icon,
-                          size: 16,
-                          color: Colors.white,
+                    // Place Category Badge
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 6,
+                      ),
+                      decoration: BoxDecoration(
+                        color: place.category.color.withValues(alpha: 0.3),
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(
+                          color: place.category.color,
+                          width: 1,
                         ),
-                        const SizedBox(width: 6),
-                        Text(
-                          place.category.translationKey.tr(),
-                          style: const TextStyle(
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            place.category.icon,
+                            size: 16,
                             color: Colors.white,
-                            fontSize: 12,
-                            fontWeight: FontWeight.bold,
+                          ),
+                          const SizedBox(width: 6),
+                          Text(
+                            place.category.translationKey.tr(),
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+
+                    // Place Address
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.location_on,
+                          color: Colors.white70,
+                          size: 16,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            place.formattedAddress,
+                            style: const TextStyle(
+                              color: Colors.white70,
+                              fontSize: 14,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           ),
                         ),
                       ],
                     ),
-                  ),
-                  const SizedBox(height: 12),
+                    const SizedBox(height: 24),
 
-                  // Place Address
-                  Row(
-                    children: [
-                      const Icon(
-                        Icons.location_on,
-                        color: Colors.white70,
-                        size: 16,
+                    // Title
+                    Text(
+                      'config_screen.select_aspect_title'.tr(),
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
                       ),
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: Text(
-                          place.formattedAddress,
-                          style: const TextStyle(
-                            color: Colors.white70,
-                            fontSize: 14,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Aspect Options (scrollable)
+                    Flexible(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          children: availableAspects.map((aspect) {
+                            return Padding(
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: AspectOption(
+                                aspect: aspect,
+                                isSelected: selectedAspect == aspect,
+                                onTap: () {
+                                  ref
+                                      .read(narrationAspectProvider.notifier)
+                                      .state = aspect;
+                                },
+                              ),
+                            );
+                          }).toList(),
                         ),
                       ),
-                    ],
-                  ),
-                  const SizedBox(height: 24),
-
-                  // Title
-                  Text(
-                    'config_screen.select_aspect_title'.tr(),
-                    style: const TextStyle(
-                      color: Colors.white,
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
                     ),
-                  ),
-                  const SizedBox(height: 16),
+                    const SizedBox(height: 24),
 
-                  // Aspect Options
-                  ...availableAspects.map((aspect) {
-                    return Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: AspectOption(
-                        aspect: aspect,
-                        isSelected: selectedAspect == aspect,
-                        onTap: () {
-                          ref.read(narrationAspectProvider.notifier).state =
-                              aspect;
-                        },
-                      ),
-                    );
-                  }),
-                  const SizedBox(height: 24),
-
-                  // Start Button
-                  ElevatedButton(
+                    // Start Button
+                    ElevatedButton(
                     onPressed: () async {
                       final usageRepo = ref.read(usageRepositoryProvider);
                       final status = await usageRepo.getUsageStatus();
@@ -226,6 +241,7 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
               ),
             ),
           ),
+        ),
         ],
       ),
     );


### PR DESCRIPTION
- Wrap aspect options list in Flexible + SingleChildScrollView so it
  scrolls when the screen is too small, preventing the title from being
  clipped off the top
- Add ConstrainedBox (maxHeight 85% of screen) on the bottom panel so
  fixed elements (place name, address, start button) stay visible
- Replace tour-guide metaphor descriptions with factual keyword lists
  in both zh-TW and en translations

https://claude.ai/code/session_01JjRyA2TVcnbqTr363MNcHU