### PR TITLE
fix: resolve prefer_final_locals and prefer_null_aware_operators violations

### DIFF
--- a/frontend/lib/features/explore/data/services/geolocator_service.dart
+++ b/frontend/lib/features/explore/data/services/geolocator_service.dart
@@ -5,11 +5,9 @@ import 'package:context_app/features/explore/domain/services/location_service.da
 class GeolocatorService implements LocationService {
   @override
   Future<PlaceLocation> getCurrentLocation() async {
-    bool serviceEnabled;
-    LocationPermission permission;
-
     // Test if location services are enabled.
-    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    final bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    LocationPermission permission;
     if (!serviceEnabled) {
       // Location services are not enabled don't continue
       // accessing the position and request users of the

--- a/frontend/lib/features/journey/domain/models/journey_entry.dart
+++ b/frontend/lib/features/journey/domain/models/journey_entry.dart
@@ -32,10 +32,7 @@ class JourneyEntry {
   }) {
     const uuid = Uuid();
 
-    String? imageUrl;
-    if (place.primaryPhoto != null) {
-      imageUrl = place.primaryPhoto!.url;
-    }
+    final String? imageUrl = place.primaryPhoto?.url;
 
     final savedPlace = SavedPlace(
       id: place.id,

--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -246,7 +246,7 @@ class PlayerController extends StateNotifier<NarrationState> {
       await _ttsService.stop();
     }
 
-    String textToPlay;
+    final String textToPlay;
     if (isResuming) {
       // 從暫停位置恢復播放：截取當前位置到結尾的文本
       _charPositionOffset = currentPos;

--- a/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
+++ b/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
@@ -40,7 +40,7 @@ class _QuickGuideScreenState extends ConsumerState<QuickGuideScreen> {
   ) async {
     final language = _currentLanguage();
 
-    NarrationContent content;
+    final NarrationContent content;
     try {
       content = NarrationContent.create(description, language: language);
     } catch (_) {


### PR DESCRIPTION
- quick_guide_screen: declare `content` as final (definitely assigned via try-catch-return)
- player_controller: declare `textToPlay` as final (definitely assigned via if-else)
- geolocator_service: combine `serviceEnabled` declaration and await assignment
- journey_entry: replace null-check + `!` with null-aware operator `?.`

https://claude.ai/code/session_01TQQtw9iHuTdHN7wgF2r4zh