### PR TITLE
Support multiple narration aspects selection

### DIFF
--- a/frontend/integration_test/fakes/fake_narration_service.dart
+++ b/frontend/integration_test/fakes/fake_narration_service.dart
@@ -38,7 +38,7 @@ class FakeNarrationService implements NarrationService {
   @override
   Future<String> generateNarration({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required Language language,
   }) async {
     // 模擬網路延遲

--- a/frontend/lib/features/journey/domain/models/journey_entry.dart
+++ b/frontend/lib/features/journey/domain/models/journey_entry.dart
@@ -8,7 +8,7 @@ class JourneyEntry {
   final String id;
   final SavedPlace place;
   final NarrationContent narrationContent;
-  final NarrationAspect narrationAspect;
+  final Set<NarrationAspect> narrationAspects;
   final DateTime createdAt;
   final Language language;
 
@@ -16,7 +16,7 @@ class JourneyEntry {
     required this.id,
     required this.place,
     required this.narrationContent,
-    required this.narrationAspect,
+    required this.narrationAspects,
     required this.createdAt,
     required this.language,
   });
@@ -27,7 +27,7 @@ class JourneyEntry {
   factory JourneyEntry.create({
     required String id,
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required NarrationContent content,
     required Language language,
   }) {
@@ -44,7 +44,7 @@ class JourneyEntry {
       id: id,
       place: savedPlace,
       narrationContent: content,
-      narrationAspect: aspect,
+      narrationAspects: aspects,
       createdAt: DateTime.now(),
       language: language,
     );
@@ -57,7 +57,9 @@ class JourneyEntry {
     'place_address': place.address,
     'place_image_url': place.imageUrl,
     'narration_text': narrationContent.text,
-    'narration_style': narrationAspect.key,
+    'narration_styles': narrationAspects
+        .map((a) => a.key)
+        .toList(),
     'created_at': createdAt.toIso8601String(),
     'language': language.code,
   };
@@ -78,15 +80,32 @@ class JourneyEntry {
       language: language,
     );
 
-    final narrationAspect =
-        NarrationAspect.fromKey(json['narration_style'] as String) ??
-        NarrationAspect.historicalBackground;
+    // 向下相容：支援舊的 narration_style（單一字串）
+    // 和新的 narration_styles（字串陣列）
+    Set<NarrationAspect> narrationAspects;
+    if (json.containsKey('narration_styles')) {
+      final styles = (json['narration_styles'] as List<dynamic>)
+          .cast<String>();
+      narrationAspects = styles
+          .map((key) => NarrationAspect.fromKey(key))
+          .whereType<NarrationAspect>()
+          .toSet();
+      if (narrationAspects.isEmpty) {
+        narrationAspects = {NarrationAspect.historicalBackground};
+      }
+    } else {
+      final aspect = NarrationAspect.fromKey(
+            json['narration_style'] as String,
+          ) ??
+          NarrationAspect.historicalBackground;
+      narrationAspects = {aspect};
+    }
 
     return JourneyEntry(
       id: json['id'] as String,
       place: place,
       narrationContent: narrationContent,
-      narrationAspect: narrationAspect,
+      narrationAspects: narrationAspects,
       createdAt: DateTime.parse(json['created_at'] as String),
       language: language,
     );

--- a/frontend/lib/features/narration/data/gemini_service.dart
+++ b/frontend/lib/features/narration/data/gemini_service.dart
@@ -18,13 +18,13 @@ class GeminiService implements NarrationService {
   /// 生成地點導覽內容
   ///
   /// [place] 地點資訊
-  /// [aspect] 導覽介紹面向
+  /// [aspects] 導覽介紹面向（支援多選）
   /// [language] 語言代碼（'zh-TW' 或 'en-US'）
   /// 返回適合語音播放的導覽文本
   @override
   Future<String> generateNarration({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required app_lang.Language language,
   }) async {
     try {
@@ -37,7 +37,7 @@ class GeminiService implements NarrationService {
       // 使用 NarrationPromptBuilder 建立提示詞
       final promptBuilder = NarrationPromptBuilder(
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         language: language.code,
       );
       final prompt = promptBuilder.build();

--- a/frontend/lib/features/narration/data/mappers/narration_aspect_mapper.dart
+++ b/frontend/lib/features/narration/data/mappers/narration_aspect_mapper.dart
@@ -5,10 +5,21 @@ import 'package:context_app/features/narration/domain/models/narration_aspect.da
 /// 委派至 [NarrationAspect.key] 和 [NarrationAspect.fromKey]，
 /// 保留此類別以維持 data 層既有的 Mapper 慣例。
 class NarrationAspectMapper {
-  /// 從字串解析
+  /// 從字串解析單一面向
   static NarrationAspect? fromString(String value) =>
       NarrationAspect.fromKey(value);
 
-  /// 轉換為 API 字串
+  /// 轉換單一面向為 API 字串
   static String toApiString(NarrationAspect aspect) => aspect.key;
+
+  /// 從字串列表解析多個面向
+  static Set<NarrationAspect> fromStringList(List<String> values) =>
+      values
+          .map(NarrationAspect.fromKey)
+          .whereType<NarrationAspect>()
+          .toSet();
+
+  /// 轉換多個面向為 API 字串列表
+  static List<String> toApiStringList(Set<NarrationAspect> aspects) =>
+      aspects.map((a) => a.key).toList();
 }

--- a/frontend/lib/features/narration/data/narration_prompt_builder.dart
+++ b/frontend/lib/features/narration/data/narration_prompt_builder.dart
@@ -5,21 +5,26 @@ import 'package:context_app/features/narration/domain/models/narration_aspect.da
 /// 導覽 Prompt 建構器
 ///
 /// 負責根據景點類型和介紹面向生成對應的 AI prompt
+/// 支援多個面向同時選擇，將各面向的指引合併為單一 prompt
 class NarrationPromptBuilder {
   final Place place;
-  final NarrationAspect aspect;
+  final Set<NarrationAspect> aspects;
   final String language;
 
   NarrationPromptBuilder({
     required this.place,
-    required this.aspect,
+    required this.aspects,
     required this.language,
   });
 
   /// 建構完整的 prompt
   String build() {
     final languageName = language.startsWith('zh') ? '繁體中文' : 'English';
-    final aspectGuideline = _getAspectGuideline(aspect);
+    final aspectDescriptions =
+        aspects.map(_getAspectDescription).join(', ');
+    final aspectGuidelines = aspects
+        .map(_getAspectGuideline)
+        .join('\n');
 
     return '''
 You are a professional tour guide creating an engaging audio narration for a location.
@@ -33,14 +38,14 @@ ${place.rating != null ? '- Rating: ${place.rating}/5.0' : ''}
 
 Requirements:
 - Language: $languageName
-- Narration Aspect: ${_getAspectDescription(aspect)}
+- Narration Aspects: $aspectDescriptions
 - Target Length: approximately 800-1200 characters
 - Estimated Duration: 3-5 minutes when read aloud
 - Tone: Engaging, vivid, and informative - as if you're speaking to a tourist standing at the location
 - Do NOT include any opening greetings, introductions, or welcome phrases (e.g., "Hello everyone", "Welcome to..."). Start directly with the content.
 
 Content Guidelines:
-$aspectGuideline
+$aspectGuidelines
 
 Format:
 - Write in a conversational tone suitable for audio playback
@@ -48,6 +53,7 @@ Format:
 - Avoid bullet points or lists
 - Write in flowing paragraphs with clear sentence endings (。！？or . ! ?)
 - Make it engaging and memorable
+- Weave all selected aspects naturally into a cohesive narrative
 
 Please generate the narration now:''';
   }

--- a/frontend/lib/features/narration/domain/services/narration_service.dart
+++ b/frontend/lib/features/narration/domain/services/narration_service.dart
@@ -6,13 +6,13 @@ abstract class NarrationService {
   /// 生成導覽內容文本
   ///
   /// [place] 地點資訊
-  /// [aspect] 導覽介紹面向
+  /// [aspects] 導覽介紹面向（支援多選）
   /// [language] 語言
   /// 返回生成的導覽文本
   /// 拋出 NarrationServiceException 如果服務呼叫失敗
   Future<String> generateNarration({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required Language language,
   });
 }

--- a/frontend/lib/features/narration/domain/use_cases/create_narration_use_case.dart
+++ b/frontend/lib/features/narration/domain/use_cases/create_narration_use_case.dart
@@ -31,7 +31,7 @@ class CreateNarrationUseCase {
   /// 執行用例：生成導覽內容
   ///
   /// [place] 地點資訊
-  /// [aspect] 導覽介紹面向
+  /// [aspects] 導覽介紹面向（支援多選）
   /// [language] 語言
   /// 返回生成的 NarrationContent
   ///
@@ -41,7 +41,7 @@ class CreateNarrationUseCase {
   /// - NarrationError.contentGenerationFailed: 內容驗證失敗
   Future<NarrationContent> execute({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required Language language,
   }) async {
     // 1. 檢查每日使用額度
@@ -54,7 +54,7 @@ class CreateNarrationUseCase {
     // AppError 會直接透傳給上層
     final text = await _narrationService.generateNarration(
       place: place,
-      aspect: aspect,
+      aspects: aspects,
       language: language,
     );
 

--- a/frontend/lib/features/narration/presentation/controllers/narration_generation_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/narration_generation_controller.dart
@@ -75,13 +75,13 @@ class NarrationGenerationController
     this._journeyRepository,
   ) : super(const NarrationGenerationState());
 
-  /// Generates narration content for the given place and aspect.
+  /// Generates narration content for the given place and aspects.
   ///
   /// On success, auto-saves to journey and sets state to [success].
   /// On error, sets state to [error] with the appropriate error type.
   Future<void> generate({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required Language language,
   }) async {
     state = const NarrationGenerationState(
@@ -91,11 +91,11 @@ class NarrationGenerationController
     try {
       final content = await _createNarrationUseCase.execute(
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         language: language,
       );
 
-      await _autoSaveToJourney(place, aspect, content, language);
+      await _autoSaveToJourney(place, aspects, content, language);
 
       state = NarrationGenerationState(
         status: NarrationGenerationStatus.success,
@@ -137,7 +137,7 @@ class NarrationGenerationController
 
   Future<void> _autoSaveToJourney(
     Place place,
-    NarrationAspect aspect,
+    Set<NarrationAspect> aspects,
     NarrationContent content,
     Language language,
   ) async {
@@ -145,7 +145,7 @@ class NarrationGenerationController
       final entry = JourneyEntry.create(
         id: const Uuid().v4(),
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         content: content,
         language: language,
       );

--- a/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
@@ -40,7 +40,8 @@ class _SelectNarrationAspectScreenState
   }
 
   Future<void> _onStartPressed() async {
-    final selectedAspect = ref.read(narrationAspectProvider);
+    final selectedAspects = ref.read(narrationAspectsProvider);
+    if (selectedAspects.isEmpty) return;
 
     // Quota check before generation
     final usageRepo = ref.read(usageRepositoryProvider);
@@ -63,7 +64,7 @@ class _SelectNarrationAspectScreenState
         .read(narrationGenerationControllerProvider.notifier)
         .generate(
           place: widget.place,
-          aspect: selectedAspect,
+          aspects: selectedAspects,
           language: _currentLanguage(),
         );
   }
@@ -102,7 +103,7 @@ class _SelectNarrationAspectScreenState
 
   @override
   Widget build(BuildContext context) {
-    final selectedAspect = ref.watch(narrationAspectProvider);
+    final selectedAspects = ref.watch(narrationAspectsProvider);
     final generationState = ref.watch(
       narrationGenerationControllerProvider,
     );
@@ -227,14 +228,21 @@ class _SelectNarrationAspectScreenState
                                 padding: const EdgeInsets.only(bottom: 12),
                                 child: AspectOption(
                                   aspect: aspect,
-                                  isSelected: selectedAspect == aspect,
+                                  isSelected:
+                                      selectedAspects.contains(aspect),
                                   onTap: () {
-                                    ref
-                                            .read(
-                                              narrationAspectProvider.notifier,
-                                            )
-                                            .state =
-                                        aspect;
+                                    final notifier = ref.read(
+                                      narrationAspectsProvider.notifier,
+                                    );
+                                    final current = ref.read(
+                                      narrationAspectsProvider,
+                                    );
+                                    if (current.contains(aspect)) {
+                                      notifier.state =
+                                          {...current}..remove(aspect);
+                                    } else {
+                                      notifier.state = {...current, aspect};
+                                    }
                                   },
                                 ),
                               );
@@ -246,7 +254,9 @@ class _SelectNarrationAspectScreenState
 
                       // Start Button
                       ElevatedButton(
-                        onPressed: _onStartPressed,
+                        onPressed: selectedAspects.isEmpty
+                            ? null
+                            : _onStartPressed,
                         style: ElevatedButton.styleFrom(
                           backgroundColor: AppColors.primary,
                           shape: RoundedRectangleBorder(
@@ -481,9 +491,12 @@ class AspectOption extends StatelessWidget {
               ),
             ),
             if (isSelected)
-              const Icon(Icons.check_circle, color: AppColors.primary)
+              const Icon(Icons.check_box, color: AppColors.primary)
             else
-              const Icon(Icons.radio_button_unchecked, color: Colors.white54),
+              const Icon(
+                Icons.check_box_outline_blank,
+                color: Colors.white54,
+              ),
           ],
         ),
       ),

--- a/frontend/lib/features/narration/providers.dart
+++ b/frontend/lib/features/narration/providers.dart
@@ -18,13 +18,12 @@ final narrationServiceProvider = Provider<NarrationService>((ref) {
 
 /// 導覽介紹面向選擇 Provider
 ///
-/// 管理用戶選擇的導覽介紹面向
+/// 管理用戶選擇的導覽介紹面向（支援多選）
 /// 預設為歷史背景（historicalBackground）
 /// 使用 autoDispose 確保離開頁面時自動重置
-final narrationAspectProvider = StateProvider.autoDispose<NarrationAspect>((
-  ref,
-) {
-  return NarrationAspect.historicalBackground;
+final narrationAspectsProvider =
+    StateProvider.autoDispose<Set<NarrationAspect>>((ref) {
+  return {NarrationAspect.historicalBackground};
 });
 
 /// TtsService Provider

--- a/frontend/test/features/journey/data/hive_journey_repository_test.dart
+++ b/frontend/test/features/journey/data/hive_journey_repository_test.dart
@@ -16,7 +16,7 @@ JourneyEntry _makeEntry({String id = 'e1', DateTime? createdAt}) {
     address: 'Test Address',
   );
 
-  const aspect = NarrationAspect.historicalBackground;
+  const aspects = {NarrationAspect.historicalBackground};
   final content = NarrationContent.create(
     'Narration text',
     language: const Language('zh-TW'),
@@ -26,7 +26,7 @@ JourneyEntry _makeEntry({String id = 'e1', DateTime? createdAt}) {
     id: id,
     place: place,
     narrationContent: content,
-    narrationAspect: aspect,
+    narrationAspects: aspects,
     createdAt: createdAt ?? DateTime.now(),
     language: const Language('zh-TW'),
   );
@@ -101,7 +101,7 @@ void main() {
     expect(restored.place.name, original.place.name);
     expect(restored.place.address, original.place.address);
     expect(restored.narrationContent.text, original.narrationContent.text);
-    expect(restored.narrationAspect, original.narrationAspect);
+    expect(restored.narrationAspects, original.narrationAspects);
     expect(restored.language.code, original.language.code);
   });
 }

--- a/frontend/test/features/journey/domain/models/journey_entry_test.dart
+++ b/frontend/test/features/journey/domain/models/journey_entry_test.dart
@@ -22,7 +22,7 @@ void main() {
         category: PlaceCategory.historicalCultural,
       );
 
-      const aspect = NarrationAspect.historicalBackground;
+      const aspects = {NarrationAspect.historicalBackground};
       final content = NarrationContent.create(
         'Test narration',
         language: Language.traditionalChinese,
@@ -31,7 +31,7 @@ void main() {
       final entry = JourneyEntry.create(
         id: 'test-id',
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         content: content,
         language: Language.traditionalChinese,
       );
@@ -47,7 +47,7 @@ void main() {
         ),
       );
       expect(entry.narrationContent, equals(content));
-      expect(entry.narrationAspect, equals(aspect));
+      expect(entry.narrationAspects, equals(aspects));
       expect(entry.language, equals(Language.traditionalChinese));
       expect(entry.id, isNotEmpty);
     });
@@ -72,7 +72,7 @@ void main() {
           category: PlaceCategory.naturalLandscape,
         );
 
-        const aspect = NarrationAspect.geology;
+        const aspects = {NarrationAspect.geology};
         final content = NarrationContent.create(
           'Geology narration',
           language: Language.traditionalChinese,
@@ -81,7 +81,7 @@ void main() {
         final entry = JourneyEntry.create(
           id: 'test-id-2',
           place: place,
-          aspect: aspect,
+          aspects: aspects,
           content: content,
           language: Language.traditionalChinese,
         );
@@ -98,7 +98,7 @@ void main() {
           ),
         );
         expect(entry.narrationContent, equals(content));
-        expect(entry.narrationAspect, equals(aspect));
+        expect(entry.narrationAspects, equals(aspects));
         expect(entry.language, equals(Language.traditionalChinese));
       },
     );
@@ -114,7 +114,7 @@ void main() {
         category: PlaceCategory.modernUrban,
       );
 
-      const aspect = NarrationAspect.historicalBackground;
+      const aspects = {NarrationAspect.historicalBackground};
       final content = NarrationContent.create(
         'Test narration',
         language: Language.traditionalChinese,
@@ -123,7 +123,7 @@ void main() {
       final entry1 = JourneyEntry.create(
         id: 'id-1',
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         content: content,
         language: Language.traditionalChinese,
       );
@@ -131,7 +131,7 @@ void main() {
       final entry2 = JourneyEntry.create(
         id: 'id-2',
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         content: content,
         language: Language.traditionalChinese,
       );
@@ -154,7 +154,7 @@ void main() {
         category: PlaceCategory.historicalCultural,
       );
 
-      const aspect = NarrationAspect.historicalBackground;
+      const aspects = {NarrationAspect.historicalBackground};
       final content = NarrationContent.create(
         'Round trip text',
         language: Language.traditionalChinese,
@@ -163,7 +163,7 @@ void main() {
       final original = JourneyEntry.create(
         id: 'round-trip-id',
         place: place,
-        aspect: aspect,
+        aspects: aspects,
         content: content,
         language: Language.traditionalChinese,
       );
@@ -175,7 +175,7 @@ void main() {
       expect(restored.place.name, original.place.name);
       expect(restored.place.address, original.place.address);
       expect(restored.narrationContent.text, original.narrationContent.text);
-      expect(restored.narrationAspect, original.narrationAspect);
+      expect(restored.narrationAspects, original.narrationAspects);
       expect(restored.language, original.language);
     });
 
@@ -196,7 +196,7 @@ void main() {
       final entry = JourneyEntry.create(
         id: 'lang-test-id',
         place: place,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         content: content,
         language: Language.english,
       );

--- a/frontend/test/features/narration/domain/use_cases/create_narration_use_case_test.dart
+++ b/frontend/test/features/narration/domain/use_cases/create_narration_use_case_test.dart
@@ -28,7 +28,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakePlace());
-    registerFallbackValue(NarrationAspect.historicalBackground);
+    registerFallbackValue(<NarrationAspect>{NarrationAspect.historicalBackground});
     registerFallbackValue(FakeLanguage());
   });
 
@@ -63,14 +63,14 @@ void main() {
     when(
       () => mockNarrationService.generateNarration(
         place: testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: any(named: 'language'),
       ),
     ).thenAnswer((_) async => testGeneratedText);
 
     final narrationContent = await useCase.execute(
       place: testPlace,
-      aspect: NarrationAspect.historicalBackground,
+      aspects: {NarrationAspect.historicalBackground},
       language: Language.traditionalChinese,
     );
 
@@ -89,14 +89,14 @@ void main() {
     when(
       () => mockNarrationService.generateNarration(
         place: testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: any(named: 'language'),
       ),
     ).thenAnswer((_) async => testGeneratedText);
 
     await useCase.execute(
       place: testPlace,
-      aspect: NarrationAspect.historicalBackground,
+      aspects: {NarrationAspect.historicalBackground},
       language: Language.traditionalChinese,
     );
 
@@ -111,7 +111,7 @@ void main() {
     expect(
       () => useCase.execute(
         place: testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       ),
       throwsA(
@@ -126,7 +126,7 @@ void main() {
     verifyNever(
       () => mockNarrationService.generateNarration(
         place: any(named: 'place'),
-        aspect: any(named: 'aspect'),
+        aspects: any(named: 'aspects'),
         language: any(named: 'language'),
       ),
     );
@@ -140,14 +140,14 @@ void main() {
     when(
       () => mockNarrationService.generateNarration(
         place: testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: any(named: 'language'),
       ),
     ).thenAnswer((_) async => testGeneratedText);
 
     final narrationContent = await useCase.execute(
       place: testPlace,
-      aspect: NarrationAspect.historicalBackground,
+      aspects: {NarrationAspect.historicalBackground},
       language: Language.traditionalChinese,
     );
 
@@ -162,14 +162,14 @@ void main() {
     when(
       () => mockNarrationService.generateNarration(
         place: testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: any(named: 'language'),
       ),
     ).thenAnswer((_) async => testGeneratedText);
 
     await useCase.execute(
       place: testPlace,
-      aspect: NarrationAspect.historicalBackground,
+      aspects: {NarrationAspect.historicalBackground},
       language: Language.traditionalChinese,
     );
 

--- a/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
+++ b/frontend/test/features/narration/presentation/controllers/narration_generation_controller_test.dart
@@ -39,7 +39,7 @@ class _SpyNarrationService implements NarrationService {
   @override
   Future<String> generateNarration({
     required Place place,
-    required NarrationAspect aspect,
+    required Set<NarrationAspect> aspects,
     required Language language,
   }) async {
     called = true;
@@ -112,7 +112,7 @@ void main() {
 
       await controller.generate(
         place: _testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       );
 
@@ -128,7 +128,7 @@ void main() {
 
       await controller.generate(
         place: _testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       );
 
@@ -154,7 +154,7 @@ void main() {
 
       await controller.generate(
         place: _testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       );
 
@@ -172,7 +172,7 @@ void main() {
 
       await controller.generate(
         place: _testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       );
 
@@ -190,7 +190,7 @@ void main() {
 
       await controller.generate(
         place: _testPlace,
-        aspect: NarrationAspect.historicalBackground,
+        aspects: {NarrationAspect.historicalBackground},
         language: Language.traditionalChinese,
       );
       expect(controller.state.isSuccess, isTrue);


### PR DESCRIPTION
## Summary
This PR extends the narration feature to support selecting multiple narration aspects simultaneously, instead of limiting users to a single aspect choice. The changes propagate this multi-select capability throughout the presentation, domain, and data layers.

## Key Changes

### Presentation Layer
- **Select Narration Aspect Screen**: 
  - Changed from single-select (`narrationAspectProvider`) to multi-select (`narrationAspectsProvider`)
  - Updated aspect selection logic to toggle aspects in/out of a set
  - Changed checkbox icons from radio buttons to actual checkboxes for better UX
  - Added validation to disable the start button when no aspects are selected

### Domain Layer
- **JourneyEntry Model**:
  - Changed `narrationAspect` field from single `NarrationAspect` to `Set<NarrationAspect>`
  - Updated factory methods and serialization to handle multiple aspects
  - Added backward compatibility for deserializing old single-aspect data

- **Use Cases & Services**:
  - Updated `CreateNarrationUseCase` to accept `Set<NarrationAspect>`
  - Updated `NarrationService` interface to accept multiple aspects
  - Updated `NarrationGenerationController` to pass multiple aspects through the pipeline

### Data Layer
- **NarrationPromptBuilder**:
  - Modified to accept and process multiple aspects
  - Combines aspect guidelines into a single cohesive prompt
  - Updated prompt instructions to weave multiple aspects naturally into the narrative

- **GeminiService**: Updated to pass multiple aspects to the prompt builder

- **NarrationAspectMapper**: Added helper methods for converting between string lists and aspect sets

### Tests
- Updated all test files to use `Set<NarrationAspect>` instead of single aspects
- Updated mock service implementations and test cases throughout

## Notable Implementation Details
- Multi-select uses a `Set<NarrationAspect>` to prevent duplicates and maintain consistency
- Backward compatibility is maintained for existing journey entries with single aspects
- The prompt builder intelligently merges multiple aspect guidelines into a unified narrative instruction
- UI validation prevents generation with empty aspect selection

https://claude.ai/code/session_01Btj32KyQWzk5FCmr8jeDtM