### PR TITLE
Add saved locations feature with FAB and dialog UI

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -232,5 +232,14 @@
     "watch_ad_subtitle": "Watch a short video to get 1 extra narration",
     "watch_video": "Watch Video",
     "ad_reward_success": "Earned 1 extra narration!"
+  },
+  "saved_locations": {
+    "title": "Saved Locations",
+    "empty": "No saved locations yet",
+    "empty_hint": "Tap the bookmark icon on a place card to save it",
+    "delete_title": "Remove Location",
+    "delete_message": "Are you sure you want to remove this saved location?",
+    "delete_confirm": "Remove",
+    "cancel": "Cancel"
   }
 }

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -232,5 +232,14 @@
     "watch_ad_subtitle": "觀看一段短影片即可獲得 1 次額外導覽",
     "watch_video": "觀看影片",
     "ad_reward_success": "獲得 1 次額外導覽！"
+  },
+  "saved_locations": {
+    "title": "儲存的地點",
+    "empty": "尚未儲存任何地點",
+    "empty_hint": "點擊地點卡片上的書籤圖示即可儲存",
+    "delete_title": "移除地點",
+    "delete_message": "確定要移除此儲存的地點嗎？",
+    "delete_confirm": "移除",
+    "cancel": "取消"
   }
 }

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -7,6 +7,8 @@ import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/shared/extensions/place_category_extension.dart';
 import 'package:context_app/features/explore/providers.dart';
 import 'package:context_app/features/settings/providers.dart';
