### PR TITLE
Remove desaturation and opacity filters from timeline entry images

### DIFF
--- a/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
@@ -217,18 +217,9 @@ class _QuickGuideTimelineEntryState
                         color: colorScheme.surfaceContainerHigh,
                       ),
                       clipBehavior: Clip.antiAlias,
-                      child: ColorFiltered(
-                        colorFilter: const ColorFilter.mode(
-                          Colors.grey,
-                          BlendMode.saturation,
-                        ),
-                        child: Opacity(
-                          opacity: 0.8,
-                          child: Image.memory(
-                            widget.entry.imageBytes,
-                            fit: BoxFit.cover,
-                          ),
-                        ),
+                      child: Image.memory(
+                        widget.entry.imageBytes,
+                        fit: BoxFit.cover,
                       ),
                     ),
                   ],

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -233,26 +233,17 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                           color: colorScheme.surfaceContainerHigh,
                         ),
                         clipBehavior: Clip.antiAlias,
-                        child: ColorFiltered(
-                          colorFilter: const ColorFilter.mode(
-                            Colors.grey,
-                            BlendMode.saturation,
+                        child: CachedNetworkImage(
+                          imageUrl: widget.entry.place.imageUrl!,
+                          fit: BoxFit.cover,
+                          cacheManager: PlaceImageCacheManager.instance,
+                          placeholder: (context, url) => Container(
+                            color: colorScheme.surfaceContainerHigh,
                           ),
-                          child: Opacity(
-                            opacity: 0.8,
-                            child: CachedNetworkImage(
-                              imageUrl: widget.entry.place.imageUrl!,
-                              fit: BoxFit.cover,
-                              cacheManager: PlaceImageCacheManager.instance,
-                              placeholder: (context, url) => Container(
-                                color: colorScheme.surfaceContainerHigh,
-                              ),
-                              errorWidget: (context, url, error) => Icon(
-                                Icons.image_not_supported,
-                                color: colorScheme.onSurfaceVariant,
-                                size: 20,
-                              ),
-                            ),
+                          errorWidget: (context, url, error) => Icon(
+                            Icons.image_not_supported,
+                            color: colorScheme.onSurfaceVariant,
+                            size: 20,
                           ),
                         ),
                       ),


### PR DESCRIPTION
## Summary
Removed the `ColorFiltered` and `Opacity` wrappers that were applying desaturation and reduced opacity effects to images in timeline entries. Images now display at full saturation and opacity.

## Changes
- **timeline_entry.dart**: Removed `ColorFiltered` (saturation blend mode) and `Opacity` (0.8) wrappers from the `CachedNetworkImage` widget for place images
- **quick_guide_timeline_entry.dart**: Removed `ColorFiltered` (saturation blend mode) and `Opacity` (0.8) wrappers from the `Image.memory` widget for quick guide entry images

## Details
The visual filters were previously applied to all timeline entry images, resulting in desaturated and semi-transparent appearance. This change restores images to their original appearance with full color saturation and opacity, improving visual clarity and image quality in the timeline UI.

https://claude.ai/code/session_01EYuJXi6xTsobWfBmoZLEFL