### PR TITLE
Add app store links and convert CTA buttons to proper links

### DIFF
--- a/landing/src/components/FinalCTA.tsx
+++ b/landing/src/components/FinalCTA.tsx
@@ -20,9 +20,36 @@ export default function FinalCTA() {
         <p className="text-on-surface-variant mb-12 font-medium">
           Join 50,000+ explorers uncovering the hidden narratives of our world.
         </p>
-        <button className="bg-primary hover:bg-primary-fixed-dim text-white text-lg px-12 py-5 rounded-full font-black transition-all shadow-2xl shadow-primary/40 active:scale-95">
-          Download for iOS / Android
-        </button>
+        <div className="flex flex-wrap justify-center gap-4">
+          <a
+            href="https://apps.apple.com/tw/app/%E8%AE%80%E6%99%AF/id6751904060"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-primary text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-primary-fixed-dim hover:scale-105 active:scale-95 shadow-2xl shadow-primary/40"
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              ios
+            </span>
+            App Store
+          </a>
+          <a
+            href="https://play.google.com/store/apps/details?id=com.paulchwu.instantexplore&hl=zh_TW"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="glass-card text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-white/20 hover:scale-105 active:scale-95"
+          >
+            <span
+              className="material-symbols-outlined"
+              style={{ fontVariationSettings: "'FILL' 1" }}
+            >
+              android
+            </span>
+            Play Store
+          </a>
+        </div>
       </div>
     </section>
   );

--- a/landing/src/components/Footer.tsx
+++ b/landing/src/components/Footer.tsx
@@ -1,10 +1,16 @@
 const links = [
-  "Privacy Policy",
-  "Terms of Service",
-  "Support",
-  "Instagram",
-  "App Store",
-  "Play Store",
+  { label: "Privacy Policy", href: "#" },
+  { label: "Terms of Service", href: "#" },
+  { label: "Support", href: "#" },
+  { label: "Instagram", href: "#" },
+  {
+    label: "App Store",
+    href: "https://apps.apple.com/tw/app/%E8%AE%80%E6%99%AF/id6751904060",
+  },
+  {
+    label: "Play Store",
+    href: "https://play.google.com/store/apps/details?id=com.paulchwu.instantexplore&hl=zh_TW",
+  },
 ];
 
 export default function Footer() {
@@ -15,11 +21,13 @@ export default function Footer() {
         <div className="flex flex-wrap justify-center gap-8 text-[10px] uppercase tracking-widest text-white/40">
           {links.map((link) => (
             <a
-              key={link}
+              key={link.label}
               className="hover:text-blue-400 transition-colors"
-              href="#"
+              href={link.href}
+              target={link.href !== "#" ? "_blank" : undefined}
+              rel={link.href !== "#" ? "noopener noreferrer" : undefined}
             >
-              {link}
+              {link.label}
             </a>
           ))}
         </div>

--- a/landing/src/components/Hero.tsx
+++ b/landing/src/components/Hero.tsx
@@ -25,7 +25,12 @@ export default function Hero() {
           the stories behind the stones.
         </p>
         <div className="flex flex-wrap justify-center gap-4">
-          <button className="bg-primary text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-primary-fixed-dim hover:scale-105 active:scale-95">
+          <a
+            href="https://apps.apple.com/tw/app/%E8%AE%80%E6%99%AF/id6751904060"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-primary text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-primary-fixed-dim hover:scale-105 active:scale-95"
+          >
             <span
               className="material-symbols-outlined"
               style={{ fontVariationSettings: "'FILL' 1" }}
@@ -33,16 +38,21 @@ export default function Hero() {
               ios
             </span>
             App Store
-          </button>
-          <button className="glass-card text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-white/20 hover:scale-105 active:scale-95">
+          </a>
+          <a
+            href="https://play.google.com/store/apps/details?id=com.paulchwu.instantexplore&hl=zh_TW"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="glass-card text-white px-8 py-4 rounded-full font-black flex items-center gap-3 transition-all hover:bg-white/20 hover:scale-105 active:scale-95"
+          >
             <span
               className="material-symbols-outlined"
               style={{ fontVariationSettings: "'FILL' 1" }}
             >
-              play_store_installed
+              android
             </span>
             Play Store
-          </button>
+          </a>
         </div>
       </div>
 

--- a/landing/src/components/Navbar.tsx
+++ b/landing/src/components/Navbar.tsx
@@ -25,9 +25,14 @@ export default function Navbar() {
             Passport
           </a>
         </div>
-        <button className="bg-primary hover:bg-primary/90 text-white px-6 py-2 rounded-full font-bold transition-all active:scale-95 shadow-lg shadow-primary/20">
+        <a
+          href="https://apps.apple.com/tw/app/%E8%AE%80%E6%99%AF/id6751904060"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="bg-primary hover:bg-primary/90 text-white px-6 py-2 rounded-full font-bold transition-all active:scale-95 shadow-lg shadow-primary/20"
+        >
           Download
-        </button>
+        </a>
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
This PR adds functional app store links throughout the landing page and converts call-to-action buttons to semantic anchor elements. The changes include integrating direct links to the iOS App Store and Google Play Store across multiple components.

## Key Changes
- **FinalCTA Component**: Replaced single download button with two separate app store links (iOS App Store and Google Play Store) with proper icons and styling
- **Hero Component**: Converted button elements to anchor tags linking to app stores; fixed Android icon from `play_store_installed` to `android`
- **Navbar Component**: Converted download button to an anchor link pointing to iOS App Store
- **Footer Component**: 
  - Refactored links array from simple strings to objects with `label` and `href` properties
  - Added actual app store URLs for App Store and Play Store links
  - Updated link rendering to use `target="_blank"` and `rel="noopener noreferrer"` for external links
  - Conditional attributes to only open external links in new tabs

## Implementation Details
- All app store links use proper semantic HTML (`<a>` tags) instead of buttons
- External links include security attributes (`target="_blank"`, `rel="noopener noreferrer"`)
- Consistent styling maintained across components with hover and active states
- Material icons properly configured with `fontVariationSettings` for filled variants
- Links point to Taiwan-specific app store pages (zh_TW locale)

https://claude.ai/code/session_01DExt1JJMCKaAfakRoqwi13