### PR TITLE
Add journey card sharing feature with beautiful passport-style cards

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -247,5 +247,11 @@
     "delete_message": "Are you sure you want to remove this saved location?",
     "delete_confirm": "Remove",
     "cancel": "Cancel"
+  },
+  "share_card": {
+    "share": "Share",
+    "visited": "Visited",
+    "explore_more": "Explore More",
+    "share_text": "I explored this place with Contexture"
   }
 }

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -247,5 +247,11 @@
     "delete_message": "確定要移除此儲存的地點嗎？",
     "delete_confirm": "移除",
     "cancel": "取消"
+  },
+  "share_card": {
+    "share": "分享",
+    "visited": "已探訪",
+    "explore_more": "探索更多",
+    "share_text": "我用讀景探索了這個地方"
   }
 }

--- a/frontend/lib/features/journey/domain/services/journey_sharing_service.dart
+++ b/frontend/lib/features/journey/domain/services/journey_sharing_service.dart
@@ -54,11 +54,9 @@ class JourneySharingService {
       final shareText =
           '${'share_card.share_text'.tr()} — $placeName';
 
-      await SharePlus.instance.share(
-        ShareParams(
-          files: [XFile(file.path, mimeType: 'image/png')],
-          text: shareText,
-        ),
+      await Share.shareXFiles(
+        [XFile(file.path, mimeType: 'image/png')],
+        text: shareText,
       );
     } catch (e, stack) {
       _log.severe('Error sharing journey card', e, stack);
@@ -82,7 +80,7 @@ class JourneySharingService {
       child: MediaQuery(
         data: MediaQuery.of(context),
         child: Directionality(
-          textDirection: TextDirection.ltr,
+          textDirection: ui.TextDirection.ltr,
           child: Localizations.override(
             context: context,
             child: Material(

--- a/frontend/lib/features/journey/domain/services/journey_sharing_service.dart
+++ b/frontend/lib/features/journey/domain/services/journey_sharing_service.dart
@@ -1,0 +1,132 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:context_app/features/journey/presentation/widgets/journey_sharing_card.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:logging/logging.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'dart:io';
+
+final _log = Logger('JourneySharingService');
+
+/// Captures a [JourneySharingCard] as a PNG image and shares it
+/// via the platform share sheet.
+class JourneySharingService {
+  JourneySharingService._();
+
+  /// Shares a journey entry as a beautifully designed card image.
+  ///
+  /// Renders the [JourneySharingCard] off-screen, captures it to a
+  /// PNG, writes it to a temp file, and opens the system share sheet.
+  static Future<void> shareJourneyCard({
+    required BuildContext context,
+    required String placeName,
+    required String placeAddress,
+    required String narrationExcerpt,
+    required DateTime visitedAt,
+    String? imageUrl,
+    Uint8List? imageBytes,
+  }) async {
+    try {
+      final pngBytes = await _captureCardImage(
+        context: context,
+        placeName: placeName,
+        placeAddress: placeAddress,
+        narrationExcerpt: narrationExcerpt,
+        visitedAt: visitedAt,
+        imageUrl: imageUrl,
+        imageBytes: imageBytes,
+      );
+
+      if (pngBytes == null) {
+        _log.warning('Failed to capture card image');
+        return;
+      }
+
+      final tempDir = await getTemporaryDirectory();
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final file = File('${tempDir.path}/journey_card_$timestamp.png');
+      await file.writeAsBytes(pngBytes);
+
+      final shareText =
+          '${'share_card.share_text'.tr()} — $placeName';
+
+      await SharePlus.instance.share(
+        ShareParams(
+          files: [XFile(file.path, mimeType: 'image/png')],
+          text: shareText,
+        ),
+      );
+    } catch (e, stack) {
+      _log.severe('Error sharing journey card', e, stack);
+    }
+  }
+
+  /// Renders the card widget off-screen and captures it as PNG bytes.
+  static Future<Uint8List?> _captureCardImage({
+    required BuildContext context,
+    required String placeName,
+    required String placeAddress,
+    required String narrationExcerpt,
+    required DateTime visitedAt,
+    String? imageUrl,
+    Uint8List? imageBytes,
+  }) async {
+    final key = GlobalKey();
+
+    final widget = RepaintBoundary(
+      key: key,
+      child: MediaQuery(
+        data: MediaQuery.of(context),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Localizations.override(
+            context: context,
+            child: Material(
+              color: Colors.transparent,
+              child: JourneySharingCard(
+                placeName: placeName,
+                placeAddress: placeAddress,
+                narrationExcerpt: narrationExcerpt,
+                visitedAt: visitedAt,
+                imageUrl: imageUrl,
+                imageBytes: imageBytes,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Build the widget in an overlay so it renders off-screen.
+    final overlay = OverlayEntry(
+      builder: (_) => Positioned(
+        left: -1000,
+        top: -1000,
+        child: widget,
+      ),
+    );
+
+    final overlayState = Overlay.of(context);
+    overlayState.insert(overlay);
+
+    // Wait for the widget tree and any image loading to settle.
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+
+    try {
+      final boundary =
+          key.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+      if (boundary == null) return null;
+
+      final image = await boundary.toImage(pixelRatio: 3.0);
+      final byteData =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      return byteData?.buffer.asUint8List();
+    } finally {
+      overlay.remove();
+    }
+  }
+}

--- a/frontend/lib/features/journey/presentation/widgets/journey_sharing_card.dart
+++ b/frontend/lib/features/journey/presentation/widgets/journey_sharing_card.dart
@@ -1,0 +1,423 @@
+import 'dart:typed_data';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:context_app/common/config/app_colors.dart';
+import 'package:context_app/core/services/place_image_cache_manager.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+/// A beautiful sharing card that renders a Journey entry as a
+/// passport-style card suitable for social media sharing.
+///
+/// This widget is rendered off-screen via [RepaintBoundary] and
+/// captured as an image by [JourneySharingService].
+class JourneySharingCard extends StatelessWidget {
+  final String placeName;
+  final String placeAddress;
+  final String narrationExcerpt;
+  final DateTime visitedAt;
+  final String? imageUrl;
+  final Uint8List? imageBytes;
+
+  const JourneySharingCard({
+    super.key,
+    required this.placeName,
+    required this.placeAddress,
+    required this.narrationExcerpt,
+    required this.visitedAt,
+    this.imageUrl,
+    this.imageBytes,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 380,
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF0F1923), Color(0xFF1A2B3D)],
+        ),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x40000000),
+            blurRadius: 24,
+            offset: Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _CardHeader(
+            imageUrl: imageUrl,
+            imageBytes: imageBytes,
+            placeName: placeName,
+          ),
+          _CardBody(
+            placeName: placeName,
+            placeAddress: placeAddress,
+            narrationExcerpt: narrationExcerpt,
+            visitedAt: visitedAt,
+          ),
+          const _CardFooter(),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardHeader extends StatelessWidget {
+  final String? imageUrl;
+  final Uint8List? imageBytes;
+  final String placeName;
+
+  const _CardHeader({
+    required this.imageUrl,
+    required this.imageBytes,
+    required this.placeName,
+  });
+
+  bool get _hasImage =>
+      (imageUrl != null && imageUrl!.isNotEmpty) || imageBytes != null;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_hasImage) {
+      return _PlaceholderHeader(placeName: placeName);
+    }
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      child: SizedBox(
+        height: 200,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            _buildImage(),
+            // Gradient overlay for text readability
+            Container(
+              decoration: const BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [Colors.transparent, Color(0xCC0F1923)],
+                  stops: [0.4, 1.0],
+                ),
+              ),
+            ),
+            // Stamp badge
+            const Positioned(
+              top: 16,
+              right: 16,
+              child: _StampBadge(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildImage() {
+    if (imageBytes != null) {
+      return Image.memory(imageBytes!, fit: BoxFit.cover);
+    }
+    return CachedNetworkImage(
+      imageUrl: imageUrl!,
+      fit: BoxFit.cover,
+      cacheManager: PlaceImageCacheManager.instance,
+      placeholder: (_, __) => Container(color: const Color(0xFF1A2B3D)),
+      errorWidget: (_, __, ___) => Container(
+        color: const Color(0xFF1A2B3D),
+        child: const Center(
+          child: Icon(Icons.image_not_supported, color: Colors.white38),
+        ),
+      ),
+    );
+  }
+}
+
+class _PlaceholderHeader extends StatelessWidget {
+  final String placeName;
+
+  const _PlaceholderHeader({required this.placeName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 120,
+      decoration: const BoxDecoration(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [Color(0xFF137fec), Color(0xFF0D5BB5)],
+        ),
+      ),
+      child: Stack(
+        children: [
+          // Decorative pattern
+          Positioned(
+            right: -20,
+            top: -20,
+            child: Icon(
+              Icons.explore,
+              size: 120,
+              color: Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          const Positioned(top: 16, right: 16, child: _StampBadge()),
+          Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                Icon(
+                  Icons.location_on,
+                  color: Colors.white.withValues(alpha: 0.9),
+                  size: 28,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StampBadge extends StatelessWidget {
+  const _StampBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withValues(alpha: 0.9),
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x40137fec),
+            blurRadius: 8,
+            offset: Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.verified, color: Colors.white, size: 14),
+          const SizedBox(width: 4),
+          Text(
+            'share_card.visited'.tr(),
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardBody extends StatelessWidget {
+  final String placeName;
+  final String placeAddress;
+  final String narrationExcerpt;
+  final DateTime visitedAt;
+
+  const _CardBody({
+    required this.placeName,
+    required this.placeAddress,
+    required this.narrationExcerpt,
+    required this.visitedAt,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final dateLabel = DateFormat('yyyy.MM.dd').format(visitedAt);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(24, 20, 24, 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Date chip
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              dateLabel,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 11,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.8,
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 12),
+
+          // Place name
+          Text(
+            placeName,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+              height: 1.2,
+              letterSpacing: -0.3,
+            ),
+          ),
+
+          if (placeAddress.isNotEmpty) ...[
+            const SizedBox(height: 6),
+            Row(
+              children: [
+                Icon(
+                  Icons.location_on_outlined,
+                  size: 14,
+                  color: Colors.white.withValues(alpha: 0.5),
+                ),
+                const SizedBox(width: 4),
+                Expanded(
+                  child: Text(
+                    placeAddress,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.5),
+                      fontSize: 12,
+                      height: 1.3,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+
+          const SizedBox(height: 16),
+
+          // Divider
+          Container(
+            height: 1,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  Colors.white.withValues(alpha: 0.1),
+                  Colors.white.withValues(alpha: 0.05),
+                  Colors.transparent,
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Narration excerpt
+          Text(
+            narrationExcerpt,
+            maxLines: 5,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.75),
+              fontSize: 14,
+              height: 1.7,
+              letterSpacing: 0.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardFooter extends StatelessWidget {
+  const _CardFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(24, 12, 24, 20),
+      decoration: BoxDecoration(
+        border: Border(
+          top: BorderSide(
+            color: Colors.white.withValues(alpha: 0.06),
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          // App icon
+          Container(
+            width: 28,
+            height: 28,
+            decoration: BoxDecoration(
+              color: AppColors.primary,
+              borderRadius: BorderRadius.circular(7),
+            ),
+            child: const Center(
+              child: Icon(Icons.explore, color: Colors.white, size: 16),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'app.name'.tr(),
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              Text(
+                'app.tagline'.tr(),
+                style: TextStyle(
+                  color: Colors.white.withValues(alpha: 0.4),
+                  fontSize: 10,
+                ),
+              ),
+            ],
+          ),
+          const Spacer(),
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 10,
+              vertical: 4,
+            ),
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.15),
+              ),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Text(
+              'share_card.explore_more'.tr(),
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.5),
+                fontSize: 10,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
@@ -2,6 +2,7 @@ import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/explore/domain/models/place_category.dart';
 import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/journey/domain/services/journey_sharing_service.dart';
 import 'package:context_app/features/journey/providers.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
 import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
@@ -29,6 +30,27 @@ class QuickGuideTimelineEntry extends ConsumerStatefulWidget {
 class _QuickGuideTimelineEntryState
     extends ConsumerState<QuickGuideTimelineEntry> {
   bool _isDeleting = false;
+  bool _isSharing = false;
+
+  Future<void> _shareAsCard() async {
+    if (_isSharing || _isDeleting) return;
+    setState(() => _isSharing = true);
+
+    try {
+      await JourneySharingService.shareJourneyCard(
+        context: context,
+        placeName: 'quick_guide.title'.tr(),
+        placeAddress: '',
+        narrationExcerpt: widget.entry.aiDescription,
+        visitedAt: widget.entry.createdAt,
+        imageBytes: widget.entry.imageBytes,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSharing = false);
+      }
+    }
+  }
 
   void _navigateToPlayer() {
     if (_isDeleting) return;
@@ -266,6 +288,22 @@ class _QuickGuideTimelineEntryState
                         child: Row(
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
+                            if (_isSharing)
+                              const SizedBox(
+                                width: 18,
+                                height: 18,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: AppColors.primary,
+                                ),
+                              )
+                            else
+                              _ActionButton(
+                                icon: Icons.share_outlined,
+                                label: 'share_card.share'.tr(),
+                                onTap: _shareAsCard,
+                              ),
+                            const SizedBox(width: 16),
                             if (_isDeleting)
                               const SizedBox(
                                 width: 18,
@@ -276,7 +314,11 @@ class _QuickGuideTimelineEntryState
                                 ),
                               )
                             else
-                              _DeleteButton(onTap: _showDeleteConfirmDialog),
+                              _ActionButton(
+                                icon: Icons.delete_outline,
+                                label: 'passport.delete_confirm'.tr(),
+                                onTap: _showDeleteConfirmDialog,
+                              ),
                           ],
                         ),
                       ),
@@ -292,9 +334,16 @@ class _QuickGuideTimelineEntryState
   }
 }
 
-class _DeleteButton extends StatelessWidget {
+class _ActionButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
   final VoidCallback onTap;
-  const _DeleteButton({required this.onTap});
+
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -304,10 +353,10 @@ class _DeleteButton extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.delete_outline, size: 16, color: color),
+          Icon(icon, size: 16, color: color),
           const SizedBox(width: 6),
           Text(
-            'passport.delete_confirm'.tr(),
+            label,
             style: TextStyle(
               color: color,
               fontSize: 12,

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -1,4 +1,5 @@
 import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/journey/domain/services/journey_sharing_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -23,6 +24,27 @@ class TimelineEntry extends ConsumerStatefulWidget {
 
 class _TimelineEntryState extends ConsumerState<TimelineEntry> {
   bool _isDeleting = false;
+  bool _isSharing = false;
+
+  Future<void> _shareAsCard() async {
+    if (_isSharing || _isDeleting) return;
+    setState(() => _isSharing = true);
+
+    try {
+      await JourneySharingService.shareJourneyCard(
+        context: context,
+        placeName: widget.entry.place.name,
+        placeAddress: widget.entry.place.address,
+        narrationExcerpt: widget.entry.narrationContent.text,
+        visitedAt: widget.entry.createdAt,
+        imageUrl: widget.entry.place.imageUrl,
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isSharing = false);
+      }
+    }
+  }
 
   Future<void> _showDeleteConfirmDialog() async {
     if (_isDeleting) return; // Prevent multiple clicks
@@ -296,6 +318,22 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.end,
                             children: [
+                              if (_isSharing)
+                                const SizedBox(
+                                  width: 18,
+                                  height: 18,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    color: AppColors.primary,
+                                  ),
+                                )
+                              else
+                                _ActionButton(
+                                  icon: Icons.share_outlined,
+                                  label: 'share_card.share'.tr(),
+                                  onTap: _shareAsCard,
+                                ),
+                              const SizedBox(width: 16),
                               if (_isDeleting)
                                 const SizedBox(
                                   width: 18,

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -88,6 +88,9 @@ dependencies:
   # Receive shared content from other apps (e.g. Google Maps)
   receive_sharing_intent: ^1.8.1
 
+  # Share content to other apps (social media, messaging, etc.)
+  share_plus: ^10.1.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
Adds a complete journey sharing feature that allows users to share their visited places as beautifully designed passport-style cards via social media and messaging apps.

## Key Changes

- **New `JourneySharingCard` widget**: A passport-style card component that displays journey entries with:
  - Header with place image or gradient placeholder
  - Visited date badge and stamp verification badge
  - Place name, address, and narration excerpt
  - App branding footer with call-to-action
  - Responsive design optimized for social media sharing

- **New `JourneySharingService`**: Service that:
  - Renders the sharing card off-screen using `RepaintBoundary`
  - Captures the rendered card as a high-resolution PNG image (3x pixel ratio)
  - Writes the image to temporary storage
  - Opens the platform share sheet with the image and contextual text

- **Integration with timeline entries**: Added share button to both:
  - `TimelineEntry` widget (for regular journey entries)
  - `QuickGuideTimelineEntry` widget (for quick guide entries)
  - Share button shows loading state during capture and sharing

- **Refactored action buttons**: Generalized `_DeleteButton` to `_ActionButton` to support both delete and share actions with consistent styling

- **Localization support**: Added translation strings for:
  - Share button label
  - "Visited" badge text
  - "Explore More" call-to-action
  - Share text template
  - Supported languages: English and Traditional Chinese

- **Dependencies**: Added `share_plus` package for cross-platform sharing functionality

## Implementation Details

- Card rendering uses `RepaintBoundary` with proper context wrapping (MediaQuery, Directionality, Localizations) to ensure correct rendering
- 500ms delay allows image loading to complete before capture
- Supports both network images (via URL) and in-memory images (Uint8List)
- High pixel ratio (3.0) ensures crisp output on all devices
- Temporary files are created with timestamp to avoid conflicts

https://claude.ai/code/session_01DfbeEuwYy8XKtWYPmCrxCN