+import 'package:context_app/features/saved_locations/providers.dart';
+import 'package:context_app/features/saved_locations/presentation/widgets/saved_locations_fab.dart';
 
 class ExploreScreen extends ConsumerStatefulWidget {
   const ExploreScreen({super.key});
@@ -60,6 +62,7 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
     final isFilterActive = minReviewCount != 100;
 
     return Scaffold(
+      floatingActionButton: const SavedLocationsFab(),
       body: SafeArea(
         child: Column(
           children: [
@@ -359,14 +362,19 @@ class _FilterPanelState extends ConsumerState<_FilterPanel> {
   }
 }
 
-class PlaceCard extends StatelessWidget {
+class PlaceCard extends ConsumerWidget {
   final Place place;
 
   const PlaceCard({super.key, required this.place});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
+    final savedLocations = ref.watch(savedLocationsProvider);
+    final isSaved = savedLocations.valueOrNull
+            ?.any((e) => e.placeId == place.id) ??
+        false;
+
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8),
       child: InkWell(
@@ -408,12 +416,12 @@ class PlaceCard extends StatelessWidget {
                             vertical: 4,
                           ),
                           decoration: BoxDecoration(
-                            color: place.category.color.withValues(alpha: 0.2),
+                            color: place.category.color
+                                .withValues(alpha: 0.2),
                             borderRadius: BorderRadius.circular(12),
                             border: Border.all(
-                              color: place.category.color.withValues(
-                                alpha: 0.5,
-                              ),
+                              color: place.category.color
+                                  .withValues(alpha: 0.5),
                               width: 1,
                             ),
                           ),
@@ -452,8 +460,49 @@ class PlaceCard extends StatelessWidget {
                   ],
                 ),
               ),
+              _BookmarkButton(
+                isSaved: isSaved,
+                onTap: () {
+                  ref
+                      .read(savedLocationsProvider.notifier)
+                      .togglePlace(place);
+                },
+              ),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BookmarkButton extends StatelessWidget {
+  final bool isSaved;
+  final VoidCallback onTap;
+
+  const _BookmarkButton({
+    required this.isSaved,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        transitionBuilder: (child, animation) {
+          return ScaleTransition(scale: animation, child: child);
+        },
+        child: Icon(
+          isSaved ? Icons.bookmark : Icons.bookmark_border,
+          key: ValueKey(isSaved),
+          color: isSaved
+              ? AppColors.primary
+              : Theme.of(context)
+                  .colorScheme
+                  .onSurfaceVariant,
+          size: 28,
         ),
       ),
     );

--- a/frontend/lib/features/saved_locations/data/hive_saved_locations_repository.dart
+++ b/frontend/lib/features/saved_locations/data/hive_saved_locations_repository.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+import 'package:hive/hive.dart';
+import 'package:logging/logging.dart';
+
+/// Hive-based local implementation of [SavedLocationsRepository].
+///
+/// Stores each [SavedLocationEntry] as a JSON string keyed by placeId.
+class HiveSavedLocationsRepository implements SavedLocationsRepository {
+  static const String _boxName = 'saved_locations';
+  static final _log = Logger('HiveSavedLocationsRepository');
+
+  Future<Box<dynamic>> _getBox() => Hive.openBox<dynamic>(_boxName);
+
+  @override
+  Future<List<SavedLocationEntry>> getAll() async {
+    try {
+      final box = await _getBox();
+      return box.values
+          .map(
+            (v) => SavedLocationEntry.fromJson(
+              jsonDecode(v as String) as Map<String, dynamic>,
+            ),
+          )
+          .toList()
+        ..sort((a, b) => b.savedAt.compareTo(a.savedAt));
+    } catch (e, stack) {
+      _log.warning('Failed to load saved locations', e, stack);
+      return [];
+    }
+  }
+
+  @override
+  Future<void> save(SavedLocationEntry entry) async {
+    final box = await _getBox();
+    await box.put(entry.placeId, jsonEncode(entry.toJson()));
+  }
+
+  @override
+  Future<void> delete(String placeId) async {
+    final box = await _getBox();
+    await box.delete(placeId);
+  }
+
+  @override
+  Future<bool> isSaved(String placeId) async {
+    final box = await _getBox();
+    return box.containsKey(placeId);
+  }
+}

--- a/frontend/lib/features/saved_locations/domain/models/saved_location_entry.dart
+++ b/frontend/lib/features/saved_locations/domain/models/saved_location_entry.dart
@@ -1,0 +1,127 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/domain/models/place_photo.dart';
+import 'package:equatable/equatable.dart';
+
+/// A location saved by the user for later narration.
+///
+/// Stores the full [Place] data so it can be passed directly
+/// to the narration config screen.
+class SavedLocationEntry extends Equatable {
+  final String placeId;
+  final String name;
+  final String formattedAddress;
+  final double latitude;
+  final double longitude;
+  final double? rating;
+  final int? userRatingCount;
+  final List<String> types;
+  final List<Map<String, dynamic>> photosJson;
+  final String categoryKey;
+  final DateTime savedAt;
+
+  const SavedLocationEntry({
+    required this.placeId,
+    required this.name,
+    required this.formattedAddress,
+    required this.latitude,
+    required this.longitude,
+    this.rating,
+    this.userRatingCount,
+    required this.types,
+    required this.photosJson,
+    required this.categoryKey,
+    required this.savedAt,
+  });
+
+  /// Creates from a [Place] domain model.
+  factory SavedLocationEntry.fromPlace(Place place) {
+    return SavedLocationEntry(
+      placeId: place.id,
+      name: place.name,
+      formattedAddress: place.formattedAddress,
+      latitude: place.location.latitude,
+      longitude: place.location.longitude,
+      rating: place.rating,
+      userRatingCount: place.userRatingCount,
+      types: place.types,
+      photosJson: place.photos
+          .map((p) => {
+                'url': p.url,
+                'width_px': p.widthPx,
+                'height_px': p.heightPx,
+                'author_attributions': p.authorAttributions,
+              })
+          .toList(),
+      categoryKey: place.category.name,
+      savedAt: DateTime.now(),
+    );
+  }
+
+  /// Reconstructs the [Place] domain model.
+  Place toPlace() {
+    final photos = photosJson
+        .map((p) => PlacePhoto(
+              url: p['url'] as String,
+              widthPx: p['width_px'] as int,
+              heightPx: p['height_px'] as int,
+              authorAttributions:
+                  (p['author_attributions'] as List<dynamic>).cast<String>(),
+            ))
+        .toList();
+
+    return Place(
+      id: placeId,
+      name: name,
+      formattedAddress: formattedAddress,
+      location: PlaceLocation(
+        latitude: latitude,
+        longitude: longitude,
+      ),
+      rating: rating,
+      userRatingCount: userRatingCount,
+      types: types,
+      photos: photos,
+      category: PlaceCategory.values.firstWhere(
+        (c) => c.name == categoryKey,
+        orElse: () => PlaceCategory.modernUrban,
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'place_id': placeId,
+        'name': name,
+        'formatted_address': formattedAddress,
+        'latitude': latitude,
+        'longitude': longitude,
+        'rating': rating,
+        'user_rating_count': userRatingCount,
+        'types': types,
+        'photos': photosJson,
+        'category_key': categoryKey,
+        'saved_at': savedAt.toIso8601String(),
+      };
+
+  factory SavedLocationEntry.fromJson(Map<String, dynamic> json) {
+    return SavedLocationEntry(
+      placeId: json['place_id'] as String,
+      name: json['name'] as String,
+      formattedAddress: json['formatted_address'] as String,
+      latitude: (json['latitude'] as num).toDouble(),
+      longitude: (json['longitude'] as num).toDouble(),
+      rating: (json['rating'] as num?)?.toDouble(),
+      userRatingCount: json['user_rating_count'] as int?,
+      types: (json['types'] as List<dynamic>).cast<String>(),
+      photosJson: (json['photos'] as List<dynamic>)
+          .map((p) => Map<String, dynamic>.from(p as Map))
+          .toList(),
+      categoryKey: json['category_key'] as String,
+      savedAt: DateTime.parse(json['saved_at'] as String),
+    );
+  }
+
+  @override
+  List<Object?> get props => [placeId];
+}

--- a/frontend/lib/features/saved_locations/domain/repositories/saved_locations_repository.dart
+++ b/frontend/lib/features/saved_locations/domain/repositories/saved_locations_repository.dart
@@ -1,0 +1,17 @@
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+
+/// Abstract repository for managing saved locations.
+abstract class SavedLocationsRepository {
+  /// Returns all saved locations, newest first.
+  Future<List<SavedLocationEntry>> getAll();
+
+  /// Saves a location. If a location with the same placeId
+  /// already exists, it is overwritten.
+  Future<void> save(SavedLocationEntry entry);
+
+  /// Deletes a saved location by its place ID.
+  Future<void> delete(String placeId);
+
+  /// Returns whether a location is already saved.
+  Future<bool> isSaved(String placeId);
+}

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
@@ -1,0 +1,252 @@
+import 'package:context_app/common/config/app_colors.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/providers.dart';
+import 'package:context_app/shared/extensions/place_category_extension.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+/// Content of the saved locations dialog, displayed inside
+/// the expanding animation from [SavedLocationsFab].
+class SavedLocationsDialog extends ConsumerWidget {
+  const SavedLocationsDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final savedLocations = ref.watch(savedLocationsProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      children: [
+        _DialogHeader(colorScheme: colorScheme),
+        const Divider(height: 1),
+        Expanded(
+          child: savedLocations.when(
+            data: (entries) => entries.isEmpty
+                ? _EmptyState(colorScheme: colorScheme)
+                : _SavedLocationsList(entries: entries),
+            loading: () =>
+                const Center(child: CircularProgressIndicator()),
+            error: (_, __) => Center(
+              child: Text(
+                'common.error_prefix'.tr(),
+                style: TextStyle(color: colorScheme.error),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DialogHeader extends StatelessWidget {
+  final ColorScheme colorScheme;
+
+  const _DialogHeader({required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 8, 12),
+      child: Row(
+        children: [
+          Icon(
+            Icons.bookmark,
+            color: AppColors.primary,
+            size: 24,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'saved_locations.title'.tr(),
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface,
+              ),
+            ),
+          ),
+          IconButton(
+            onPressed: () => Navigator.of(context).pop(),
+            icon: Icon(
+              Icons.close,
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  final ColorScheme colorScheme;
+
+  const _EmptyState({required this.colorScheme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.bookmark_border,
+              size: 64,
+              color: colorScheme.onSurfaceVariant.withValues(
+                alpha: 0.4,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'saved_locations.empty'.tr(),
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'saved_locations.empty_hint'.tr(),
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 13,
+                color: colorScheme.onSurfaceVariant.withValues(
+                  alpha: 0.7,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SavedLocationsList extends ConsumerWidget {
+  final List<SavedLocationEntry> entries;
+
+  const _SavedLocationsList({required this.entries});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: entries.length,
+      separatorBuilder: (_, __) => const Divider(
+        height: 1,
+        indent: 16,
+        endIndent: 16,
+      ),
+      itemBuilder: (context, index) {
+        return _SavedLocationTile(entry: entries[index]);
+      },
+    );
+  }
+}
+
+class _SavedLocationTile extends ConsumerWidget {
+  final SavedLocationEntry entry;
+
+  const _SavedLocationTile({required this.entry});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final place = entry.toPlace();
+
+    return Dismissible(
+      key: ValueKey(entry.placeId),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        color: colorScheme.error,
+        child: Icon(
+          Icons.delete_outline,
+          color: colorScheme.onError,
+        ),
+      ),
+      confirmDismiss: (_) => _confirmDelete(context),
+      onDismissed: (_) {
+        ref
+            .read(savedLocationsProvider.notifier)
+            .removePlace(entry.placeId);
+      },
+      child: ListTile(
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+        leading: ClipRRect(
+          borderRadius: BorderRadius.circular(10),
+          child: Image.asset(
+            place.category.imageAssetPath,
+            width: 48,
+            height: 48,
+            fit: BoxFit.cover,
+          ),
+        ),
+        title: Text(
+          entry.name,
+          style: TextStyle(
+            fontWeight: FontWeight.w600,
+            color: colorScheme.onSurface,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        subtitle: Text(
+          entry.formattedAddress,
+          style: TextStyle(
+            fontSize: 12,
+            color: colorScheme.onSurfaceVariant,
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Icon(
+          Icons.chevron_right,
+          color: colorScheme.onSurfaceVariant,
+        ),
+        onTap: () {
+          final router = GoRouter.of(context);
+          Navigator.of(context).pop();
+          router.pushNamed('config', extra: place);
+        },
+      ),
+    );
+  }
+
+  Future<bool?> _confirmDelete(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) {
+        final colorScheme = Theme.of(context).colorScheme;
+        return AlertDialog(
+          title: Text('saved_locations.delete_title'.tr()),
+          content: Text('saved_locations.delete_message'.tr()),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(
+                'saved_locations.cancel'.tr(),
+                style: TextStyle(color: colorScheme.onSurfaceVariant),
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(
+                'saved_locations.delete_confirm'.tr(),
+                style: TextStyle(color: colorScheme.error),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
@@ -52,7 +52,7 @@ class _DialogHeader extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(20, 16, 8, 12),
       child: Row(
         children: [
-          Icon(
+          const Icon(
             Icons.bookmark,
             color: AppColors.primary,
             size: 24,

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_fab.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_fab.dart
@@ -1,0 +1,114 @@
+import 'package:context_app/common/config/app_colors.dart';
+import 'package:context_app/features/saved_locations/presentation/widgets/saved_locations_dialog.dart';
+import 'package:context_app/features/saved_locations/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Floating action button that opens the saved locations dialog
+/// with a hero-style expand animation from the FAB position.
+class SavedLocationsFab extends ConsumerWidget {
+  const SavedLocationsFab({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final savedLocations = ref.watch(savedLocationsProvider);
+    final count = savedLocations.valueOrNull?.length ?? 0;
+
+    return FloatingActionButton(
+      heroTag: 'saved_locations_fab',
+      onPressed: () {
+        final box = context.findRenderObject() as RenderBox?;
+        final fabRect = _computeFabRect(context, box);
+        Navigator.of(context).push(
+          _SavedLocationsRoute(fabRect: fabRect),
+        );
+      },
+      backgroundColor: AppColors.primary,
+      child: Badge(
+        isLabelVisible: count > 0,
+        label: Text('$count', style: const TextStyle(fontSize: 10)),
+        child: const Icon(Icons.bookmark, color: Colors.white),
+      ),
+    );
+  }
+
+  Rect _computeFabRect(BuildContext context, RenderBox? box) {
+    if (box != null && box.hasSize) {
+      final offset = box.localToGlobal(Offset.zero);
+      return offset & box.size;
+    }
+    final size = MediaQuery.of(context).size;
+    return Rect.fromLTWH(size.width - 76, size.height - 160, 56, 56);
+  }
+}
+
+/// Custom page route: expands a rounded rect from [fabRect] to
+/// a centered dialog, with content fading in.
+class _SavedLocationsRoute extends PageRouteBuilder<void> {
+  _SavedLocationsRoute({required Rect fabRect})
+      : super(
+          opaque: false,
+          barrierDismissible: true,
+          barrierColor: Colors.black54,
+          transitionDuration: const Duration(milliseconds: 350),
+          reverseTransitionDuration: const Duration(milliseconds: 250),
+          pageBuilder: (_, __, ___) => const SavedLocationsDialog(),
+          transitionsBuilder: (context, animation, _, child) {
+            final size = MediaQuery.of(context).size;
+            final dialogRect = Rect.fromLTRB(
+              20,
+              size.height * 0.15,
+              size.width - 20,
+              size.height * 0.85,
+            );
+
+            final curved = CurvedAnimation(
+              parent: animation,
+              curve: Curves.easeOutCubic,
+              reverseCurve: Curves.easeInCubic,
+            );
+
+            final rectTween = RectTween(
+              begin: fabRect,
+              end: dialogRect,
+            );
+
+            final radiusTween = Tween<double>(begin: 28, end: 20);
+            final fadeTween = Tween<double>(begin: 0, end: 1);
+            final fadeCurved = CurvedAnimation(
+              parent: animation,
+              curve: const Interval(0.2, 0.6),
+            );
+
+            return ListenableBuilder(
+              listenable: animation,
+              builder: (context, _) {
+                final rect = rectTween.evaluate(curved);
+                if (rect == null) return const SizedBox.shrink();
+                final radius = radiusTween.evaluate(curved);
+
+                return Stack(
+                  children: [
+                    Positioned(
+                      left: rect.left,
+                      top: rect.top,
+                      width: rect.width,
+                      height: rect.height,
+                      child: Material(
+                        color: Theme.of(context).colorScheme.surface,
+                        elevation: 8,
+                        borderRadius: BorderRadius.circular(radius),
+                        clipBehavior: Clip.antiAlias,
+                        child: Opacity(
+                          opacity: fadeTween.evaluate(fadeCurved),
+                          child: child,
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        );
+}

--- a/frontend/lib/features/saved_locations/providers.dart
+++ b/frontend/lib/features/saved_locations/providers.dart
@@ -1,0 +1,67 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/saved_locations/data/hive_saved_locations_repository.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Singleton repository provider.
+final savedLocationsRepositoryProvider =
+    Provider<SavedLocationsRepository>((ref) {
+  return HiveSavedLocationsRepository();
+});
+
+/// Notifier that manages the saved locations list.
+final savedLocationsProvider = AsyncNotifierProvider<
+    SavedLocationsNotifier, List<SavedLocationEntry>>(() {
+  return SavedLocationsNotifier();
+});
+
+class SavedLocationsNotifier
+    extends AsyncNotifier<List<SavedLocationEntry>> {
+  @override
+  Future<List<SavedLocationEntry>> build() async {
+    final repo = ref.read(savedLocationsRepositoryProvider);
+    return repo.getAll();
+  }
+
+  /// Saves a place. Does nothing if already saved.
+  Future<void> savePlace(Place place) async {
+    final repo = ref.read(savedLocationsRepositoryProvider);
+    final alreadySaved = await repo.isSaved(place.id);
+    if (alreadySaved) return;
+
+    final entry = SavedLocationEntry.fromPlace(place);
+    await repo.save(entry);
+    state = AsyncValue.data(
+      [entry, ...state.valueOrNull ?? []],
+    );
+  }
+
+  /// Removes a saved location by place ID.
+  Future<void> removePlace(String placeId) async {
+    final repo = ref.read(savedLocationsRepositoryProvider);
+    await repo.delete(placeId);
+    state = AsyncValue.data(
+      (state.valueOrNull ?? [])
+          .where((e) => e.placeId != placeId)
+          .toList(),
+    );
+  }
+
+  /// Toggles save state for a place.
+  Future<void> togglePlace(Place place) async {
+    final repo = ref.read(savedLocationsRepositoryProvider);
+    final alreadySaved = await repo.isSaved(place.id);
+    if (alreadySaved) {
+      await removePlace(place.id);
+    } else {
+      await savePlace(place);
+    }
+  }
+
+  /// Checks if a place is saved (synchronous, from current state).
+  bool isSaved(String placeId) {
+    final entries = state.valueOrNull ?? [];
+    return entries.any((e) => e.placeId == placeId);
+  }
+}

--- a/frontend/test/features/saved_locations/data/hive_saved_locations_repository_test.dart
+++ b/frontend/test/features/saved_locations/data/hive_saved_locations_repository_test.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/saved_locations/data/hive_saved_locations_repository.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+SavedLocationEntry _makeEntry({
+  String placeId = 'p1',
+  DateTime? savedAt,
+}) {
+  final place = Place(
+    id: placeId,
+    name: 'Place $placeId',
+    formattedAddress: 'Address $placeId',
+    location: const PlaceLocation(latitude: 25.0, longitude: 121.5),
+    types: const [],
+    photos: const [],
+    category: PlaceCategory.historicalCultural,
+  );
+
+  final entry = SavedLocationEntry.fromPlace(place);
+  if (savedAt != null) {
+    return SavedLocationEntry(
+      placeId: entry.placeId,
+      name: entry.name,
+      formattedAddress: entry.formattedAddress,
+      latitude: entry.latitude,
+      longitude: entry.longitude,
+      types: entry.types,
+      photosJson: entry.photosJson,
+      categoryKey: entry.categoryKey,
+      savedAt: savedAt,
+    );
+  }
+  return entry;
+}
+
+void main() {
+  late HiveSavedLocationsRepository repo;
+
+  setUp(() async {
+    final dir = Directory.systemTemp.createTempSync();
+    Hive.init(dir.path);
+    repo = HiveSavedLocationsRepository();
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+  });
+
+  test('getAll returns empty list when no entries saved', () async {
+    final result = await repo.getAll();
+    expect(result, isEmpty);
+  });
+
+  test('save then getAll returns the saved entry', () async {
+    final entry = _makeEntry(placeId: 'abc');
+    await repo.save(entry);
+
+    final result = await repo.getAll();
+    expect(result.length, 1);
+    expect(result.first.placeId, 'abc');
+    expect(result.first.name, 'Place abc');
+  });
+
+  test('getAll returns entries sorted newest first', () async {
+    final old = _makeEntry(
+      placeId: 'old',
+      savedAt: DateTime(2026, 1, 1),
+    );
+    final recent = _makeEntry(
+      placeId: 'recent',
+      savedAt: DateTime(2026, 3, 1),
+    );
+
+    await repo.save(old);
+    await repo.save(recent);
+
+    final result = await repo.getAll();
+    expect(result.first.placeId, 'recent');
+    expect(result.last.placeId, 'old');
+  });
+
+  test('delete removes the entry', () async {
+    final entry = _makeEntry(placeId: 'del');
+    await repo.save(entry);
+    await repo.delete('del');
+
+    final result = await repo.getAll();
+    expect(result, isEmpty);
+  });
+
+  test('delete non-existent id does nothing', () async {
+    await repo.save(_makeEntry(placeId: 'keep'));
+    await repo.delete('nope');
+
+    final result = await repo.getAll();
+    expect(result.length, 1);
+  });
+
+  test('isSaved returns true for saved entry', () async {
+    await repo.save(_makeEntry(placeId: 'check'));
+    expect(await repo.isSaved('check'), isTrue);
+  });
+
+  test('isSaved returns false for unsaved entry', () async {
+    expect(await repo.isSaved('missing'), isFalse);
+  });
+
+  test('save overwrites entry with same placeId', () async {
+    await repo.save(_makeEntry(placeId: 'dup'));
+    await repo.save(_makeEntry(placeId: 'dup'));
+
+    final result = await repo.getAll();
+    expect(result.length, 1);
+  });
+
+  test('save preserves all fields through JSON round-trip', () async {
+    final original = _makeEntry(placeId: 'rt');
+    await repo.save(original);
+
+    final result = await repo.getAll();
+    final restored = result.first;
+
+    expect(restored.placeId, original.placeId);
+    expect(restored.name, original.name);
+    expect(restored.formattedAddress, original.formattedAddress);
+    expect(restored.latitude, original.latitude);
+    expect(restored.longitude, original.longitude);
+    expect(restored.categoryKey, original.categoryKey);
+  });
+}

--- a/frontend/test/features/saved_locations/domain/models/saved_location_entry_test.dart
+++ b/frontend/test/features/saved_locations/domain/models/saved_location_entry_test.dart
@@ -16,7 +16,7 @@ Place _makePlace({
     location: const PlaceLocation(latitude: 25.0, longitude: 121.5),
     rating: 4.5,
     userRatingCount: 200,
-    types: ['tourist_attraction', 'point_of_interest'],
+    types: const ['tourist_attraction', 'point_of_interest'],
     photos: photos,
     category: PlaceCategory.historicalCultural,
   );

--- a/frontend/test/features/saved_locations/domain/models/saved_location_entry_test.dart
+++ b/frontend/test/features/saved_locations/domain/models/saved_location_entry_test.dart
@@ -1,0 +1,163 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/domain/models/place_photo.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Place _makePlace({
+  String id = 'place-1',
+  List<PlacePhoto> photos = const [],
+}) {
+  return Place(
+    id: id,
+    name: 'Test Place',
+    formattedAddress: 'Test Address',
+    location: const PlaceLocation(latitude: 25.0, longitude: 121.5),
+    rating: 4.5,
+    userRatingCount: 200,
+    types: ['tourist_attraction', 'point_of_interest'],
+    photos: photos,
+    category: PlaceCategory.historicalCultural,
+  );
+}
+
+void main() {
+  group('SavedLocationEntry.fromPlace', () {
+    test('creates entry with correct fields from Place', () {
+      final place = _makePlace();
+      final entry = SavedLocationEntry.fromPlace(place);
+
+      expect(entry.placeId, 'place-1');
+      expect(entry.name, 'Test Place');
+      expect(entry.formattedAddress, 'Test Address');
+      expect(entry.latitude, 25.0);
+      expect(entry.longitude, 121.5);
+      expect(entry.rating, 4.5);
+      expect(entry.userRatingCount, 200);
+      expect(entry.types, ['tourist_attraction', 'point_of_interest']);
+      expect(entry.categoryKey, 'historicalCultural');
+      expect(entry.savedAt, isNotNull);
+    });
+
+    test('preserves photo data', () {
+      const photo = PlacePhoto(
+        url: 'https://example.com/photo.jpg',
+        widthPx: 800,
+        heightPx: 600,
+        authorAttributions: ['Author'],
+      );
+      final place = _makePlace(photos: [photo]);
+      final entry = SavedLocationEntry.fromPlace(place);
+
+      expect(entry.photosJson.length, 1);
+      expect(entry.photosJson.first['url'], 'https://example.com/photo.jpg');
+      expect(entry.photosJson.first['width_px'], 800);
+      expect(entry.photosJson.first['height_px'], 600);
+    });
+  });
+
+  group('SavedLocationEntry.toPlace', () {
+    test('reconstructs Place from entry', () {
+      final place = _makePlace();
+      final entry = SavedLocationEntry.fromPlace(place);
+      final restored = entry.toPlace();
+
+      expect(restored.id, place.id);
+      expect(restored.name, place.name);
+      expect(restored.formattedAddress, place.formattedAddress);
+      expect(restored.location.latitude, place.location.latitude);
+      expect(restored.location.longitude, place.location.longitude);
+      expect(restored.rating, place.rating);
+      expect(restored.userRatingCount, place.userRatingCount);
+      expect(restored.types, place.types);
+      expect(restored.category, place.category);
+    });
+
+    test('reconstructs photos correctly', () {
+      const photo = PlacePhoto(
+        url: 'https://example.com/photo.jpg',
+        widthPx: 800,
+        heightPx: 600,
+        authorAttributions: ['Author'],
+      );
+      final place = _makePlace(photos: [photo]);
+      final entry = SavedLocationEntry.fromPlace(place);
+      final restored = entry.toPlace();
+
+      expect(restored.photos.length, 1);
+      expect(restored.photos.first.url, photo.url);
+      expect(restored.photos.first.widthPx, photo.widthPx);
+      expect(restored.photos.first.heightPx, photo.heightPx);
+      expect(restored.photos.first.authorAttributions, photo.authorAttributions);
+    });
+  });
+
+  group('JSON round-trip', () {
+    test('toJson/fromJson preserves all fields', () {
+      final place = _makePlace();
+      final original = SavedLocationEntry.fromPlace(place);
+      final restored = SavedLocationEntry.fromJson(original.toJson());
+
+      expect(restored.placeId, original.placeId);
+      expect(restored.name, original.name);
+      expect(restored.formattedAddress, original.formattedAddress);
+      expect(restored.latitude, original.latitude);
+      expect(restored.longitude, original.longitude);
+      expect(restored.rating, original.rating);
+      expect(restored.userRatingCount, original.userRatingCount);
+      expect(restored.types, original.types);
+      expect(restored.categoryKey, original.categoryKey);
+      expect(restored.savedAt, original.savedAt);
+    });
+
+    test('toJson/fromJson preserves photos through round-trip', () {
+      const photo = PlacePhoto(
+        url: 'https://example.com/photo.jpg',
+        widthPx: 800,
+        heightPx: 600,
+        authorAttributions: ['Author'],
+      );
+      final place = _makePlace(photos: [photo]);
+      final original = SavedLocationEntry.fromPlace(place);
+      final restored = SavedLocationEntry.fromJson(original.toJson());
+
+      expect(restored.photosJson.length, 1);
+      expect(restored.photosJson.first['url'], 'https://example.com/photo.jpg');
+    });
+
+    test('handles null rating', () {
+      const place = Place(
+        id: 'no-rating',
+        name: 'No Rating Place',
+        formattedAddress: 'Addr',
+        location: PlaceLocation(latitude: 0, longitude: 0),
+        types: [],
+        photos: [],
+        category: PlaceCategory.modernUrban,
+      );
+      final original = SavedLocationEntry.fromPlace(place);
+      final restored = SavedLocationEntry.fromJson(original.toJson());
+
+      expect(restored.rating, isNull);
+      expect(restored.userRatingCount, isNull);
+    });
+  });
+
+  group('Equatable', () {
+    test('two entries with same placeId are equal', () {
+      final place = _makePlace(id: 'same-id');
+      final entry1 = SavedLocationEntry.fromPlace(place);
+      final entry2 = SavedLocationEntry.fromPlace(place);
+
+      expect(entry1, equals(entry2));
+    });
+
+    test('two entries with different placeId are not equal', () {
+      final entry1 = SavedLocationEntry.fromPlace(_makePlace(id: 'id-1'));
+      final entry2 = SavedLocationEntry.fromPlace(_makePlace(id: 'id-2'));
+
+      expect(entry1, isNot(equals(entry2)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements a complete saved locations feature allowing users to bookmark places for later narration. Includes a floating action button with expanding dialog animation, local persistence via Hive, and full state management with Riverpod.

## Key Changes

**Domain Layer**
- Added `SavedLocationEntry` model with JSON serialization to store place data locally
- Created `SavedLocationsRepository` abstract interface for data persistence

**Data Layer**
- Implemented `HiveSavedLocationsRepository` using Hive for local storage
- Stores entries as JSON strings keyed by placeId, sorted newest-first on retrieval

**Presentation Layer**
- `SavedLocationsFab`: Floating action button with badge showing saved count
- `SavedLocationsDialog`: Full-screen dialog with header, empty state, and list of saved locations
- `SavedLocationsTile`: Individual location tile with swipe-to-delete and tap-to-navigate
- Added bookmark button to `PlaceCard` for toggling save state

**State Management**
- `SavedLocationsNotifier`: Async notifier managing the saved locations list
- Provides `savePlace()`, `removePlace()`, `togglePlace()`, and `isSaved()` methods
- Optimistically updates UI state on save/delete operations

**UI/UX Details**
- Custom page route with hero-style expand animation from FAB to centered dialog
- Smooth curved animations (350ms forward, 250ms reverse)
- Swipe-to-delete with confirmation dialog
- Empty state with helpful hint text
- Tap location tile to navigate to narration config screen
- Badge on FAB displays count of saved locations

**Localization**
- Added English and Traditional Chinese translations for all UI strings

## Testing
- Comprehensive unit tests for `SavedLocationEntry` model (JSON round-trip, Place conversion)
- Integration tests for `HiveSavedLocationsRepository` (CRUD operations, sorting, persistence)

https://claude.ai/code/session_01T9pP8V94D4KcrQ9F9s581N