### PR TITLE
Refactor narration generation to separate concerns between generation and playback

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -13,7 +13,11 @@
   "config_screen": {
     "title": "Select Narration Depth",
     "select_aspect_title": "Select Narration Aspect",
-    "start_button": "Start Guide"
+    "start_button": "Start Guide",
+    "generating": "Generating narration...",
+    "generation_error_title": "Generation Failed",
+    "generation_error_message": "Failed to generate narration. Please try again later.",
+    "generation_error_ok": "OK"
   },
   "narration_style": {
     "brief": "Brief",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -13,7 +13,11 @@
   "config_screen": {
     "title": "選擇解說深度",
     "select_aspect_title": "選擇導覽面向",
-    "start_button": "開始導覽"
+    "start_button": "開始導覽",
+    "generating": "正在生成導覽內容...",
+    "generation_error_title": "生成失敗",
+    "generation_error_message": "導覽內容生成失敗，請稍後再試。",
+    "generation_error_ok": "確定"
   },
   "narration_style": {
     "brief": "摘要版",

--- a/frontend/lib/common/config/router_config.dart
+++ b/frontend/lib/common/config/router_config.dart
@@ -7,7 +7,6 @@ import 'package:context_app/features/main_screen.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/presentation/screens/select_narration_aspect_screen.dart';
 import 'package:context_app/features/narration/presentation/screens/narration_screen.dart';
-import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
 import 'package:context_app/features/journey/presentation/screens/save_success_screen.dart';
 import 'package:context_app/features/camera/presentation/screens/camera_screen.dart';
@@ -63,19 +62,17 @@ class RouterConfig {
             final extra = state.extra;
             if (extra == null || extra is! Map<String, dynamic>) return '/';
             if (extra['place'] is! Place) return '/';
+            if (extra['narrationContent'] is! NarrationContent) return '/';
             return null;
           },
           builder: (context, state) {
             final params = state.extra as Map<String, dynamic>;
             final place = params['place'] as Place;
-            final narrationAspect =
-                params['narrationAspect'] as NarrationAspect?;
             final narrationContent =
-                params['narrationContent'] as NarrationContent?;
+                params['narrationContent'] as NarrationContent;
             final autoPlay = params['autoPlay'] as bool? ?? false;
             return NarrationScreen(
               place: place,
-              narrationAspect: narrationAspect,
               narrationContent: narrationContent,
               autoPlay: autoPlay,
             );

--- a/frontend/lib/features/narration/presentation/controllers/narration_generation_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/narration_generation_controller.dart
@@ -1,0 +1,155 @@
+import 'package:context_app/core/errors/app_error.dart';
+import 'package:context_app/core/errors/app_error_type.dart';
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
+import 'package:context_app/features/narration/domain/errors/narration_error.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:context_app/features/usage/domain/errors/usage_error.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The lifecycle of a narration generation session.
+enum NarrationGenerationStatus {
+  /// Waiting for the user to press "Start".
+  idle,
+
+  /// AI is generating the narration content.
+  generating,
+
+  /// Narration content is ready.
+  success,
+
+  /// An error occurred during generation.
+  error,
+}
+
+/// Immutable state for [NarrationGenerationController].
+class NarrationGenerationState {
+  final NarrationGenerationStatus status;
+  final NarrationContent? content;
+  final NarrationGenerationErrorType? errorType;
+  final String? errorMessage;
+
+  const NarrationGenerationState({
+    this.status = NarrationGenerationStatus.idle,
+    this.content,
+    this.errorType,
+    this.errorMessage,
+  });
+
+  bool get isIdle => status == NarrationGenerationStatus.idle;
+  bool get isGenerating => status == NarrationGenerationStatus.generating;
+  bool get isSuccess => status == NarrationGenerationStatus.success;
+  bool get hasError => status == NarrationGenerationStatus.error;
+}
+
+/// Error types for narration generation.
+enum NarrationGenerationErrorType {
+  network,
+  server,
+  configurationError,
+  contentGenerationFailed,
+  unknown;
+
+  bool get isRetryable => switch (this) {
+    network || server => true,
+    _ => false,
+  };
+}
+
+/// Manages the narration generation flow on the config screen.
+///
+/// Similar to [QuickGuideController], this controller handles
+/// AI generation before navigating to the player screen.
+class NarrationGenerationController
+    extends StateNotifier<NarrationGenerationState> {
+  final CreateNarrationUseCase _createNarrationUseCase;
+  final JourneyRepository _journeyRepository;
+
+  NarrationGenerationController(
+    this._createNarrationUseCase,
+    this._journeyRepository,
+  ) : super(const NarrationGenerationState());
+
+  /// Generates narration content for the given place and aspect.
+  ///
+  /// On success, auto-saves to journey and sets state to [success].
+  /// On error, sets state to [error] with the appropriate error type.
+  Future<void> generate({
+    required Place place,
+    required NarrationAspect aspect,
+    required Language language,
+  }) async {
+    state = const NarrationGenerationState(
+      status: NarrationGenerationStatus.generating,
+    );
+
+    try {
+      final content = await _createNarrationUseCase.execute(
+        place: place,
+        aspect: aspect,
+        language: language,
+      );
+
+      await _autoSaveToJourney(place, aspect, content, language);
+
+      state = NarrationGenerationState(
+        status: NarrationGenerationStatus.success,
+        content: content,
+      );
+    } on AppError catch (e) {
+      state = NarrationGenerationState(
+        status: NarrationGenerationStatus.error,
+        errorType: _mapAppError(e.type),
+        errorMessage: e.message,
+      );
+    }
+  }
+
+  /// Resets to the idle state.
+  void reset() => state = const NarrationGenerationState();
+
+  NarrationGenerationErrorType _mapAppError(AppErrorType type) {
+    if (type is NarrationError) {
+      return switch (type) {
+        NarrationError.networkError => NarrationGenerationErrorType.network,
+        NarrationError.serverError => NarrationGenerationErrorType.server,
+        NarrationError.configurationError =>
+          NarrationGenerationErrorType.configurationError,
+        NarrationError.contentGenerationFailed =>
+          NarrationGenerationErrorType.contentGenerationFailed,
+        _ => NarrationGenerationErrorType.unknown,
+      };
+    }
+
+    if (type is UsageError) {
+      // Quota exceeded should not reach here because it's checked
+      // before calling generate, but handle defensively.
+      return NarrationGenerationErrorType.unknown;
+    }
+
+    return NarrationGenerationErrorType.unknown;
+  }
+
+  Future<void> _autoSaveToJourney(
+    Place place,
+    NarrationAspect aspect,
+    NarrationContent content,
+    Language language,
+  ) async {
+    try {
+      final entry = JourneyEntry.create(
+        place: place,
+        aspect: aspect,
+        content: content,
+        language: language,
+      );
+      await _journeyRepository.save(entry);
+    } catch (_) {
+      // Fail silently - don't affect the generation flow.
+    }
+  }
+}

--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -1,29 +1,17 @@
 import 'dart:async';
-import 'package:context_app/core/errors/app_error.dart';
-import 'package:context_app/core/errors/app_error_type.dart';
-import 'package:context_app/features/narration/domain/errors/narration_error.dart';
-import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
-import 'package:context_app/features/usage/domain/errors/usage_error.dart';
+import 'package:context_app/features/narration/presentation/controllers/narration_state_error_type.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:context_app/features/narration/data/tts_service.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
-import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
 import 'package:context_app/features/narration/presentation/controllers/narration_state.dart';
 import 'package:context_app/features/narration/presentation/controllers/player_state.dart';
-import 'package:context_app/features/narration/presentation/controllers/narration_state_error_type.dart';
-import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
-import 'package:context_app/features/journey/domain/models/journey_entry.dart';
-import 'package:context_app/features/settings/domain/models/language.dart';
 
 /// 播放器控制器
 ///
 /// 使用 StateNotifier 管理播放器狀態
-/// 負責協調 Use Cases 和 TTS Service
-/// 注意：權益檢查由 CreateNarrationUseCase 處理
+/// 僅負責播放控制，不負責生成導覽內容
 class PlayerController extends StateNotifier<NarrationState> {
-  final CreateNarrationUseCase _createNarrationUseCase;
-  final JourneyRepository _journeyRepository;
   final TtsService _ttsService;
 
   StreamSubscription<void>? _ttsCompleteSubscription;
@@ -40,93 +28,16 @@ class PlayerController extends StateNotifier<NarrationState> {
   /// 用於防止 onComplete 事件在跳段時誤觸
   bool _isSkipping = false;
 
-  PlayerController(
-    this._createNarrationUseCase,
-    this._journeyRepository,
-    this._ttsService,
-  ) : super(NarrationState.initial()) {
+  PlayerController(this._ttsService) : super(NarrationState.initial()) {
     _setupTtsListeners();
   }
 
-  /// 初始化並開始生成導覽
-  ///
-  /// [place] 地點資訊
-  /// [aspect] 導覽介紹面向
-  /// [language] 語言（預設為繁體中文）
-  Future<void> initialize(
-    Place place,
-    NarrationAspect aspect, {
-    required Language language,
-  }) async {
-    // 設定為載入中狀態
-    state = state.loading();
-
-    try {
-      // 使用 CreateNarrationUseCase 生成導覽內容
-      // Use Case 會處理權益檢查和消耗免費額度
-      final content = await _createNarrationUseCase.execute(
-        place: place,
-        aspect: aspect,
-        language: language,
-      );
-
-      // 初始化 TtsService
-      await _ttsService.initialize();
-      await _ttsService.setLanguage(language);
-
-      // 更新狀態為就緒
-      state = state.ready(place, aspect, content);
-
-      // 自動儲存到歷程
-      await _autoSaveToJourney(place, aspect, content, language);
-    } on AppError catch (e) {
-      final stateErrorType = _mapAppErrorToStateError(e.type);
-      state = state.error(stateErrorType, message: e.message);
-    }
-  }
-
-  /// 將 AppErrorType 轉換為 NarrationStateErrorType
-  NarrationStateErrorType _mapAppErrorToStateError(AppErrorType type) {
-    // Narration 相關錯誤
-    if (type is NarrationError) {
-      switch (type) {
-        case NarrationError.freeQuotaExceeded:
-          return NarrationStateErrorType.freeQuotaExceeded;
-        case NarrationError.networkError:
-          return NarrationStateErrorType.networkError;
-        case NarrationError.configurationError:
-          return NarrationStateErrorType.configurationError;
-        case NarrationError.serverError:
-          return NarrationStateErrorType.serverError;
-        case NarrationError.unsupportedLocation:
-          return NarrationStateErrorType.unsupportedLocation;
-        case NarrationError.contentGenerationFailed:
-          return NarrationStateErrorType.contentGenerationFailed;
-        case NarrationError.ttsPlaybackError:
-          return NarrationStateErrorType.ttsPlaybackError;
-        case NarrationError.unknown:
-          return NarrationStateErrorType.unknown;
-      }
-    }
-
-    // Usage 相關錯誤
-    if (type is UsageError) {
-      switch (type) {
-        case UsageError.dailyQuotaExceeded:
-          return NarrationStateErrorType.freeQuotaExceeded;
-      }
-    }
-
-    // 其他類型一律返回 unknown
-    return NarrationStateErrorType.unknown;
-  }
-
-  /// 使用現有內容初始化（用於回放已儲存的導覽）
+  /// 使用現有內容初始化（用於播放已生成的導覽）
   Future<void> initializeWithContent(
     Place place,
     NarrationContent content,
   ) async {
-    // 立即顯示內容讓使用者知道這是回放，TTS 初始化期間播放鈕暫時停用
+    // 立即顯示內容，TTS 初始化期間播放鈕暫時停用
     state = NarrationState(
       place: place,
       content: content,
@@ -137,44 +48,8 @@ class PlayerController extends StateNotifier<NarrationState> {
     await _ttsService.initialize();
     await _ttsService.setLanguage(content.language);
 
-    // 更新狀態為就緒（aspect 為 null 因為是回放模式）
+    // 更新狀態為就緒
     state = state.ready(place, null, content);
-  }
-
-  /// 自動儲存導覽到歷程（生成完成後靜默儲存）
-  Future<void> _autoSaveToJourney(
-    Place place,
-    NarrationAspect aspect,
-    NarrationContent content,
-    Language language,
-  ) async {
-    try {
-      final entry = JourneyEntry.create(
-        place: place,
-        aspect: aspect,
-        content: content,
-        language: language,
-      );
-      await _journeyRepository.save(entry);
-    } catch (_) {
-      // 靜默失敗，不影響播放體驗
-    }
-  }
-
-  /// 手動儲存導覽到歷程
-  Future<void> saveToJourney({required Language language}) async {
-    final place = state.place;
-    final aspect = state.aspect;
-    final content = state.content;
-    if (place == null || aspect == null || content == null) return;
-
-    final entry = JourneyEntry.create(
-      place: place,
-      aspect: aspect,
-      content: content,
-      language: language,
-    );
-    await _journeyRepository.save(entry);
   }
 
   /// 設定 TTS 事件監聽器
@@ -194,13 +69,12 @@ class PlayerController extends StateNotifier<NarrationState> {
     // 監聽播放開始事件
     _ttsStartSubscription = _ttsService.onStart.listen((_) {
       // 新播放真正開始後，重置跳段標誌
-      // 這樣可以確保 stop() 觸發的非同步 onComplete 不會影響狀態
       _isSkipping = false;
       // 根據偏移量設定字符位置（跳段播放時偏移量不為 0）
       state = state.updateCharPosition(_charPositionOffset);
     });
 
-    // 監聯錯誤事件
+    // 監聽錯誤事件
     _ttsErrorSubscription = _ttsService.onError.listen((error) {
       state = state.error(
         NarrationStateErrorType.ttsPlaybackError,
@@ -210,8 +84,6 @@ class PlayerController extends StateNotifier<NarrationState> {
 
     // 監聽進度事件（字符級別的精確追蹤）
     _ttsProgressSubscription = _ttsService.onProgress.listen((progress) {
-      // 使用 TTS 提供的字符級別進度更新段落索引和進度
-      // 加入偏移量以對應原始文本的實際位置（跳段播放時需要）
       if (state.content != null && state.isPlaying) {
         state = state.updateCharPosition(
           progress.currentPosition + _charPositionOffset,
@@ -262,7 +134,6 @@ class PlayerController extends StateNotifier<NarrationState> {
     final success = await _ttsService.speak(textToPlay);
 
     if (success) {
-      // 更新狀態為播放中
       state = state.playing();
     } else {
       state = state.error(
@@ -278,10 +149,7 @@ class PlayerController extends StateNotifier<NarrationState> {
       return;
     }
 
-    // 暫停 TTS
     await _ttsService.pause();
-
-    // 更新狀態為暫停
     state = state.paused();
   }
 
@@ -309,7 +177,6 @@ class PlayerController extends StateNotifier<NarrationState> {
     await _ttsService.stop();
 
     // 在 iOS 上，TTS 引擎需要一點時間來完全重置狀態
-    // 特別是從暫停狀態轉換時
     if (wasPaused) {
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
@@ -326,7 +193,6 @@ class PlayerController extends StateNotifier<NarrationState> {
     // 開始播放（onStart 會重置 _isSkipping）
     final success = await _ttsService.speak(textToPlay);
     if (!success) {
-      // 播放失敗時手動重置 flag
       _isSkipping = false;
       state = state.error(
         NarrationStateErrorType.ttsPlaybackError,
@@ -336,8 +202,6 @@ class PlayerController extends StateNotifier<NarrationState> {
   }
 
   /// 跳到下一段
-  ///
-  /// 如果已是最後一段則不執行
   Future<void> skipToNextSegment() async {
     if (state.content == null) return;
 
@@ -350,8 +214,6 @@ class PlayerController extends StateNotifier<NarrationState> {
   }
 
   /// 跳到上一段
-  ///
-  /// 如果已是第一段則不執行
   Future<void> skipToPreviousSegment() async {
     if (state.content == null) return;
 
@@ -365,10 +227,8 @@ class PlayerController extends StateNotifier<NarrationState> {
 
   @override
   void dispose() {
-    // 停止播放
     _ttsService.stop();
 
-    // 取消訂閱
     _ttsCompleteSubscription?.cancel();
     _ttsStartSubscription?.cancel();
     _ttsErrorSubscription?.cancel();

--- a/frontend/lib/features/narration/presentation/screens/narration_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/narration_screen.dart
@@ -1,22 +1,20 @@
 import 'package:context_app/common/config/app_colors.dart';
-import 'package:context_app/features/narration/presentation/controllers/narration_state_error_type.dart';
-import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:easy_localization/easy_localization.dart' as easy;
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
-import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_transcript_area.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_control_panel.dart';
 
+/// 導覽播放頁面
+///
+/// 僅負責播放已生成的導覽內容，不負責生成。
 class NarrationScreen extends ConsumerStatefulWidget {
   final Place place;
-  final NarrationAspect? narrationAspect;
-  final NarrationContent? narrationContent;
+  final NarrationContent narrationContent;
 
   /// Whether to start playback automatically after initialisation.
   final bool autoPlay;
@@ -24,8 +22,7 @@ class NarrationScreen extends ConsumerStatefulWidget {
   const NarrationScreen({
     super.key,
     required this.place,
-    this.narrationAspect,
-    this.narrationContent,
+    required this.narrationContent,
     this.autoPlay = false,
   });
 
@@ -40,32 +37,16 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
   @override
   void initState() {
     super.initState();
-    // 初始化播放器
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
 
-      if (widget.narrationContent != null) {
-        // 使用已有的 NarrationContent 初始化（例如從 JourneyEntry 回放）
-        ref
-            .read(playerControllerProvider.notifier)
-            .initializeWithContent(widget.place, widget.narrationContent!)
-            .then((_) {
-              if (!mounted || !widget.autoPlay) return;
-              ref.read(playerControllerProvider.notifier).play();
-            });
-      } else if (widget.narrationAspect != null) {
-        // 生成新的導覽內容（需要明確的 narrationAspect）
-        final locale =
-            easy.EasyLocalization.of(context)?.locale.toLanguageTag() ??
-            'zh-TW';
-        ref
-            .read(playerControllerProvider.notifier)
-            .initialize(
-              widget.place,
-              widget.narrationAspect!,
-              language: Language(locale),
-            );
-      }
+      ref
+          .read(playerControllerProvider.notifier)
+          .initializeWithContent(widget.place, widget.narrationContent)
+          .then((_) {
+            if (!mounted || !widget.autoPlay) return;
+            ref.read(playerControllerProvider.notifier).play();
+          });
     });
   }
 
@@ -85,57 +66,17 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
 
     _lastSegmentIndex = segmentIndex;
 
-    // 使用 scrollToIndex 滑動到指定段落（定位到螢幕頂部）
     _scrollController.scrollToIndex(
-      segmentIndex + 1, // +1 因為 index 0 是頂部空白項
-      preferPosition: AutoScrollPosition.middle, // 定位到螢幕頂部
+      segmentIndex + 1,
+      preferPosition: AutoScrollPosition.middle,
       duration: const Duration(milliseconds: 300),
     );
   }
 
-  /// 顯示額度用完對話框（防禦性檢查）
-  void _showQuotaExceededDialog() {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('額度已用完'),
-        content: const Text('今日免費次數已用完，觀看廣告即可繼續使用。'),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-            },
-            child: const Text('確定'),
-          ),
-        ],
-      ),
-    ).then((_) {
-      if (mounted) {
-        context.go('/');
-      }
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    // 監聽錯誤狀態並顯示對應的對話框
+    // 監聽當前段落索引變化並自動滾動
     ref.listen(playerControllerProvider, (previous, current) {
-      // 當狀態從非錯誤變為錯誤時，且需要特殊對話框
-      if ((previous == null || !previous.hasError) &&
-          current.hasError &&
-          current.errorType != null &&
-          current.errorType!.requiresSpecialDialog) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!mounted) return;
-
-          // 根據錯誤類型顯示不同的對話框
-          if (current.errorType!.requiresAdDialog) {
-            _showQuotaExceededDialog();
-          }
-        });
-      }
-
-      // 監聽當前段落索引變化並自動滾動
       final previousIndex = previous?.currentSegmentIndex;
       final currentIndex = current.currentSegmentIndex;
       if (previousIndex != currentIndex && currentIndex != null) {
@@ -192,8 +133,6 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
                       scrollController: _scrollController,
                       backgroundColor: backgroundColor,
                       primaryColor: primaryColor,
-                      place: widget.place,
-                      narrationAspect: widget.narrationAspect,
                     ),
                   ),
                 ],

--- a/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
@@ -3,6 +3,8 @@ import 'dart:typed_data';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/core/services/place_image_cache_manager.dart';
+import 'package:context_app/features/narration/presentation/controllers/narration_generation_controller.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -15,7 +17,7 @@ import 'package:context_app/features/ads/presentation/widgets/watch_ad_dialog.da
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
 
-class SelectNarrationAspectScreen extends ConsumerWidget {
+class SelectNarrationAspectScreen extends ConsumerStatefulWidget {
   final Place place;
   final Uint8List? capturedImageBytes;
 
@@ -26,21 +28,115 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final selectedAspect = ref.watch(narrationAspectProvider);
+  ConsumerState<SelectNarrationAspectScreen> createState() =>
+      _SelectNarrationAspectScreenState();
+}
 
-    // 根據景點類型取得可用的介紹面向
-    final availableAspects = NarrationAspect.getAspectsForCategory(
-      place.category,
+class _SelectNarrationAspectScreenState
+    extends ConsumerState<SelectNarrationAspectScreen> {
+  Language _currentLanguage() {
+    final locale = EasyLocalization.of(context)?.locale.toLanguageTag();
+    return Language(locale ?? 'zh-TW');
+  }
+
+  Future<void> _onStartPressed() async {
+    final selectedAspect = ref.read(narrationAspectProvider);
+
+    // Quota check before generation
+    final usageRepo = ref.read(usageRepositoryProvider);
+    final status = await usageRepo.getUsageStatus();
+    if (!status.canUseNarration) {
+      if (!mounted) return;
+      final result = await showWatchAdDialog(context, ref);
+      if (result == 'subscribe') {
+        if (!mounted) return;
+        context.pushNamed('subscription');
+        return;
+      }
+      if (result != true || !mounted) return;
+    }
+
+    if (!mounted) return;
+
+    // Start generation on this page
+    ref
+        .read(narrationGenerationControllerProvider.notifier)
+        .generate(
+          place: widget.place,
+          aspect: selectedAspect,
+          language: _currentLanguage(),
+        );
+  }
+
+  void _navigateToPlayer(NarrationGenerationState genState) {
+    ref.read(narrationGenerationControllerProvider.notifier).reset();
+    context.pushNamed(
+      'player',
+      extra: {
+        'place': widget.place,
+        'narrationContent': genState.content,
+        'autoPlay': true,
+      },
+    );
+  }
+
+  void _showErrorDialog(NarrationGenerationState genState) {
+    ref.read(narrationGenerationControllerProvider.notifier).reset();
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('config_screen.generation_error_title'.tr()),
+        content: Text(
+          genState.errorMessage ??
+              'config_screen.generation_error_message'.tr(),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text('config_screen.generation_error_ok'.tr()),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedAspect = ref.watch(narrationAspectProvider);
+    final generationState = ref.watch(
+      narrationGenerationControllerProvider,
     );
 
-    final photoUrl = place.primaryPhoto?.url;
+    // Listen for generation success / error
+    ref.listen<NarrationGenerationState>(
+      narrationGenerationControllerProvider,
+      (previous, current) {
+        if (previous?.isSuccess != true && current.isSuccess) {
+          _navigateToPlayer(current);
+        }
+        if (previous?.hasError != true && current.hasError) {
+          _showErrorDialog(current);
+        }
+      },
+    );
+
+    final availableAspects = NarrationAspect.getAspectsForCategory(
+      widget.place.category,
+    );
+
+    final photoUrl = widget.place.primaryPhoto?.url;
+    final isGenerating = generationState.isGenerating;
 
     return Scaffold(
       body: Stack(
         children: [
           // Background Image
-          Positioned.fill(child: _buildBackgroundImage(photoUrl)),
+          Positioned.fill(
+            child: _BackgroundImage(
+              photoUrl: photoUrl,
+              capturedImageBytes: widget.capturedImageBytes,
+            ),
+          ),
 
           // Top Navigation
           Positioned(
@@ -50,10 +146,15 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
             child: AppBar(
               backgroundColor: Colors.transparent,
               elevation: 0,
-              leading: IconButton(
-                icon: const Icon(Icons.arrow_back_ios_new, color: Colors.white),
-                onPressed: () => context.pop(),
-              ),
+              leading: isGenerating
+                  ? null
+                  : IconButton(
+                      icon: const Icon(
+                        Icons.arrow_back_ios_new,
+                        color: Colors.white,
+                      ),
+                      onPressed: () => context.pop(),
+                    ),
             ),
           ),
 
@@ -85,7 +186,7 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
                   children: [
                     // Place Name
                     Text(
-                      place.name,
+                      widget.place.name,
                       style: const TextStyle(
                         color: Colors.white,
                         fontSize: 32,
@@ -95,151 +196,83 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
                     const SizedBox(height: 8),
 
                     // Place Category Badge
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 6,
-                      ),
-                      decoration: BoxDecoration(
-                        color: place.category.color.withValues(alpha: 0.3),
-                        borderRadius: BorderRadius.circular(16),
-                        border: Border.all(
-                          color: place.category.color,
-                          width: 1,
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            place.category.icon,
-                            size: 16,
-                            color: Colors.white,
-                          ),
-                          const SizedBox(width: 6),
-                          Text(
-                            place.category.translationKey.tr(),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 12,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
+                    _CategoryBadge(place: widget.place),
                     const SizedBox(height: 12),
 
                     // Place Address
-                    Row(
-                      children: [
-                        const Icon(
-                          Icons.location_on,
-                          color: Colors.white70,
-                          size: 16,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            place.formattedAddress,
-                            style: const TextStyle(
-                              color: Colors.white70,
-                              fontSize: 14,
-                            ),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
-                    ),
+                    _AddressRow(place: widget.place),
                     const SizedBox(height: 24),
 
-                    // Title
-                    Text(
-                      'config_screen.select_aspect_title'.tr(),
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
+                    // Content area: loading spinner or aspect options
+                    if (isGenerating)
+                      _GeneratingIndicator()
+                    else ...[
+                      // Title
+                      Text(
+                        'config_screen.select_aspect_title'.tr(),
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 16),
+                      const SizedBox(height: 16),
 
-                    // Aspect Options (scrollable)
-                    Flexible(
-                      child: SingleChildScrollView(
-                        child: Column(
-                          children: availableAspects.map((aspect) {
-                            return Padding(
-                              padding: const EdgeInsets.only(bottom: 12),
-                              child: AspectOption(
-                                aspect: aspect,
-                                isSelected: selectedAspect == aspect,
-                                onTap: () {
-                                  ref
-                                          .read(
-                                            narrationAspectProvider.notifier,
-                                          )
-                                          .state =
-                                      aspect;
-                                },
+                      // Aspect Options (scrollable)
+                      Flexible(
+                        child: SingleChildScrollView(
+                          child: Column(
+                            children: availableAspects.map((aspect) {
+                              return Padding(
+                                padding: const EdgeInsets.only(bottom: 12),
+                                child: AspectOption(
+                                  aspect: aspect,
+                                  isSelected: selectedAspect == aspect,
+                                  onTap: () {
+                                    ref
+                                            .read(
+                                              narrationAspectProvider.notifier,
+                                            )
+                                            .state =
+                                        aspect;
+                                  },
+                                ),
+                              );
+                            }).toList(),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+
+                      // Start Button
+                      ElevatedButton(
+                        onPressed: _onStartPressed,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.primary,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          padding: const EdgeInsets.symmetric(vertical: 16),
+                          minimumSize: const Size(double.infinity, 50),
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Icon(Icons.play_arrow, color: Colors.white),
+                            const SizedBox(width: 8),
+                            Text(
+                              'config_screen.start_button'.tr(),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
                               ),
-                            );
-                          }).toList(),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 24),
-
-                    // Start Button
-                    ElevatedButton(
-                      onPressed: () async {
-                        final usageRepo = ref.read(usageRepositoryProvider);
-                        final status = await usageRepo.getUsageStatus();
-                        if (!status.canUseNarration) {
-                          if (!context.mounted) return;
-                          final result = await showWatchAdDialog(context, ref);
-                          if (result == 'subscribe') {
-                            if (!context.mounted) return;
-                            context.pushNamed('subscription');
-                            return;
-                          }
-                          if (result != true || !context.mounted) return;
-                        }
-                        if (!context.mounted) return;
-                        context.pushNamed(
-                          'player',
-                          extra: {
-                            'place': place,
-                            'narrationAspect': selectedAspect,
-                          },
-                        );
-                      },
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primary,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        padding: const EdgeInsets.symmetric(vertical: 16),
-                        minimumSize: const Size(double.infinity, 50),
-                      ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Icon(Icons.play_arrow, color: Colors.white),
-                          const SizedBox(width: 8),
-                          Text(
-                            'config_screen.start_button'.tr(),
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
-                    const SizedBox(height: 20),
+                      const SizedBox(height: 20),
+                    ],
                   ],
                 ),
               ),
@@ -249,10 +282,40 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
       ),
     );
   }
+}
 
-  /// 建立背景圖片
-  Widget _buildBackgroundImage(String? photoUrl) {
-    // 優先使用相機拍攝的圖片
+class _GeneratingIndicator extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(color: AppColors.primary),
+            const SizedBox(height: 16),
+            Text(
+              'config_screen.generating'.tr(),
+              style: const TextStyle(
+                color: Colors.white70,
+                fontSize: 16,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BackgroundImage extends StatelessWidget {
+  final String? photoUrl;
+  final Uint8List? capturedImageBytes;
+
+  const _BackgroundImage({this.photoUrl, this.capturedImageBytes});
+
+  @override
+  Widget build(BuildContext context) {
     if (capturedImageBytes != null) {
       return ColorFiltered(
         colorFilter: const ColorFilter.mode(
@@ -268,10 +331,9 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
       );
     }
 
-    // 使用網路圖片
     if (photoUrl != null) {
       return CachedNetworkImage(
-        imageUrl: photoUrl,
+        imageUrl: photoUrl!,
         fit: BoxFit.cover,
         color: const Color(0x66000000),
         colorBlendMode: BlendMode.darken,
@@ -291,8 +353,64 @@ class SelectNarrationAspectScreen extends ConsumerWidget {
       );
     }
 
-    // 沒有圖片時顯示深色背景
     return Container(color: Colors.black);
+  }
+}
+
+class _CategoryBadge extends StatelessWidget {
+  final Place place;
+
+  const _CategoryBadge({required this.place});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: place.category.color.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: place.category.color, width: 1),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(place.category.icon, size: 16, color: Colors.white),
+          const SizedBox(width: 6),
+          Text(
+            place.category.translationKey.tr(),
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AddressRow extends StatelessWidget {
+  final Place place;
+
+  const _AddressRow({required this.place});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        const Icon(Icons.location_on, color: Colors.white70, size: 16),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            place.formattedAddress,
+            style: const TextStyle(color: Colors.white70, fontSize: 14),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
+++ b/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
@@ -1,10 +1,6 @@
 import 'package:context_app/common/config/app_colors.dart';
-import 'package:context_app/features/explore/domain/models/place.dart';
-import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
-import 'package:context_app/features/narration/presentation/controllers/narration_state_error_type.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/narration/presentation/widgets/transcript_segment_item.dart';
-import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:easy_localization/easy_localization.dart' as easy;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,33 +11,19 @@ class NarrationTranscriptArea extends ConsumerWidget {
   final AutoScrollController scrollController;
   final Color backgroundColor;
   final Color primaryColor;
-  final Place place;
-  final NarrationAspect? narrationAspect;
 
   const NarrationTranscriptArea({
     super.key,
     required this.scrollController,
     required this.backgroundColor,
     required this.primaryColor,
-    required this.place,
-    this.narrationAspect,
   });
-
-  /// 格式化重試延遲時間
-  String _formatRetryDelay(int seconds) {
-    if (seconds < 60) {
-      return '$seconds 秒';
-    } else {
-      return '${seconds ~/ 60} 分鐘';
-    }
-  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final playerState = ref.watch(playerControllerProvider);
 
-    // 載入中且尚無內容（生成模式）才顯示 spinner；
-    // 回放模式下 content 已立即設定，直接顯示轉錄文字
+    // 載入中且尚無內容時顯示 spinner（TTS 初始化中）
     if (playerState.isLoading && playerState.content == null) {
       return Center(
         child: Column(
@@ -63,11 +45,6 @@ class NarrationTranscriptArea extends ConsumerWidget {
 
     // 錯誤狀態
     if (playerState.hasError) {
-      final locale =
-          easy.EasyLocalization.of(context)?.locale.toLanguageTag() ?? 'zh-TW';
-      final errorType = playerState.errorType;
-
-      // 取得錯誤訊息
       final errorMessage =
           playerState.errorMessage ?? 'player_screen.error'.tr();
 
@@ -87,42 +64,6 @@ class NarrationTranscriptArea extends ConsumerWidget {
                 ),
                 textAlign: TextAlign.center,
               ),
-
-              // 顯示建議的重試時間
-              if (errorType?.suggestedRetryDelay != null) ...[
-                const SizedBox(height: 8),
-                Text(
-                  'player_screen.suggested_retry'.tr(
-                    namedArgs: {
-                      'delay': _formatRetryDelay(
-                        errorType!.suggestedRetryDelay!,
-                      ),
-                    },
-                  ),
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    fontSize: 14,
-                  ),
-                ),
-              ],
-
-              // 重試按鈕（僅在可重試且非 AI quota 錯誤時顯示，且有 narrationAspect 時）
-              if (errorType?.isRetryable == true &&
-                  narrationAspect != null) ...[
-                const SizedBox(height: 24),
-                ElevatedButton(
-                  onPressed: () {
-                    ref
-                        .read(playerControllerProvider.notifier)
-                        .initialize(
-                          place,
-                          narrationAspect!,
-                          language: Language(locale),
-                        );
-                  },
-                  child: const Text('重試'),
-                ),
-              ],
             ],
           ),
         ),
@@ -144,19 +85,18 @@ class NarrationTranscriptArea extends ConsumerWidget {
           controller: scrollController,
           padding: const EdgeInsets.symmetric(horizontal: 24.0),
           itemCount: content.segments.length + 2,
-          // +2 for top/bottom spacing
           itemBuilder: (context, index) {
-            // 頂部空白 - 不需要 AutoScrollTag
+            // 頂部空白
             if (index == 0) {
               return const SizedBox(height: 60);
             }
 
-            // 底部空白 - 不需要 AutoScrollTag
+            // 底部空白
             if (index == content.segments.length + 1) {
               return const SizedBox(height: 200);
             }
 
-            // 文本段落 - 使用 AutoScrollTag 包裝
+            // 文本段落
             final segmentIndex = index - 1;
             final segment = content.segments[segmentIndex];
             final isActive = currentSegmentIndex == segmentIndex;

--- a/frontend/lib/features/narration/presentation/widgets/save_to_passport_button.dart
+++ b/frontend/lib/features/narration/presentation/widgets/save_to_passport_button.dart
@@ -1,14 +1,16 @@
 import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/providers.dart';
-import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:easy_localization/easy_localization.dart' as easy;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 /// 儲存到護照的按鈕
-class SaveToPassportButton extends ConsumerStatefulWidget {
+///
+/// 導覽內容已在生成時自動儲存到歷程，
+/// 此按鈕僅導航到成功頁面。
+class SaveToPassportButton extends ConsumerWidget {
   final Place place;
   final Color surfaceColor;
 
@@ -19,74 +21,27 @@ class SaveToPassportButton extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<SaveToPassportButton> createState() =>
-      _SaveToPassportButtonState();
-}
-
-class _SaveToPassportButtonState extends ConsumerState<SaveToPassportButton> {
-  bool _isSaving = false;
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final playerState = ref.watch(playerControllerProvider);
-    final playerController = ref.read(playerControllerProvider.notifier);
+    final isDisabled = playerState.isLoading ||
+        playerState.hasError ||
+        playerState.content == null;
 
     return Material(
       color: Colors.transparent,
       child: InkWell(
-        onTap:
-            (playerState.isLoading ||
-                playerState.hasError ||
-                playerState.content == null ||
-                _isSaving)
+        onTap: isDisabled
             ? null
-            : () async {
-                final locale =
-                    easy.EasyLocalization.of(context)?.locale.toLanguageTag() ??
-                    'zh-TW';
-
-                setState(() {
-                  _isSaving = true;
-                });
-
-                try {
-                  await playerController.saveToJourney(
-                    language: Language(locale),
-                  );
-                  if (context.mounted) {
-                    context.pushNamed('passport_success', extra: widget.place);
-                  }
-                } catch (e) {
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text(
-                          '${easy.tr('player_screen.save_failed')}: $e',
-                        ),
-                      ),
-                    );
-                  }
-                } finally {
-                  if (mounted) {
-                    setState(() {
-                      _isSaving = false;
-                    });
-                  }
-                }
+            : () {
+                context.pushNamed('passport_success', extra: place);
               },
         borderRadius: BorderRadius.circular(12),
         child: Opacity(
-          opacity:
-              (playerState.isLoading ||
-                  playerState.hasError ||
-                  playerState.content == null ||
-                  _isSaving)
-              ? 0.5
-              : 1.0,
+          opacity: isDisabled ? 0.5 : 1.0,
           child: Container(
             height: 56,
             decoration: BoxDecoration(
-              color: widget.surfaceColor,
+              color: surfaceColor,
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: Colors.white.withValues(alpha: 0.1),
@@ -95,41 +50,30 @@ class _SaveToPassportButtonState extends ConsumerState<SaveToPassportButton> {
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
-              children: _isSaving
-                  ? const [
-                      SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: CircularProgressIndicator(
-                          color: Colors.white,
-                          strokeWidth: 2,
-                        ),
-                      ),
-                    ]
-                  : [
-                      Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: AppColors.amber.withValues(alpha: 0.1),
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: const Icon(
-                          Icons.bookmark_add,
-                          color: AppColors.amber,
-                          size: 20,
-                        ),
-                      ),
-                      const SizedBox(width: 12),
-                      Text(
-                        easy.tr('player_screen.save_to_passport'),
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ],
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: AppColors.amber.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: const Icon(
+                    Icons.bookmark_add,
+                    color: AppColors.amber,
+                    size: 20,
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Text(
+                  easy.tr('player_screen.save_to_passport'),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
             ),
           ),
         ),

--- a/frontend/lib/features/narration/providers.dart
+++ b/frontend/lib/features/narration/providers.dart
@@ -4,6 +4,7 @@ import 'package:context_app/features/narration/data/gemini_service.dart';
 import 'package:context_app/features/narration/data/tts_service.dart';
 import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
 import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
+import 'package:context_app/features/narration/presentation/controllers/narration_generation_controller.dart';
 import 'package:context_app/features/narration/presentation/controllers/player_controller.dart';
 import 'package:context_app/features/narration/presentation/controllers/narration_state.dart';
 import 'package:context_app/features/journey/providers.dart';
@@ -46,19 +47,26 @@ final startNarrationUseCaseProvider = Provider<CreateNarrationUseCase>((ref) {
   return CreateNarrationUseCase(narrationService, usageRepository);
 });
 
+/// NarrationGenerationController Provider
+///
+/// 管理導覽生成的狀態（在選擇面向頁面使用）
+/// 使用 autoDispose 確保離開頁面時自動清理資源
+final narrationGenerationControllerProvider = StateNotifierProvider
+    .autoDispose<NarrationGenerationController, NarrationGenerationState>((
+      ref,
+    ) {
+      final useCase = ref.watch(startNarrationUseCaseProvider);
+      final journeyRepository = ref.watch(journeyRepositoryProvider);
+      return NarrationGenerationController(useCase, journeyRepository);
+    });
+
 /// PlayerController Provider
 ///
 /// 管理播放器狀態和控制播放行為
 /// 使用 autoDispose 確保離開頁面時自動清理資源
-/// 注意：權益檢查由 CreateNarrationUseCase 處理
+/// 僅負責播放，不負責生成導覽內容
 final playerControllerProvider =
     StateNotifierProvider.autoDispose<PlayerController, NarrationState>((ref) {
-      final startNarrationUseCase = ref.watch(startNarrationUseCaseProvider);
-      final journeyRepository = ref.watch(journeyRepositoryProvider);
       final ttsService = ref.watch(ttsServiceProvider);
-      return PlayerController(
-        startNarrationUseCase,
-        journeyRepository,
-        ttsService,
-      );
+      return PlayerController(ttsService);
     });

--- a/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
+++ b/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
@@ -6,7 +6,6 @@ import 'package:context_app/features/journey/domain/models/journey_entry.dart';
 import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
 import 'package:context_app/features/narration/domain/errors/narration_error.dart';
 import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
-import 'package:context_app/features/narration/domain/models/narration_content.dart';
 import 'package:context_app/features/narration/domain/services/narration_service.dart';
 import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
 import 'package:context_app/features/narration/presentation/controllers/narration_generation_controller.dart';

--- a/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
+++ b/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
@@ -1,0 +1,200 @@
+import 'package:context_app/core/errors/app_error.dart';
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
+import 'package:context_app/features/narration/domain/errors/narration_error.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/narration/domain/services/narration_service.dart';
+import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
+import 'package:context_app/features/narration/presentation/controllers/narration_generation_controller.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:context_app/features/usage/domain/models/usage_status.dart';
+import 'package:context_app/features/usage/domain/repositories/usage_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeUsageRepository implements UsageRepository {
+  @override
+  Future<UsageStatus> getUsageStatus() async =>
+      const UsageStatus(usedToday: 0, dailyFreeLimit: 3);
+
+  @override
+  Future<void> consumeUsage() async {}
+
+  @override
+  Future<void> addBonusFromAd() async {}
+}
+
+class _SpyNarrationService implements NarrationService {
+  bool called = false;
+  final String? textToReturn;
+
+  _SpyNarrationService({this.textToReturn});
+
+  @override
+  Future<String> generateNarration({
+    required Place place,
+    required NarrationAspect aspect,
+    required Language language,
+  }) async {
+    called = true;
+    if (textToReturn == null) {
+      throw const AppError(
+        type: NarrationError.serverError,
+        message: 'spy: no text configured',
+      );
+    }
+    return textToReturn!;
+  }
+}
+
+class _FakeJourneyRepository implements JourneyRepository {
+  bool saveCalled = false;
+
+  @override
+  Future<List<JourneyEntry>> getAll() async => [];
+
+  @override
+  Future<void> save(JourneyEntry entry) async {
+    saveCalled = true;
+  }
+
+  @override
+  Future<void> delete(String id) async {}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _testPlace = Place(
+  id: 'place-1',
+  name: 'Test Place',
+  formattedAddress: 'Test Address',
+  location: PlaceLocation(latitude: 25.0, longitude: 121.0),
+  types: [],
+  photos: [],
+  category: PlaceCategory.historicalCultural,
+);
+
+const _testNarrationText =
+    '這是一個測試地點。這裡有豐富的歷史。許多遊客來到這裡參觀。這是一個著名的景點。';
+
+NarrationGenerationController _makeController({
+  _SpyNarrationService? narrationService,
+  _FakeJourneyRepository? journeyRepository,
+}) {
+  final service = narrationService ?? _SpyNarrationService();
+  final useCase = CreateNarrationUseCase(service, _FakeUsageRepository());
+  return NarrationGenerationController(
+    useCase,
+    journeyRepository ?? _FakeJourneyRepository(),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('NarrationGenerationController.generate', () {
+    test('成功生成後狀態為 success 且包含內容', () async {
+      final controller = _makeController(
+        narrationService: _SpyNarrationService(
+          textToReturn: _testNarrationText,
+        ),
+      );
+
+      await controller.generate(
+        place: _testPlace,
+        aspect: NarrationAspect.historicalBackground,
+        language: Language.traditionalChinese,
+      );
+
+      expect(controller.state.isSuccess, isTrue);
+      expect(controller.state.content, isNotNull);
+      expect(controller.state.content!.text, _testNarrationText.trim());
+    });
+
+    test('生成失敗後狀態為 error', () async {
+      final controller = _makeController(
+        narrationService: _SpyNarrationService(),
+      );
+
+      await controller.generate(
+        place: _testPlace,
+        aspect: NarrationAspect.historicalBackground,
+        language: Language.traditionalChinese,
+      );
+
+      expect(controller.state.hasError, isTrue);
+      expect(controller.state.errorType, isNotNull);
+    });
+
+    test('生成中狀態為 generating', () async {
+      final controller = _makeController(
+        narrationService: _SpyNarrationService(
+          textToReturn: _testNarrationText,
+        ),
+      );
+
+      final states = <NarrationGenerationStatus>[];
+      controller.addListener((state) {
+        states.add(state.status);
+      });
+
+      await controller.generate(
+        place: _testPlace,
+        aspect: NarrationAspect.historicalBackground,
+        language: Language.traditionalChinese,
+      );
+
+      expect(states.first, NarrationGenerationStatus.generating);
+    });
+
+    test('成功生成後自動儲存到歷程', () async {
+      final journeyRepo = _FakeJourneyRepository();
+      final controller = _makeController(
+        narrationService: _SpyNarrationService(
+          textToReturn: _testNarrationText,
+        ),
+        journeyRepository: journeyRepo,
+      );
+
+      await controller.generate(
+        place: _testPlace,
+        aspect: NarrationAspect.historicalBackground,
+        language: Language.traditionalChinese,
+      );
+
+      expect(journeyRepo.saveCalled, isTrue);
+    });
+  });
+
+  group('NarrationGenerationController.reset', () {
+    test('重置後狀態為 idle', () async {
+      final controller = _makeController(
+        narrationService: _SpyNarrationService(
+          textToReturn: _testNarrationText,
+        ),
+      );
+
+      await controller.generate(
+        place: _testPlace,
+        aspect: NarrationAspect.historicalBackground,
+        language: Language.traditionalChinese,
+      );
+      expect(controller.state.isSuccess, isTrue);
+
+      controller.reset();
+      expect(controller.state.isIdle, isTrue);
+      expect(controller.state.content, isNull);
+    });
+  });
+}

--- a/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
+++ b/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
@@ -144,9 +144,13 @@ void main() {
       );
 
       final states = <NarrationGenerationStatus>[];
-      controller.addListener((state) {
-        states.add(state.status);
-      });
+      // fireImmediately: false 避免收到初始狀態 idle
+      controller.addListener(
+        (state) {
+          states.add(state.status);
+        },
+        fireImmediately: false,
+      );
 
       await controller.generate(
         place: _testPlace,

--- a/frontend/test/features/narration/presentation/controllers/player_controller_test.dart
+++ b/frontend/test/features/narration/presentation/controllers/player_controller_test.dart
@@ -1,77 +1,17 @@
 import 'dart:async';
 
-import 'package:context_app/core/errors/app_error.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/explore/domain/models/place_category.dart';
 import 'package:context_app/features/explore/domain/models/place_location.dart';
-import 'package:context_app/features/journey/domain/models/journey_entry.dart';
-import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
 import 'package:context_app/features/narration/data/tts_service.dart';
-import 'package:context_app/features/narration/domain/errors/narration_error.dart';
-import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
-import 'package:context_app/features/narration/domain/services/narration_service.dart';
-import 'package:context_app/features/narration/domain/use_cases/create_narration_use_case.dart';
 import 'package:context_app/features/narration/presentation/controllers/player_controller.dart';
 import 'package:context_app/features/settings/domain/models/language.dart';
-import 'package:context_app/features/usage/domain/models/usage_status.dart';
-import 'package:context_app/features/usage/domain/repositories/usage_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // ---------------------------------------------------------------------------
 // Fakes
 // ---------------------------------------------------------------------------
-
-class _FakeUsageRepository implements UsageRepository {
-  @override
-  Future<UsageStatus> getUsageStatus() async =>
-      const UsageStatus(usedToday: 0, dailyFreeLimit: 3);
-
-  @override
-  Future<void> consumeUsage() async {}
-
-  @override
-  Future<void> addBonusFromAd() async {}
-}
-
-/// NarrationService that records whether it was called.
-///
-/// When [textToReturn] is null, throws [AppError] with
-/// [NarrationError.serverError] to let [PlayerController] catch it and
-/// transition to an error state.
-class _SpyNarrationService implements NarrationService {
-  bool called = false;
-  final String? textToReturn;
-
-  _SpyNarrationService({this.textToReturn});
-
-  @override
-  Future<String> generateNarration({
-    required Place place,
-    required NarrationAspect aspect,
-    required Language language,
-  }) async {
-    called = true;
-    if (textToReturn == null) {
-      throw const AppError(
-        type: NarrationError.serverError,
-        message: 'spy: no text configured',
-      );
-    }
-    return textToReturn!;
-  }
-}
-
-class _FakeJourneyRepository implements JourneyRepository {
-  @override
-  Future<List<JourneyEntry>> getAll() async => [];
-
-  @override
-  Future<void> save(JourneyEntry entry) async {}
-
-  @override
-  Future<void> delete(String id) async {}
-}
 
 /// Minimal TtsService fake that records calls and exposes controllable streams.
 class _FakeTtsService implements TtsService {
@@ -163,13 +103,8 @@ const _testPlace = Place(
 const _testNarrationText =
     '這是一個測試地點。這裡有豐富的歷史。許多遊客來到這裡參觀。這是一個著名的景點。';
 
-PlayerController _makeController({
-  _SpyNarrationService? narrationService,
-  _FakeTtsService? ttsService,
-}) {
-  final service = narrationService ?? _SpyNarrationService();
-  final useCase = CreateNarrationUseCase(service, _FakeUsageRepository());
-  return PlayerController(useCase, _FakeJourneyRepository(), ttsService ?? _FakeTtsService());
+PlayerController _makeController({_FakeTtsService? ttsService}) {
+  return PlayerController(ttsService ?? _FakeTtsService());
 }
 
 // ---------------------------------------------------------------------------
@@ -178,24 +113,6 @@ PlayerController _makeController({
 
 void main() {
   group('PlayerController.initializeWithContent', () {
-    test('使用現有內容初始化，不呼叫 AI 生成', () async {
-      final narrationService = _SpyNarrationService();
-      final controller = _makeController(narrationService: narrationService);
-
-      final content = NarrationContent.create(
-        _testNarrationText,
-        language: Language.traditionalChinese,
-      );
-
-      await controller.initializeWithContent(_testPlace, content);
-
-      expect(
-        narrationService.called,
-        isFalse,
-        reason: '回放已儲存的導覽時，不應呼叫 AI 服務重新生成',
-      );
-    });
-
     test('初始化後狀態為 ready', () async {
       final controller = _makeController();
 
@@ -223,7 +140,7 @@ void main() {
       expect(controller.state.place, equals(_testPlace));
     });
 
-    test('aspect 為 null（回放模式不帶面向）', () async {
+    test('aspect 為 null（播放模式不帶面向）', () async {
       final controller = _makeController();
 
       final content = NarrationContent.create(
@@ -233,11 +150,7 @@ void main() {
 
       await controller.initializeWithContent(_testPlace, content);
 
-      expect(
-        controller.state.aspect,
-        isNull,
-        reason: '從 Journey 卡片回放時不應帶有 aspect',
-      );
+      expect(controller.state.aspect, isNull);
     });
 
     test('初始化 TtsService 並設定語言', () async {
@@ -253,68 +166,6 @@ void main() {
 
       expect(ttsService.initializeCalled, isTrue);
       expect(ttsService.lastLanguageSet, equals(Language.traditionalChinese));
-    });
-
-    test('載入後清除先前的錯誤狀態', () async {
-      // Arrange: first put the controller into an error state via initialize
-      // (use case throws because narration service is not set up to return)
-      final failingService = _SpyNarrationService();
-      final useCase = CreateNarrationUseCase(failingService, _FakeUsageRepository());
-      final controller = PlayerController(
-        useCase,
-        _FakeJourneyRepository(),
-        _FakeTtsService(),
-      );
-
-      // Trigger error via initialize (service.called = true but throws)
-      await controller.initialize(
-        _testPlace,
-        NarrationAspect.historicalBackground,
-        language: Language.traditionalChinese,
-      );
-      expect(controller.state.hasError, isTrue);
-
-      // Act: replay from journey card
-      final content = NarrationContent.create(
-        _testNarrationText,
-        language: Language.traditionalChinese,
-      );
-      await controller.initializeWithContent(_testPlace, content);
-
-      // Assert: error is cleared
-      expect(controller.state.hasError, isFalse);
-      expect(controller.state.errorType, isNull);
-      expect(controller.state.isReady, isTrue);
-    });
-  });
-
-  group('PlayerController.initialize', () {
-    test('呼叫 AI 服務生成新導覽', () async {
-      final narrationService = _SpyNarrationService(
-        textToReturn: _testNarrationText,
-      );
-      final useCase = CreateNarrationUseCase(
-        narrationService,
-        _FakeUsageRepository(),
-      );
-      final controller = PlayerController(
-        useCase,
-        _FakeJourneyRepository(),
-        _FakeTtsService(),
-      );
-
-      await controller.initialize(
-        _testPlace,
-        NarrationAspect.historicalBackground,
-        language: Language.traditionalChinese,
-      );
-
-      expect(
-        narrationService.called,
-        isTrue,
-        reason: '生成新導覽時應呼叫 AI 服務',
-      );
-      expect(controller.state.isReady, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
This PR refactors the narration feature to separate the concerns of content generation and playback. A new `NarrationGenerationController` handles AI generation on the config screen, while `PlayerController` is simplified to only handle playback of pre-generated content.

## Key Changes

- **New `NarrationGenerationController`**: Manages the narration generation lifecycle on the select aspect screen
  - Handles quota checks and error states during generation
  - Auto-saves generated content to journey on success
  - Provides clear state transitions (idle → generating → success/error)
  - Maps domain errors to generation-specific error types

- **Simplified `PlayerController`**: Now focuses solely on playback
  - Removed `initialize()` method that performed generation
  - Removed `_createNarrationUseCase` and `_journeyRepository` dependencies
  - Kept only `initializeWithContent()` for playing pre-generated content
  - Removed auto-save logic (now handled by generation controller)

- **Updated `SelectNarrationAspectScreen`**: Changed from `ConsumerWidget` to `ConsumerStatefulWidget`
  - Integrated `NarrationGenerationController` to handle generation flow
  - Listens for generation success/error and navigates accordingly
  - Shows loading indicator during generation
  - Disables back button while generating
  - Extracted UI components (`_BackgroundImage`, `_CategoryBadge`, `_AddressRow`, `_GeneratingIndicator`) for better organization

- **Updated `NarrationScreen`**: Simplified to only accept pre-generated content
  - Removed `narrationAspect` parameter (no longer needed)
  - Made `narrationContent` required instead of optional
  - Removed conditional logic for generation vs. playback paths

- **Simplified `SaveToPassportButton`**: Changed from `ConsumerStatefulWidget` to `ConsumerWidget`
  - Removed save logic since content is auto-saved during generation
  - Now only navigates to success page

- **Updated routing and translations**: Added generation-related UI strings and updated router configuration

## Implementation Details

- Generation happens on the config screen before navigation to player
- Content is automatically saved to journey during generation (fails silently if save fails)
- Player screen receives pre-generated content via route extras
- Error handling is now split: generation errors on config screen, playback errors on player screen
- Tests added for `NarrationGenerationController` covering success, error, and auto-save scenarios

https://claude.ai/code/session_01KxWuadmSA86XPEGXxuhdsn