### PR TITLE
fix: resolve journey delete button tap conflict and remove redundant replay button

### DIFF
--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -318,39 +318,37 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                       const SizedBox(height: 16),
 
                       // Action Bar
-                      Container(
-                        padding: const EdgeInsets.only(top: 12),
-                        decoration: BoxDecoration(
-                          border: Border(
-                            top: BorderSide(
-                              color: Colors.white.withValues(alpha: 0.08),
+                      GestureDetector(
+                        onTap: () {},
+                        child: Container(
+                          padding: const EdgeInsets.only(top: 12),
+                          decoration: BoxDecoration(
+                            border: Border(
+                              top: BorderSide(
+                                color: Colors.white.withValues(alpha: 0.08),
+                              ),
                             ),
                           ),
-                        ),
-                        child: Row(
-                          children: [
-                            _ActionButton(
-                              icon: Icons.mic_outlined,
-                              label: 'passport.replay'.tr(),
-                              onTap: _navigateToPlayer,
-                            ),
-                            const Spacer(),
-                            if (_isDeleting)
-                              const SizedBox(
-                                width: 18,
-                                height: 18,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: AppColors.primary,
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              if (_isDeleting)
+                                const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: AppColors.primary,
+                                  ),
+                                )
+                              else
+                                _ActionButton(
+                                  icon: Icons.delete_outline,
+                                  label: 'passport.delete_confirm'.tr(),
+                                  onTap: _showDeleteConfirmDialog,
                                 ),
-                              )
-                            else
-                              _ActionButton(
-                                icon: Icons.delete_outline,
-                                label: 'passport.delete_confirm'.tr(),
-                                onTap: _showDeleteConfirmDialog,
-                              ),
-                          ],
+                            ],
+                          ),
                         ),
                       ),
                     ],


### PR DESCRIPTION
Wrap the action bar in a GestureDetector(onTap: () {}) to absorb stray
taps in the action bar area, preventing the outer card's replay gesture
from firing when the user intends to tap the delete button. Remove the
replay _ActionButton since tapping the card itself now handles replay.

https://claude.ai/code/session_019hApgiQWesBPAr2tem6bMk