### PR TITLE
Add public saveToJourney method to PlayerController

### DIFF
--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -155,6 +155,22 @@ class PlayerController extends StateNotifier<NarrationState> {
     }
   }
 
+  /// 手動儲存導覽到歷程
+  Future<void> saveToJourney({required Language language}) async {
+    final place = state.place;
+    final aspect = state.aspect;
+    final content = state.content;
+    if (place == null || aspect == null || content == null) return;
+
+    final entry = JourneyEntry.create(
+      place: place,
+      aspect: aspect,
+      content: content,
+      language: language,
+    );
+    await _journeyRepository.save(entry);
+  }
+
   /// 設定 TTS 事件監聽器
   void _setupTtsListeners() {
     // 監聽播放完成事件


### PR DESCRIPTION
The save_to_passport_button.dart was calling saveToJourney on PlayerController,
but only a private _autoSaveToJourney existed. Add the public method to fix the
analyzer error.

https://claude.ai/code/session_013ST34DTZm3AQZ2Xu4nKofM