### PR TITLE
fix: journey delete UI freeze, replay regeneration, remove camera button

### DIFF
--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -92,39 +92,21 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                               color: AppColors.textPrimaryDark,
                             ),
                           ),
-                          Row(
-                            children: [
-                              IconButton(
-                                onPressed: () {
-                                  context.pushNamed('camera');
-                                },
-                                icon: const Icon(Icons.camera_alt),
-                                style: ElevatedButton.styleFrom(
-                                  foregroundColor: Colors.white,
-                                  backgroundColor: AppColors.primary,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(20),
-                                  ),
-                                ),
+                          IconButton(
+                            onPressed: () {
+                              _searchController.clear();
+                              ref
+                                  .read(placesControllerProvider.notifier)
+                                  .refresh();
+                            },
+                            icon: const Icon(Icons.refresh),
+                            style: ElevatedButton.styleFrom(
+                              foregroundColor: Colors.white,
+                              backgroundColor: AppColors.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(20),
                               ),
-                              const SizedBox(width: 8),
-                              IconButton(
-                                onPressed: () {
-                                  _searchController.clear();
-                                  ref
-                                      .read(placesControllerProvider.notifier)
-                                      .refresh();
-                                },
-                                icon: const Icon(Icons.refresh),
-                                style: ElevatedButton.styleFrom(
-                                  foregroundColor: Colors.white,
-                                  backgroundColor: AppColors.primary,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(20),
-                                  ),
-                                ),
-                              ),
-                            ],
+                            ),
                           ),
                         ],
                       ),

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -68,8 +68,8 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
 
       try {
         await ref.read(journeyRepositoryProvider).delete(widget.entry.id);
-        // 刷新列表
         ref.invalidate(myJourneyProvider);
+        ref.invalidate(allJourneyItemsProvider);
       } catch (e) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -125,7 +125,12 @@ class PlayerController extends StateNotifier<NarrationState> {
     Place place,
     NarrationContent content,
   ) async {
-    state = state.loading();
+    // 立即顯示內容讓使用者知道這是回放，TTS 初始化期間播放鈕暫時停用
+    state = NarrationState(
+      place: place,
+      content: content,
+      playerState: PlayerState.loading(),
+    );
 
     // 初始化 TtsService
     await _ttsService.initialize();

--- a/frontend/lib/features/narration/presentation/screens/narration_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/narration_screen.dart
@@ -45,8 +45,8 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
         ref
             .read(playerControllerProvider.notifier)
             .initializeWithContent(widget.place, widget.narrationContent!);
-      } else {
-        // 生成新的導覽內容
+      } else if (widget.narrationAspect != null) {
+        // 生成新的導覽內容（需要明確的 narrationAspect）
         final locale =
             easy.EasyLocalization.of(context)?.locale.toLanguageTag() ??
             'zh-TW';
@@ -54,7 +54,7 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
             .read(playerControllerProvider.notifier)
             .initialize(
               widget.place,
-              widget.narrationAspect ?? NarrationAspect.historicalBackground,
+              widget.narrationAspect!,
               language: Language(locale),
             );
       }

--- a/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
+++ b/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
@@ -42,7 +42,7 @@ class NarrationTranscriptArea extends ConsumerWidget {
 
     // 載入中且尚無內容（生成模式）才顯示 spinner；
     // 回放模式下 content 已立即設定，直接顯示轉錄文字
-    if (playerState.isLoading && content == null) {
+    if (playerState.isLoading && playerState.content == null) {
       return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
+++ b/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
@@ -40,8 +40,9 @@ class NarrationTranscriptArea extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final playerState = ref.watch(playerControllerProvider);
 
-    // 載入中狀態
-    if (playerState.isLoading) {
+    // 載入中且尚無內容（生成模式）才顯示 spinner；
+    // 回放模式下 content 已立即設定，直接顯示轉錄文字
+    if (playerState.isLoading && content == null) {
       return Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
- timeline_entry: also invalidate allJourneyItemsProvider after delete so
  the journey list refreshes immediately without leaving the page
- narration_screen: only call initialize() when narrationAspect is
  explicitly set; prevents accidental narration regeneration when
  navigating to player from the journey timeline (where narrationAspect
  is always null)
- player_controller: in initializeWithContent, set place + content before
  entering loading state so the transcript is visible immediately during
  TTS initialisation (makes replay obviously distinct from generation)
- narration_transcript_area: skip the loading spinner when content is
  already available, falling through to render the transcript directly
- explore_screen: remove camera button and its spacing

https://claude.ai/code/session_01W2MLHvU6gRTjgPJVvNvFEa