### PR TITLE
feat: add user-configurable review count filter with UI panel

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -63,7 +63,13 @@
   },
   "explore": {
     "title": "Explore",
-    "refresh": "Refresh"
+    "refresh": "Refresh",
+    "filter": {
+      "title": "Filters",
+      "min_reviews": "Minimum reviews",
+      "description": "Filter out places with too few reviews to avoid showing non-genuine attractions.",
+      "reset": "Reset to default"
+    }
   },
   "common": {
     "language_english": "English",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -63,7 +63,13 @@
   },
   "explore": {
     "title": "探索",
-    "refresh": "重新整理"
+    "refresh": "重新整理",
+    "filter": {
+      "title": "篩選條件",
+      "min_reviews": "最低評論數",
+      "description": "過濾評論數不足的地點，避免顯示非真正的景點。",
+      "reset": "重設為預設值"
+    }
   },
   "common": {
     "language_english": "English",

--- a/frontend/lib/features/explore/data/repositories/places_repository_impl.dart
+++ b/frontend/lib/features/explore/data/repositories/places_repository_impl.dart
@@ -11,13 +11,6 @@ class PlacesRepositoryImpl implements PlacesRepository {
 
   PlacesRepositoryImpl(this._apiService);
 
-  /// 最低評論數門檻
-  ///
-  /// 評論數低於此值的地點會被過濾，避免顯示非真正景點。
-  /// 根據研究，真正的觀光景點通常至少會有 10 則以上的 Google 評論，
-  /// 低於此數量的地點很可能是被錯誤標記的商家或臨時性地點。
-  static const int _minUserRatingCount = 10;
-
   static const List<String> _includedTypes = [
     'tourist_attraction',
     'historical_landmark',
@@ -46,10 +39,8 @@ class PlacesRepositoryImpl implements PlacesRepository {
       );
 
       // DTO -> Domain 轉換，同時產生照片 URL
-      // 過濾掉評論數不足的地點，避免顯示非真正景點
       return dtos
           .map((dto) => dto.toDomain(apiKey: _apiService.apiKey))
-          .where(_hasEnoughReviews)
           .toList();
     } on AppError {
       rethrow;
@@ -75,10 +66,8 @@ class PlacesRepositoryImpl implements PlacesRepository {
       );
 
       // DTO -> Domain 轉換，同時產生照片 URL
-      // 過濾掉評論數不足的地點，避免顯示非真正景點
       return dtos
           .map((dto) => dto.toDomain(apiKey: _apiService.apiKey))
-          .where(_hasEnoughReviews)
           .toList();
     } on AppError {
       rethrow;
@@ -90,13 +79,5 @@ class PlacesRepositoryImpl implements PlacesRepository {
         stackTrace: stackTrace,
       );
     }
-  }
-
-  /// 檢查地點是否有足夠的評論數
-  ///
-  /// 若 API 未回傳 userRatingCount（為 null），視為評論數不足並過濾。
-  bool _hasEnoughReviews(Place place) {
-    final count = place.userRatingCount;
-    return count != null && count >= _minUserRatingCount;
   }
 }

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -42,10 +42,22 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
     super.dispose();
   }
 
