### PR TITLE
Add search and filter functionality to journey screen

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -59,7 +59,12 @@
     "today": "Today",
     "yesterday": "Yesterday",
     "replay": "Replay",
-    "login_required": "Sign in to view your journey history"
+    "login_required": "Sign in to view your journey history",
+    "search_hint": "Search places or content...",
+    "filter_all": "All",
+    "filter_narration": "Narration",
+    "filter_quick_guide": "Quick Guide",
+    "no_results": "No matching entries found"
   },
   "explore": {
     "title": "Explore",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -59,7 +59,12 @@
     "today": "今天",
     "yesterday": "昨天",
     "replay": "重播",
-    "login_required": "登入後即可查看您的旅程記錄"
+    "login_required": "登入後即可查看您的旅程記錄",
+    "search_hint": "搜尋地點或內容...",
+    "filter_all": "全部",
+    "filter_narration": "語音導覽",
+    "filter_quick_guide": "快速導覽",
+    "no_results": "找不到符合的紀錄"
   },
   "explore": {
     "title": "探索",

--- a/frontend/lib/features/journey/domain/models/journey_item.dart
+++ b/frontend/lib/features/journey/domain/models/journey_item.dart
@@ -6,6 +6,9 @@ import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry
 sealed class JourneyItem {
   String get id;
   DateTime get createdAt;
+
+  /// Text used for keyword search across all item types.
+  String get searchableText;
 }
 
 /// Wraps a [JourneyEntry] (narration-based) for display in the timeline.
@@ -19,6 +22,11 @@ class NarrationJourneyItem extends JourneyItem {
 
   @override
   DateTime get createdAt => entry.createdAt;
+
+  @override
+  String get searchableText =>
+      '${entry.place.name} ${entry.place.address} '
+      '${entry.narrationContent.text}';
 }
 
 /// Wraps a [QuickGuideEntry] (photo-based) for display in the timeline.
@@ -32,4 +40,7 @@ class QuickGuideJourneyItem extends JourneyItem {
 
   @override
   DateTime get createdAt => entry.createdAt;
+
+  @override
+  String get searchableText => entry.aiDescription;
 }

--- a/frontend/lib/features/journey/presentation/screens/journey_screen.dart
+++ b/frontend/lib/features/journey/presentation/screens/journey_screen.dart
@@ -7,44 +7,272 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class JourneyScreen extends ConsumerWidget {
+class JourneyScreen extends ConsumerStatefulWidget {
   const JourneyScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<JourneyScreen> createState() => _JourneyScreenState();
+}
+
+class _JourneyScreenState extends ConsumerState<JourneyScreen> {
+  final _searchController = TextEditingController();
+  bool _showSearch = false;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _toggleSearch() {
+    setState(() {
+      _showSearch = !_showSearch;
+      if (!_showSearch) {
+        _searchController.clear();
+        ref.read(journeySearchQueryProvider.notifier).state = '';
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
     return Scaffold(
       body: SafeArea(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // Title row with search toggle
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 10),
-              child: Text(
-                'passport.title'.tr(),
-                style: TextStyle(
-                  fontSize: 40,
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
+              padding: const EdgeInsets.fromLTRB(20, 20, 12, 0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'passport.title'.tr(),
+                      style: TextStyle(
+                        fontSize: 40,
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.onSurface,
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _toggleSearch,
+                    icon: Icon(
+                      _showSearch ? Icons.close : Icons.search,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
               ),
             ),
-            Expanded(child: _buildJourneyList(ref)),
+
+            // Search bar (animated)
+            AnimatedSize(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              child: _showSearch
+                  ? Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        20, 12, 20, 0,
+                      ),
+                      child: TextField(
+                        controller: _searchController,
+                        autofocus: true,
+                        onChanged: (value) {
+                          setState(() {});
+                          ref
+                              .read(
+                                journeySearchQueryProvider.notifier,
+                              )
+                              .state = value;
+                        },
+                        decoration: InputDecoration(
+                          hintText:
+                              'passport.search_hint'.tr(),
+                          prefixIcon: Icon(
+                            Icons.search,
+                            color: colorScheme.onSurfaceVariant,
+                            size: 20,
+                          ),
+                          suffixIcon: _searchController.text.isNotEmpty
+                              ? IconButton(
+                                  icon: const Icon(
+                                    Icons.clear,
+                                    size: 18,
+                                  ),
+                                  onPressed: () {
+                                    _searchController.clear();
+                                    setState(() {});
+                                    ref
+                                        .read(
+                                          journeySearchQueryProvider
+                                              .notifier,
+                                        )
+                                        .state = '';
+                                  },
+                                )
+                              : null,
+                          filled: true,
+                          fillColor:
+                              colorScheme.surfaceContainerHighest,
+                          contentPadding:
+                              const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 10,
+                          ),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide.none,
+                          ),
+                        ),
+                        style: TextStyle(
+                          color: colorScheme.onSurface,
+                          fontSize: 15,
+                        ),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+
+            // Filter chips
+            _FilterChips(),
+
+            // Journey list
+            Expanded(child: _JourneyList()),
           ],
         ),
       ),
     );
   }
+}
 
-  Widget _buildJourneyList(WidgetRef ref) {
-    final asyncItems = ref.watch(allJourneyItemsProvider);
+class _FilterChips extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentFilter = ref.watch(journeyFilterProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 10, 20, 4),
+      child: Row(
+        children: [
+          _buildChip(
+            context: context,
+            label: 'passport.filter_all'.tr(),
+            selected: currentFilter == JourneyFilter.all,
+            colorScheme: colorScheme,
+            onTap: () => ref
+                .read(journeyFilterProvider.notifier)
+                .state = JourneyFilter.all,
+          ),
+          const SizedBox(width: 8),
+          _buildChip(
+            context: context,
+            label: 'passport.filter_narration'.tr(),
+            selected: currentFilter == JourneyFilter.narration,
+            colorScheme: colorScheme,
+            onTap: () => ref
+                .read(journeyFilterProvider.notifier)
+                .state = JourneyFilter.narration,
+          ),
+          const SizedBox(width: 8),
+          _buildChip(
+            context: context,
+            label: 'passport.filter_quick_guide'.tr(),
+            selected: currentFilter == JourneyFilter.quickGuide,
+            colorScheme: colorScheme,
+            onTap: () => ref
+                .read(journeyFilterProvider.notifier)
+                .state = JourneyFilter.quickGuide,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChip({
+    required BuildContext context,
+    required String label,
+    required bool selected,
+    required ColorScheme colorScheme,
+    required VoidCallback onTap,
+  }) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: const EdgeInsets.symmetric(
+          horizontal: 14,
+          vertical: 7,
+        ),
+        decoration: BoxDecoration(
+          color: selected
+              ? AppColors.primary
+              : colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected
+                ? Colors.white
+                : colorScheme.onSurfaceVariant,
+            fontSize: 13,
+            fontWeight:
+                selected ? FontWeight.w600 : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _JourneyList extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncItems = ref.watch(filteredJourneyItemsProvider);
+    final query = ref.watch(journeySearchQueryProvider).trim();
+    final filter = ref.watch(journeyFilterProvider);
+    final hasActiveFilter =
+        query.isNotEmpty || filter != JourneyFilter.all;
 
     return asyncItems.when(
       data: (items) {
         if (items.isEmpty) {
           return Center(
-            child: Text(
-              'passport.no_entries'.tr(),
-              style: const TextStyle(color: Colors.white70),
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    hasActiveFilter
+                        ? Icons.search_off
+                        : Icons.explore_outlined,
+                    size: 48,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurfaceVariant
+                        .withValues(alpha: 0.5),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    hasActiveFilter
+                        ? 'passport.no_results'.tr()
+                        : 'passport.no_entries'.tr(),
+                    style: TextStyle(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurfaceVariant,
+                      fontSize: 15,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
           );
         }
@@ -56,21 +284,24 @@ class JourneyScreen extends ConsumerWidget {
             final isLast = index == items.length - 1;
 
             return switch (item) {
-              NarrationJourneyItem(:final entry) => TimelineEntry(
-                key: ValueKey(item.id),
-                entry: entry,
-                isLast: isLast,
-              ),
-              QuickGuideJourneyItem(:final entry) => QuickGuideTimelineEntry(
-                key: ValueKey(item.id),
-                entry: entry,
-                isLast: isLast,
-              ),
+              NarrationJourneyItem(:final entry) =>
+                TimelineEntry(
+                  key: ValueKey(item.id),
+                  entry: entry,
+                  isLast: isLast,
+                ),
+              QuickGuideJourneyItem(:final entry) =>
+                QuickGuideTimelineEntry(
+                  key: ValueKey(item.id),
+                  entry: entry,
+                  isLast: isLast,
+                ),
             };
           },
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () =>
+          const Center(child: CircularProgressIndicator()),
       error: (error, stack) => Center(
         child: Text(
           '${'passport.load_error'.tr()}: $error',

--- a/frontend/lib/features/journey/providers.dart
+++ b/frontend/lib/features/journey/providers.dart
@@ -8,23 +8,26 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 export 'package:context_app/features/quick_guide/providers.dart'
     show quickGuideRepositoryProvider, quickGuideEntriesProvider;
 
+/// Filter type for the journey list.
+enum JourneyFilter { all, narration, quickGuide }
+
 final journeyRepositoryProvider = Provider<JourneyRepository>((ref) {
   return HiveJourneyRepository();
 });
 
-final myJourneyProvider = FutureProvider.autoDispose<List<JourneyEntry>>((ref) {
+final myJourneyProvider =
+    FutureProvider.autoDispose<List<JourneyEntry>>((ref) {
   return ref.watch(journeyRepositoryProvider).getAll();
 });
 
 /// Combined provider returning all journey items (narration + quick guide)
 /// sorted newest first.
-final allJourneyItemsProvider = FutureProvider.autoDispose<List<JourneyItem>>((
-  ref,
-) async {
-  final narrationEntries = await ref.watch(journeyRepositoryProvider).getAll();
-  final quickGuideEntries = await ref
-      .watch(quickGuideRepositoryProvider)
-      .getAll();
+final allJourneyItemsProvider =
+    FutureProvider.autoDispose<List<JourneyItem>>((ref) async {
+  final narrationEntries =
+      await ref.watch(journeyRepositoryProvider).getAll();
+  final quickGuideEntries =
+      await ref.watch(quickGuideRepositoryProvider).getAll();
 
   final items = <JourneyItem>[
     ...narrationEntries.map(NarrationJourneyItem.new),
@@ -32,4 +35,46 @@ final allJourneyItemsProvider = FutureProvider.autoDispose<List<JourneyItem>>((
   ]..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
   return items;
+});
+
+/// Current search query entered by the user.
+final journeySearchQueryProvider =
+    StateProvider.autoDispose<String>((ref) => '');
+
+/// Current type filter selected by the user.
+final journeyFilterProvider =
+    StateProvider.autoDispose<JourneyFilter>((ref) => JourneyFilter.all);
+
+/// Items after applying search query and type filter.
+final filteredJourneyItemsProvider =
+    Provider.autoDispose<AsyncValue<List<JourneyItem>>>((ref) {
+  final asyncItems = ref.watch(allJourneyItemsProvider);
+  final query =
+      ref.watch(journeySearchQueryProvider).trim().toLowerCase();
+  final filter = ref.watch(journeyFilterProvider);
+
+  return asyncItems.whenData((items) {
+    var result = items;
+
+    if (filter != JourneyFilter.all) {
+      result = result.where((item) {
+        return switch (filter) {
+          JourneyFilter.narration => item is NarrationJourneyItem,
+          JourneyFilter.quickGuide => item is QuickGuideJourneyItem,
+          JourneyFilter.all => true,
+        };
+      }).toList();
+    }
+
+    if (query.isNotEmpty) {
+      result = result
+          .where(
+            (item) =>
+                item.searchableText.toLowerCase().contains(query),
+          )
+          .toList();
+    }
+
+    return result;
+  });
 });

--- a/frontend/test/features/journey/providers/filtered_journey_items_test.dart
+++ b/frontend/test/features/journey/providers/filtered_journey_items_test.dart
@@ -1,0 +1,238 @@
+import 'dart:typed_data';
+
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/models/journey_item.dart';
+import 'package:context_app/features/journey/domain/models/saved_place.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+JourneyEntry _makeNarration({
+  String id = 'n1',
+  String placeName = 'Kyoto Temple',
+  String placeAddress = 'Kyoto, Japan',
+  String narrationText =
+      'This ancient temple has a long and rich history.',
+  DateTime? createdAt,
+}) {
+  return JourneyEntry(
+    id: id,
+    place: SavedPlace(
+      id: 'p-$id',
+      name: placeName,
+      address: placeAddress,
+    ),
+    narrationContent: NarrationContent.create(
+      narrationText,
+      language: Language.english,
+    ),
+    narrationAspects: const {NarrationAspect.historicalBackground},
+    createdAt: createdAt ?? DateTime(2026, 4, 1),
+    language: Language.english,
+  );
+}
+
+QuickGuideEntry _makeQuickGuide({
+  String id = 'q1',
+  String description =
+      'A beautiful shrine gate standing near the river.',
+  DateTime? createdAt,
+}) {
+  return QuickGuideEntry(
+    id: id,
+    imageBytes: Uint8List.fromList([0, 1, 2]),
+    aiDescription: description,
+    createdAt: createdAt ?? DateTime(2026, 4, 2),
+    language: Language.english,
+  );
+}
+
+/// Creates a [ProviderContainer] with [allJourneyItemsProvider]
+/// overridden with the given items, plus the specified search
+/// query and filter.
+ProviderContainer _createContainer({
+  required List<JourneyItem> items,
+  String query = '',
+  JourneyFilter filter = JourneyFilter.all,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      allJourneyItemsProvider.overrideWith(
+        (ref) async => items,
+      ),
+    ],
+  );
+
+  if (query.isNotEmpty) {
+    container.read(journeySearchQueryProvider.notifier).state =
+        query;
+  }
+  if (filter != JourneyFilter.all) {
+    container.read(journeyFilterProvider.notifier).state = filter;
+  }
+
+  return container;
+}
+
+void main() {
+  final narration1 = NarrationJourneyItem(
+    _makeNarration(id: 'n1', placeName: 'Kyoto Temple'),
+  );
+  final narration2 = NarrationJourneyItem(
+    _makeNarration(
+      id: 'n2',
+      placeName: 'Tokyo Tower',
+      placeAddress: 'Tokyo, Japan',
+      narrationText:
+          'Tokyo Tower is an iconic landmark in the city.',
+    ),
+  );
+  final quickGuide1 = QuickGuideJourneyItem(
+    _makeQuickGuide(
+      id: 'q1',
+      description:
+          'A beautiful shrine gate standing near the river.',
+    ),
+  );
+
+  group('filteredJourneyItemsProvider', () {
+    test('returns all items when no filter or search applied',
+        () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+      );
+
+      // Wait for async provider to resolve.
+      await container.read(allJourneyItemsProvider.future);
+
+      final result =
+          container.read(filteredJourneyItemsProvider);
+      final items = result.value!;
+      expect(items.length, 3);
+    });
+
+    test('filters by narration type', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        filter: JourneyFilter.narration,
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 2);
+      expect(
+        items.every((i) => i is NarrationJourneyItem),
+        isTrue,
+      );
+    });
+
+    test('filters by quick guide type', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        filter: JourneyFilter.quickGuide,
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 1);
+      expect(items.first, isA<QuickGuideJourneyItem>());
+    });
+
+    test('searches by place name (case-insensitive)', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: 'kyoto',
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 1);
+      expect(items.first.id, 'n1');
+    });
+
+    test('searches by narration content', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: 'iconic landmark',
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 1);
+      expect(items.first.id, 'n2');
+    });
+
+    test('searches quick guide by AI description', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: 'shrine gate',
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 1);
+      expect(items.first.id, 'q1');
+    });
+
+    test('combines filter and search', () async {
+      // Search "japan" matches both narrations (address).
+      // Filter narration only → should exclude quick guide.
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: 'japan',
+        filter: JourneyFilter.narration,
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 2);
+      expect(
+        items.every((i) => i is NarrationJourneyItem),
+        isTrue,
+      );
+    });
+
+    test('returns empty list when nothing matches', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: 'xyznonexistent',
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items, isEmpty);
+    });
+
+    test('trims whitespace in search query', () async {
+      final container = _createContainer(
+        items: [narration1, narration2, quickGuide1],
+        query: '  kyoto  ',
+      );
+
+      await container.read(allJourneyItemsProvider.future);
+
+      final items =
+          container.read(filteredJourneyItemsProvider).value!;
+      expect(items.length, 1);
+      expect(items.first.id, 'n1');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Enhanced the journey screen with search and filtering capabilities, allowing users to find specific entries by place name, address, or content, and filter by entry type (narration or quick guide).

## Key Changes

- **Converted JourneyScreen to ConsumerStatefulWidget** to manage search UI state and text controller lifecycle
- **Added search functionality** with animated search bar that toggles via icon button in the header
- **Implemented type filtering** with three filter chips (All, Narration, Quick Guide)
- **Created new providers** for managing search query and filter state:
  - `journeySearchQueryProvider`: tracks current search query
  - `journeyFilterProvider`: tracks selected filter type
  - `filteredJourneyItemsProvider`: combines all items with search and filter logic
- **Added searchable text support** to JourneyItem models:
  - NarrationJourneyItem searches place name, address, and narration content
  - QuickGuideJourneyItem searches AI description
- **Improved empty state UI** with contextual messaging and icons (shows different message when filters are active vs. no entries exist)
- **Extracted UI components** into separate widgets (`_FilterChips`, `_JourneyList`) for better organization
- **Added comprehensive test coverage** for the filtered items provider with 9 test cases covering filtering, searching, and combined scenarios
- **Updated translations** (English and Traditional Chinese) with new search and filter labels

## Implementation Details

- Search is case-insensitive and trims whitespace
- Filter and search can be combined for refined results
- Search bar uses AnimatedSize for smooth expand/collapse animation
- Clear button appears in search field when text is present
- All providers use `.autoDispose` to clean up resources when not in use

https://claude.ai/code/session_013nQA1VuN22t3wrWQPDR5P8