+  void _showFilterPanel() {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => const _FilterPanel(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final placesState = ref.watch(placesControllerProvider);
+    final placesState = ref.watch(filteredPlacesProvider);
     final colorScheme = Theme.of(context).colorScheme;
+    final minReviewCount = ref.watch(minReviewCountProvider);
+    final isFilterActive = minReviewCount != 100;
 
     return Scaffold(
       body: SafeArea(
@@ -66,19 +78,30 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                           color: colorScheme.onSurface,
                         ),
                       ),
-                      IconButton(
-                        onPressed: () {
-                          _searchController.clear();
-                          ref.read(placesControllerProvider.notifier).refresh();
-                        },
-                        icon: const Icon(Icons.refresh),
-                        style: ElevatedButton.styleFrom(
-                          foregroundColor: Colors.white,
-                          backgroundColor: AppColors.primary,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(20),
+                      Row(
+                        children: [
+                          _FilterButton(
+                            isActive: isFilterActive,
+                            onPressed: _showFilterPanel,
                           ),
-                        ),
+                          const SizedBox(width: 8),
+                          IconButton(
+                            onPressed: () {
+                              _searchController.clear();
+                              ref
+                                  .read(placesControllerProvider.notifier)
+                                  .refresh();
+                            },
+                            icon: const Icon(Icons.refresh),
+                            style: ElevatedButton.styleFrom(
+                              foregroundColor: Colors.white,
+                              backgroundColor: AppColors.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(20),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ],
                   ),
@@ -130,7 +153,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                           return PlaceCard(place: places[index]);
                         },
                       ),
-                loading: () => const Center(child: CircularProgressIndicator()),
+                loading: () =>
+                    const Center(child: CircularProgressIndicator()),
                 error: (error, stack) => Center(
                   child: Text('${'common.error_prefix'.tr()}: $error'),
                 ),
@@ -138,6 +162,198 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _FilterButton extends StatelessWidget {
+  final bool isActive;
+  final VoidCallback onPressed;
+
+  const _FilterButton({
+    required this.isActive,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: onPressed,
+      icon: Badge(
+        isLabelVisible: isActive,
+        smallSize: 8,
+        child: const Icon(Icons.tune),
+      ),
+      style: ElevatedButton.styleFrom(
+        foregroundColor: Colors.white,
+        backgroundColor:
+            isActive ? AppColors.amber : AppColors.primary,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterPanel extends ConsumerStatefulWidget {
+  const _FilterPanel();
+
+  @override
+  ConsumerState<_FilterPanel> createState() => _FilterPanelState();
+}
+
+class _FilterPanelState extends ConsumerState<_FilterPanel> {
+  late double _sliderValue;
+
+  /// 滑桿的刻度值：0, 10, 50, 100, 200, 500, 1000
+  static const List<int> _steps = [0, 10, 50, 100, 200, 500, 1000];
+
+  @override
+  void initState() {
+    super.initState();
+    final current = ref.read(minReviewCountProvider);
+    _sliderValue = _valueToSlider(current);
+  }
+
+  /// 將評論數對應到滑桿位置（0.0 ~ 1.0）
+  double _valueToSlider(int value) {
+    for (int i = 0; i < _steps.length; i++) {
+      if (value <= _steps[i]) {
+        if (i == 0) return 0.0;
+        final prev = _steps[i - 1];
+        final curr = _steps[i];
+        final fraction = (value - prev) / (curr - prev);
+        return (i - 1 + fraction) / (_steps.length - 1);
+      }
+    }
+    return 1.0;
+  }
+
+  /// 將滑桿位置轉換為評論數
+  int _sliderToValue(double slider) {
+    final pos = slider * (_steps.length - 1);
+    final lower = pos.floor().clamp(0, _steps.length - 2);
+    final fraction = pos - lower;
+    final value =
+        _steps[lower] + ((_steps[lower + 1] - _steps[lower]) * fraction);
+    return value.round();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final currentValue = _sliderToValue(_sliderValue);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 16, 24, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          Text(
+            'explore.filter.title'.tr(),
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'explore.filter.min_reviews'.tr(),
+            style: TextStyle(
+              fontSize: 14,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: Slider(
+                  value: _sliderValue,
+                  onChanged: (value) {
+                    setState(() {
+                      _sliderValue = value;
+                    });
+                  },
+                  onChangeEnd: (value) {
+                    ref.read(minReviewCountProvider.notifier).state =
+                        _sliderToValue(value);
+                  },
+                ),
+              ),
+              SizedBox(
+                width: 60,
+                child: Text(
+                  '$currentValue',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: colorScheme.primary,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '0',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                Text(
+                  '1000',
+                  style: TextStyle(
+                    fontSize: 11,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'explore.filter.description'.tr(),
+            style: TextStyle(
+              fontSize: 12,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              onPressed: () {
+                ref.read(minReviewCountProvider.notifier).state = 100;
+                setState(() {
+                  _sliderValue = _valueToSlider(100);
+                });
+              },
+              child: Text('explore.filter.reset'.tr()),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/frontend/lib/features/explore/providers.dart
+++ b/frontend/lib/features/explore/providers.dart
@@ -33,6 +33,26 @@ final placesCacheServiceProvider = Provider<HivePlacesCacheService>((ref) {
   return HivePlacesCacheService(apiKey);
 });
 
+// Filter Providers
+
+/// 使用者設定的最低評論數門檻，預設 100
+final minReviewCountProvider = StateProvider<int>((ref) => 100);
+
+/// 根據評論數過濾後的地點列表
+///
+/// 監聽 [placesControllerProvider] 和 [minReviewCountProvider]，
+/// 當任一改變時自動重新過濾，不會重新呼叫 API。
+final filteredPlacesProvider = Provider<AsyncValue<List<Place>>>((ref) {
+  final placesAsync = ref.watch(placesControllerProvider);
+  final minCount = ref.watch(minReviewCountProvider);
+
+  return placesAsync.whenData((places) {
+    return places
+        .where((p) => (p.userRatingCount ?? 0) >= minCount)
+        .toList();
+  });
+});
+
 // Use Case Providers
 final searchNearbyPlacesUseCaseProvider = Provider<SearchNearbyPlacesUseCase>((
   ref,

--- a/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
+++ b/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
@@ -54,12 +54,12 @@ void main() {
     );
   }
 
-  group('getNearbyPlaces - 評論數過濾', () {
-    test('應過濾掉評論數低於 10 的地點', () async {
+  group('getNearbyPlaces - 回傳所有地點（不過濾）', () {
+    test('應回傳所有地點，包括評論數少的', () async {
       final dtos = [
         createDto(id: '1', name: 'Popular', userRatingCount: 500),
-        createDto(id: '2', name: 'Too Few', userRatingCount: 5),
-        createDto(id: '3', name: 'Enough', userRatingCount: 10),
+        createDto(id: '2', name: 'Few Reviews', userRatingCount: 5),
+        createDto(id: '3', name: 'No Reviews', userRatingCount: null),
       ];
 
       when(
@@ -77,14 +77,12 @@ void main() {
         radius: testRadius,
       );
 
-      expect(result.length, 2);
-      expect(result.map((p) => p.name), ['Popular', 'Enough']);
+      expect(result.length, 3);
     });
 
-    test('應過濾掉 userRatingCount 為 null 的地點', () async {
+    test('應正確傳遞 userRatingCount 到 Domain Model', () async {
       final dtos = [
-        createDto(id: '1', name: 'Has Reviews', userRatingCount: 50),
-        createDto(id: '2', name: 'No Data', userRatingCount: null),
+        createDto(id: '1', name: 'Place', userRatingCount: 42),
       ];
 
       when(
@@ -102,92 +100,15 @@ void main() {
         radius: testRadius,
       );
 
-      expect(result.length, 1);
-      expect(result.first.name, 'Has Reviews');
-    });
-
-    test('剛好 10 則評論的地點應保留', () async {
-      final dtos = [
-        createDto(
-          id: '1',
-          name: 'Exactly 10',
-          userRatingCount: 10,
-        ),
-      ];
-
-      when(
-        () => mockApiService.searchNearby(
-          any(),
-          includedTypes: any(named: 'includedTypes'),
-          languageCode: any(named: 'languageCode'),
-          radius: any(named: 'radius'),
-        ),
-      ).thenAnswer((_) async => dtos);
-
-      final result = await repository.getNearbyPlaces(
-        testLocation,
-        language: testLanguage,
-        radius: testRadius,
-      );
-
-      expect(result.length, 1);
-      expect(result.first.name, 'Exactly 10');
-    });
-
-    test('9 則評論的地點應被過濾', () async {
-      final dtos = [
-        createDto(id: '1', name: 'Almost', userRatingCount: 9),
-      ];
-
-      when(
-        () => mockApiService.searchNearby(
-          any(),
-          includedTypes: any(named: 'includedTypes'),
-          languageCode: any(named: 'languageCode'),
-          radius: any(named: 'radius'),
-        ),
-      ).thenAnswer((_) async => dtos);
-
-      final result = await repository.getNearbyPlaces(
-        testLocation,
-        language: testLanguage,
-        radius: testRadius,
-      );
-
-      expect(result, isEmpty);
-    });
-
-    test('所有地點都被過濾時應回傳空列表', () async {
-      final dtos = [
-        createDto(id: '1', name: 'Low 1', userRatingCount: 3),
-        createDto(id: '2', name: 'Low 2', userRatingCount: 0),
-        createDto(id: '3', name: 'No Data', userRatingCount: null),
-      ];
-
-      when(
-        () => mockApiService.searchNearby(
-          any(),
-          includedTypes: any(named: 'includedTypes'),
-          languageCode: any(named: 'languageCode'),
-          radius: any(named: 'radius'),
-        ),
-      ).thenAnswer((_) async => dtos);
-
-      final result = await repository.getNearbyPlaces(
-        testLocation,
-        language: testLanguage,
-        radius: testRadius,
-      );
-
-      expect(result, isEmpty);
+      expect(result.first.userRatingCount, 42);
     });
   });
 
-  group('searchPlaces - 評論數過濾', () {
-    test('文字搜尋也應過濾掉評論數不足的地點', () async {
+  group('searchPlaces - 回傳所有地點（不過濾）', () {
+    test('應回傳所有搜尋結果', () async {
       final dtos = [
         createDto(id: '1', name: 'Popular', userRatingCount: 200),
-        createDto(id: '2', name: 'Too Few', userRatingCount: 3),
+        createDto(id: '2', name: 'Tiny', userRatingCount: 3),
       ];
 
       when(
@@ -202,8 +123,7 @@ void main() {
         language: testLanguage,
       );
 
-      expect(result.length, 1);
-      expect(result.first.name, 'Popular');
+      expect(result.length, 2);
     });
   });
 }

--- a/frontend/test/features/explore/presentation/filtered_places_provider_test.dart
+++ b/frontend/test/features/explore/presentation/filtered_places_provider_test.dart
@@ -1,0 +1,82 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  /// 建立測試用 Place
+  Place createPlace({
+    required String id,
+    required String name,
+    int? userRatingCount,
+  }) {
+    return Place(
+      id: id,
+      name: name,
+      formattedAddress: 'Test Address',
+      location: const PlaceLocation(latitude: 0, longitude: 0),
+      types: const ['tourist_attraction'],
+      photos: const [],
+      category: PlaceCategory.modernUrban,
+      userRatingCount: userRatingCount,
+    );
+  }
+
+  group('filteredPlacesProvider', () {
+    test('預設門檻為 100', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final minCount = container.read(minReviewCountProvider);
+      expect(minCount, 100);
+    });
+
+    test('應根據 minReviewCountProvider 過濾地點', () {
+      final container = ProviderContainer(
+        overrides: [
+          placesControllerProvider.overrideWith(() {
+            return _FakePlacesController([
+              createPlace(id: '1', name: 'Many', userRatingCount: 500),
+              createPlace(id: '2', name: 'Some', userRatingCount: 50),
+              createPlace(id: '3', name: 'Few', userRatingCount: 5),
+              createPlace(id: '4', name: 'None', userRatingCount: null),
+            ]);
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // 預設門檻 100：只有 500 通過
+      var filtered = container.read(filteredPlacesProvider);
+      filtered.whenData((places) {
+        expect(places.length, 1);
+        expect(places.first.name, 'Many');
+      });
+
+      // 調整門檻為 50：500 和 50 通過
+      container.read(minReviewCountProvider.notifier).state = 50;
+      filtered = container.read(filteredPlacesProvider);
+      filtered.whenData((places) {
+        expect(places.length, 2);
+      });
+
+      // 調整門檻為 0：除了 null 以外都通過
+      container.read(minReviewCountProvider.notifier).state = 0;
+      filtered = container.read(filteredPlacesProvider);
+      filtered.whenData((places) {
+        expect(places.length, 3);
+      });
+    });
+  });
+}
+
+class _FakePlacesController extends PlacesController {
+  final List<Place> _places;
+
+  _FakePlacesController(this._places);
+
+  @override
+  Future<List<Place>> build() async => _places;
+}


### PR DESCRIPTION
Replace the hardcoded minimum review count with a user-adjustable filter. A filter button (tune icon) in the Explore screen header opens a bottom sheet with a non-linear slider (0-1000) to set the minimum review threshold. Default is 100.

Architecture:
- minReviewCountProvider: stores the user's threshold (default 100)
- filteredPlacesProvider: derives filtered list reactively without re-fetching from API when filter changes
- Repository no longer filters (returns all data from API)

https://claude.ai/code/session_01JC7WdbWfSy3RNAWnorBh72