### PR TITLE
feat: add platform-adaptive widget layer for iOS/Android conventions

### DIFF
--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -8,6 +8,7 @@ import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/saved_locations/providers.dart';
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/share/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// Main application widget using go_router for navigation.
 ///
@@ -120,7 +121,7 @@ class _ShareLoadingOverlay extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                CircularProgressIndicator(color: colorScheme.primary),
+                AdaptiveProgressIndicator(color: colorScheme.primary),
                 const SizedBox(height: 16),
                 Text(
                   'shared_place.loading'.tr(),

--- a/frontend/lib/features/ads/presentation/widgets/watch_ad_dialog.dart
+++ b/frontend/lib/features/ads/presentation/widgets/watch_ad_dialog.dart
@@ -4,16 +4,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/ads/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 顯示觀看廣告對話框
 ///
 /// 回傳 true 表示已觀看並獲得獎勵，false/null 表示取消，
 /// 回傳 'subscribe' 表示使用者選擇訂閱
 Future<dynamic> showWatchAdDialog(BuildContext context, WidgetRef ref) {
-  return showModalBottomSheet<dynamic>(
+  return showAdaptiveModalBottomSheet<dynamic>(
     context: context,
     isScrollControlled: true,
-    backgroundColor: Colors.transparent,
     builder: (context) => _WatchAdDialog(ref: ref),
   );
 }
@@ -128,77 +128,63 @@ class _WatchAdDialogState extends State<_WatchAdDialog> {
           const SizedBox(height: 32),
 
           // Watch Ad Button
-          SizedBox(
-            width: double.infinity,
-            height: 50,
-            child: ElevatedButton.icon(
-              onPressed: _isLoading ? null : _watchAd,
-              icon: _isLoading
-                  ? const SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Colors.white,
-                      ),
-                    )
-                  : const Icon(Icons.play_arrow, color: Colors.white),
-              label: Text(
-                'ads.watch_video'.tr(),
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                ),
-              ),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.primary,
-                disabledBackgroundColor: AppColors.primary.withValues(
-                  alpha: 0.5,
-                ),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
+          AdaptiveButton(
+            expanded: true,
+            backgroundColor: AppColors.primary,
+            foregroundColor: Colors.white,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            icon: _isLoading
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: AdaptiveProgressIndicator(
+                      strokeWidth: 2,
+                      color: Colors.white,
+                    ),
+                  )
+                : const Icon(Icons.play_arrow, color: Colors.white),
+            onPressed: _isLoading ? null : _watchAd,
+            child: Text(
+              'ads.watch_video'.tr(),
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: Colors.white,
               ),
             ),
           ),
           const SizedBox(height: 12),
 
           // Subscribe Button
-          SizedBox(
-            width: double.infinity,
-            height: 50,
-            child: OutlinedButton.icon(
-              onPressed: _isLoading
-                  ? null
-                  : () {
-                      // 回傳 'subscribe' 讓呼叫端導航
-                      Navigator.of(context).pop('subscribe');
-                    },
-              icon: const Icon(
-                Icons.workspace_premium,
+          AdaptiveButton(
+            expanded: true,
+            style: AdaptiveButtonStyle.outlined,
+            foregroundColor: AppColors.primary,
+            padding: const EdgeInsets.symmetric(vertical: 14),
+            icon: const Icon(
+              Icons.workspace_premium,
+              color: AppColors.primary,
+            ),
+            onPressed: _isLoading
+                ? null
+                : () {
+                    // 回傳 'subscribe' 讓呼叫端導航
+                    Navigator.of(context).pop('subscribe');
+                  },
+            child: Text(
+              'subscription.upgrade_cta'.tr(),
+              style: const TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
                 color: AppColors.primary,
-              ),
-              label: Text(
-                'subscription.upgrade_cta'.tr(),
-                style: const TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w600,
-                  color: AppColors.primary,
-                ),
-              ),
-              style: OutlinedButton.styleFrom(
-                side: const BorderSide(color: AppColors.primary),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
               ),
             ),
           ),
           const SizedBox(height: 12),
 
           // Cancel
-          TextButton(
+          AdaptiveButton(
+            style: AdaptiveButtonStyle.text,
             onPressed: _isLoading
                 ? null
                 : () => Navigator.of(context).pop(false),

--- a/frontend/lib/features/camera/presentation/screens/camera_screen.dart
+++ b/frontend/lib/features/camera/presentation/screens/camera_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 相機畫面
 ///
@@ -122,7 +123,7 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        leading: IconButton(
+        leading: AdaptiveIconButton(
           icon: const Icon(Icons.arrow_back_ios_new),
           onPressed: () => context.pop(),
         ),
@@ -132,7 +133,10 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
         ),
         actions: [
           if (_displayImage != null)
-            IconButton(icon: const Icon(Icons.refresh), onPressed: _retake),
+            AdaptiveIconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: _retake,
+            ),
         ],
       ),
       body: _buildBody(cameraState),
@@ -214,51 +218,33 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
             ),
             const SizedBox(height: 48),
 
-            // 拍照按鈕
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: () => _pickImage(ImageSource.camera),
-                icon: const Icon(Icons.camera_alt, size: 24),
-                label: Text(
-                  'camera.take_photo'.tr(),
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  elevation: 8,
-                  shadowColor: AppColors.primary.withValues(alpha: 0.5),
+            AdaptiveButton(
+              expanded: true,
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              icon: const Icon(Icons.camera_alt, size: 24),
+              onPressed: () => _pickImage(ImageSource.camera),
+              child: Text(
+                'camera.take_photo'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),
             const SizedBox(height: 16),
-
-            // 從相簿選擇
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => _pickImage(ImageSource.gallery),
-                icon: const Icon(Icons.photo_library, size: 24),
-                label: Text(
-                  'camera.from_gallery'.tr(),
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                style: OutlinedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
+            AdaptiveButton(
+              expanded: true,
+              style: AdaptiveButtonStyle.outlined,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              icon: const Icon(Icons.photo_library, size: 24),
+              onPressed: () => _pickImage(ImageSource.gallery),
+              child: Text(
+                'camera.from_gallery'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),
@@ -274,7 +260,7 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const CircularProgressIndicator(color: AppColors.primary),
+            const AdaptiveProgressIndicator(color: AppColors.primary),
             const SizedBox(height: 16),
             Text(
               'camera.analyzing'.tr(),
@@ -308,12 +294,10 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
+            AdaptiveButton(
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
               onPressed: _retake,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.primary,
-                foregroundColor: Colors.white,
-              ),
               child: Text('camera.retry'.tr()),
             ),
           ],
@@ -330,33 +314,18 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
           // 開始導覽按鈕（放在卡片外面）
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: SizedBox(
-              width: double.infinity,
-              child: ElevatedButton(
-                onPressed: _navigateToNarration,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  elevation: 8,
-                  shadowColor: AppColors.primary.withValues(alpha: 0.5),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.play_arrow_rounded, size: 24),
-                    const SizedBox(width: 8),
-                    Text(
-                      'camera.start_narration'.tr(),
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ],
+            child: AdaptiveButton(
+              expanded: true,
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              icon: const Icon(Icons.play_arrow_rounded, size: 24),
+              onPressed: _navigateToNarration,
+              child: Text(
+                'camera.start_narration'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -9,6 +9,7 @@ import 'package:context_app/features/explore/providers.dart';
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/saved_locations/providers.dart';
 import 'package:context_app/features/saved_locations/presentation/widgets/saved_locations_fab.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 class ExploreScreen extends ConsumerStatefulWidget {
   const ExploreScreen({super.key});
@@ -45,11 +46,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
   }
 
   void _showFilterPanel() {
-    showModalBottomSheet(
+    showAdaptiveModalBottomSheet(
       context: context,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
       builder: (context) => const _FilterPanel(),
     );
   }
@@ -109,27 +107,21 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                     ],
                   ),
                   const SizedBox(height: 16),
-                  TextField(
+                  AdaptiveTextField(
                     controller: _searchController,
-                    decoration: InputDecoration(
-                      hintText: 'Search for places...',
-                      prefixIcon: const Icon(Icons.search),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                      suffixIcon: _searchController.text.isNotEmpty
-                          ? IconButton(
-                              icon: const Icon(Icons.clear),
-                              onPressed: () {
-                                _searchController.clear();
-                                ref
-                                    .read(placesControllerProvider.notifier)
-                                    .search('');
-                              },
-                            )
-                          : null,
-                    ),
+                    hintText: 'Search for places...',
+                    prefixIcon: const Icon(Icons.search),
+                    suffix: _searchController.text.isNotEmpty
+                        ? AdaptiveIconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              ref
+                                  .read(placesControllerProvider.notifier)
+                                  .search('');
+                            },
+                          )
+                        : null,
                     onSubmitted: (value) {
                       ref.read(placesControllerProvider.notifier).search(value);
                     },
@@ -156,7 +148,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                           return PlaceCard(place: places[index]);
                         },
                       ),
-                loading: () => const Center(child: CircularProgressIndicator()),
+                loading: () =>
+                    const Center(child: AdaptiveProgressIndicator()),
                 error: (error, stack) => Center(
                   child: Text('${'common.error_prefix'.tr()}: $error'),
                 ),
@@ -276,7 +269,7 @@ class _FilterPanelState extends ConsumerState<_FilterPanel> {
           Row(
             children: [
               Expanded(
-                child: Slider(
+                child: AdaptiveSlider(
                   value: _sliderValue,
                   onChanged: (value) {
                     setState(() {
@@ -331,17 +324,15 @@ class _FilterPanelState extends ConsumerState<_FilterPanel> {
             style: TextStyle(fontSize: 12, color: colorScheme.onSurfaceVariant),
           ),
           const SizedBox(height: 20),
-          SizedBox(
-            width: double.infinity,
-            child: FilledButton(
-              onPressed: () {
-                ref.read(minReviewCountProvider.notifier).state = 100;
-                setState(() {
-                  _sliderValue = _valueToSlider(100);
-                });
-              },
-              child: Text('explore.filter.reset'.tr()),
-            ),
+          AdaptiveButton(
+            expanded: true,
+            onPressed: () {
+              ref.read(minReviewCountProvider.notifier).state = 100;
+              setState(() {
+                _sliderValue = _valueToSlider(100);
+              });
+            },
+            child: Text('explore.filter.reset'.tr()),
           ),
         ],
       ),

--- a/frontend/lib/features/journey/presentation/screens/journey_screen.dart
+++ b/frontend/lib/features/journey/presentation/screens/journey_screen.dart
@@ -9,6 +9,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 class JourneyScreen extends ConsumerStatefulWidget {
   const JourneyScreen({super.key});
@@ -64,7 +65,7 @@ class _JourneyScreenState extends ConsumerState<JourneyScreen> {
                     ),
                   ),
                   if (isTimeline)
-                    IconButton(
+                    AdaptiveIconButton(
                       onPressed: _toggleSearch,
                       icon: Icon(
                         _showSearch ? Icons.close : Icons.search,
@@ -72,9 +73,8 @@ class _JourneyScreenState extends ConsumerState<JourneyScreen> {
                       ),
                     )
                   else
-                    IconButton(
+                    AdaptiveIconButton(
                       onPressed: () => context.push('/trip/edit'),
-                      tooltip: 'trip.create_action'.tr(),
                       icon: Icon(
                         Icons.add,
                         color: colorScheme.onSurfaceVariant,
@@ -119,7 +119,7 @@ class _JourneyScreenState extends ConsumerState<JourneyScreen> {
                               size: 20,
                             ),
                             suffixIcon: _searchController.text.isNotEmpty
-                                ? IconButton(
+                                ? AdaptiveIconButton(
                                     icon: const Icon(Icons.clear, size: 18),
                                     onPressed: () {
                                       _searchController.clear();
@@ -322,15 +322,12 @@ class _CurrentTripBanner extends ConsumerWidget {
                           ],
                         ),
                       ),
-                      TextButton(
+                      AdaptiveButton(
+                        style: AdaptiveButtonStyle.text,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
                         onPressed: () =>
                             ref.read(currentTripIdProvider.notifier).clear(),
-                        style: TextButton.styleFrom(
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(horizontal: 10),
-                          minimumSize: const Size(0, 32),
-                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        ),
                         child: Text(
                           'trip.end_current'.tr(),
                           style: const TextStyle(
@@ -370,7 +367,7 @@ class _TripGridView extends ConsumerWidget {
           currentTripId: currentTripId,
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: AdaptiveProgressIndicator()),
       error: (error, _) => Center(
         child: Text(
           '${'trip.load_error'.tr()}: $error',
@@ -515,7 +512,7 @@ class _JourneyList extends ConsumerWidget {
           },
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: AdaptiveProgressIndicator()),
       error: (error, stack) => Center(
         child: Text(
           '${'passport.load_error'.tr()}: $error',

--- a/frontend/lib/features/journey/presentation/screens/save_success_screen.dart
+++ b/frontend/lib/features/journey/presentation/screens/save_success_screen.dart
@@ -1,5 +1,6 @@
 import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -35,7 +36,7 @@ class SaveSuccessScreen extends StatelessWidget {
           ),
         ),
         actions: [
-          IconButton(
+          AdaptiveIconButton(
             onPressed: () => context.pop(),
             icon: Icon(
               Icons.close,
@@ -192,19 +193,15 @@ class SaveSuccessScreen extends StatelessWidget {
 
               Column(
                 children: [
-                  ElevatedButton(
+                  AdaptiveButton(
+                    expanded: true,
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 18),
                     onPressed: onViewPassport,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: AppColors.primary,
-                      foregroundColor: Colors.white,
-                      minimumSize: const Size(double.infinity, 56),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      elevation: 0,
-                    ),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
                       children: [
                         Text(
                           'passport.view_button'.tr(),
@@ -219,16 +216,13 @@ class SaveSuccessScreen extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 12),
-                  TextButton(
+                  AdaptiveButton(
+                    expanded: true,
+                    style: AdaptiveButtonStyle.text,
+                    backgroundColor: colorScheme.surfaceContainerHigh,
+                    foregroundColor: colorScheme.onSurface,
+                    padding: const EdgeInsets.symmetric(vertical: 18),
                     onPressed: onContinueTour ?? () => context.pop(),
-                    style: TextButton.styleFrom(
-                      backgroundColor: colorScheme.surfaceContainerHigh,
-                      foregroundColor: colorScheme.onSurface,
-                      minimumSize: const Size(double.infinity, 56),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                    ),
                     child: Text(
                       'passport.continue_tour'.tr(),
                       style: const TextStyle(

--- a/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/quick_guide_timeline_entry.dart
@@ -14,6 +14,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// Timeline entry widget for a [QuickGuideEntry].
 class QuickGuideTimelineEntry extends ConsumerStatefulWidget {
@@ -114,25 +115,21 @@ class _QuickGuideTimelineEntryState
   Future<void> _showDeleteConfirmDialog() async {
     if (_isDeleting) return;
 
-    final confirmed = await showDialog<bool>(
+    final confirmed = await showAdaptiveAlertDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text('passport.delete_title'.tr()),
-        content: Text('passport.delete_message'.tr()),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text('passport.cancel'.tr()),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(
-              'passport.delete_confirm'.tr(),
-              style: const TextStyle(color: AppColors.error),
-            ),
-          ),
-        ],
-      ),
+      title: 'passport.delete_title'.tr(),
+      content: 'passport.delete_message'.tr(),
+      actions: [
+        AdaptiveDialogAction<bool>(
+          label: 'passport.cancel'.tr(),
+          result: false,
+        ),
+        AdaptiveDialogAction<bool>(
+          label: 'passport.delete_confirm'.tr(),
+          isDestructive: true,
+          result: true,
+        ),
+      ],
     );
 
     if (confirmed == true) {
@@ -322,7 +319,7 @@ class _QuickGuideTimelineEntryState
                               const SizedBox(
                                 width: 18,
                                 height: 18,
-                                child: CircularProgressIndicator(
+                                child: AdaptiveProgressIndicator(
                                   strokeWidth: 2,
                                   color: AppColors.primary,
                                 ),
@@ -338,7 +335,7 @@ class _QuickGuideTimelineEntryState
                               const SizedBox(
                                 width: 18,
                                 height: 18,
-                                child: CircularProgressIndicator(
+                                child: AdaptiveProgressIndicator(
                                   strokeWidth: 2,
                                   color: AppColors.primary,
                                 ),

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -14,6 +14,7 @@ import 'package:context_app/features/journey/domain/models/journey_entry.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/explore/domain/models/place_category.dart';
 import 'package:context_app/features/trip/presentation/widgets/move_to_trip_sheet.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 class TimelineEntry extends ConsumerStatefulWidget {
   final JourneyEntry entry;
@@ -85,25 +86,21 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
   Future<void> _showDeleteConfirmDialog() async {
     if (_isDeleting) return; // Prevent multiple clicks
 
-    final confirmed = await showDialog<bool>(
+    final confirmed = await showAdaptiveAlertDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text('passport.delete_title'.tr()),
-        content: Text('passport.delete_message'.tr()),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text('passport.cancel'.tr()),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(
-              'passport.delete_confirm'.tr(),
-              style: const TextStyle(color: AppColors.error),
-            ),
-          ),
-        ],
-      ),
+      title: 'passport.delete_title'.tr(),
+      content: 'passport.delete_message'.tr(),
+      actions: [
+        AdaptiveDialogAction<bool>(
+          label: 'passport.cancel'.tr(),
+          result: false,
+        ),
+        AdaptiveDialogAction<bool>(
+          label: 'passport.delete_confirm'.tr(),
+          isDestructive: true,
+          result: true,
+        ),
+      ],
     );
 
     if (confirmed == true) {
@@ -358,7 +355,7 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                                 const SizedBox(
                                   width: 18,
                                   height: 18,
-                                  child: CircularProgressIndicator(
+                                  child: AdaptiveProgressIndicator(
                                     strokeWidth: 2,
                                     color: AppColors.primary,
                                   ),
@@ -374,7 +371,7 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                                 const SizedBox(
                                   width: 18,
                                   height: 18,
-                                  child: CircularProgressIndicator(
+                                  child: AdaptiveProgressIndicator(
                                     strokeWidth: 2,
                                     color: AppColors.primary,
                                   ),

--- a/frontend/lib/features/narration/presentation/screens/narration_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/narration_screen.dart
@@ -10,6 +10,7 @@ import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/narration/presentation/widgets/grounding_info_sheet.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_transcript_area.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_control_panel.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 導覽播放頁面
 ///
@@ -110,7 +111,7 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        IconButton(
+                        AdaptiveIconButton(
                           icon: Icon(
                             Icons.arrow_back_ios_new,
                             color: colorScheme.onSurface,
@@ -179,8 +180,7 @@ class _GroundingInfoButton extends StatelessWidget {
       color: colorScheme.surface,
       shape: const CircleBorder(),
       elevation: 2,
-      child: IconButton(
-        tooltip: 'Google 搜尋結果',
+      child: AdaptiveIconButton(
         icon: Icon(Icons.info_outline, color: colorScheme.onSurface),
         onPressed: () => showGroundingInfoSheet(context, grounding: grounding),
       ),

--- a/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_narration_aspect_screen.dart
@@ -16,6 +16,7 @@ import 'package:context_app/features/narration/presentation/controllers/extensio
 import 'package:context_app/features/ads/presentation/widgets/watch_ad_dialog.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 class SelectNarrationAspectScreen extends ConsumerStatefulWidget {
   final Place place;
@@ -83,21 +84,18 @@ class _SelectNarrationAspectScreenState
 
   void _showErrorDialog(NarrationGenerationState genState) {
     ref.read(narrationGenerationControllerProvider.notifier).reset();
-    showDialog<void>(
+    showAdaptiveAlertDialog<void>(
       context: context,
-      builder: (dialogContext) => AlertDialog(
-        title: Text('config_screen.generation_error_title'.tr()),
-        content: Text(
+      title: 'config_screen.generation_error_title'.tr(),
+      content:
           genState.errorMessage ??
-              'config_screen.generation_error_message'.tr(),
+          'config_screen.generation_error_message'.tr(),
+      actions: [
+        AdaptiveDialogAction<void>(
+          label: 'config_screen.generation_error_ok'.tr(),
+          isDefault: true,
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(),
-            child: Text('config_screen.generation_error_ok'.tr()),
-          ),
-        ],
-      ),
+      ],
     );
   }
 
@@ -147,7 +145,7 @@ class _SelectNarrationAspectScreenState
               elevation: 0,
               leading: isGenerating
                   ? null
-                  : IconButton(
+                  : AdaptiveIconButton(
                       icon: const Icon(
                         Icons.arrow_back_ios_new,
                         color: Colors.white,
@@ -250,32 +248,22 @@ class _SelectNarrationAspectScreenState
                       const SizedBox(height: 24),
 
                       // Start Button
-                      ElevatedButton(
+                      AdaptiveButton(
+                        expanded: true,
+                        backgroundColor: AppColors.primary,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        icon: const Icon(Icons.play_arrow, color: Colors.white),
                         onPressed: selectedAspects.isEmpty
                             ? null
                             : _onStartPressed,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.primary,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
+                        child: Text(
+                          'config_screen.start_button'.tr(),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
                           ),
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          minimumSize: const Size(double.infinity, 50),
-                        ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Icon(Icons.play_arrow, color: Colors.white),
-                            const SizedBox(width: 8),
-                            Text(
-                              'config_screen.start_button'.tr(),
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 18,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ],
                         ),
                       ),
                       const SizedBox(height: 20),
@@ -299,7 +287,7 @@ class _GeneratingIndicator extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const CircularProgressIndicator(color: AppColors.primary),
+            const AdaptiveProgressIndicator(color: AppColors.primary),
             const SizedBox(height: 16),
             Text(
               'config_screen.generating'.tr(),
@@ -344,7 +332,7 @@ class _BackgroundImage extends StatelessWidget {
         cacheManager: PlaceImageCacheManager.instance,
         placeholder: (context, url) => Container(
           color: Colors.black,
-          child: const Center(child: CircularProgressIndicator()),
+          child: const Center(child: AdaptiveProgressIndicator()),
         ),
         errorWidget: (context, url, error) => Container(
           color: Colors.black,

--- a/frontend/lib/features/narration/presentation/widgets/grounding_info_sheet.dart
+++ b/frontend/lib/features/narration/presentation/widgets/grounding_info_sheet.dart
@@ -2,6 +2,7 @@ import 'package:context_app/features/narration/domain/models/grounding_info.dart
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// Opens the Google Search grounding info as a modal bottom sheet.
 ///
@@ -12,11 +13,9 @@ Future<void> showGroundingInfoSheet(
   BuildContext context, {
   required GroundingInfo grounding,
 }) {
-  return showModalBottomSheet<void>(
+  return showAdaptiveModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
-    showDragHandle: true,
-    useSafeArea: true,
     builder: (context) => GroundingInfoSheet(grounding: grounding),
   );
 }

--- a/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
+++ b/frontend/lib/features/narration/presentation/widgets/narration_transcript_area.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart' as easy;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 導覽轉錄文本顯示區域
 class NarrationTranscriptArea extends ConsumerWidget {
@@ -29,7 +30,7 @@ class NarrationTranscriptArea extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            CircularProgressIndicator(color: primaryColor),
+            AdaptiveProgressIndicator(color: primaryColor),
             const SizedBox(height: 16),
             Text(
               'player_screen.loading'.tr(),

--- a/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
+++ b/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
@@ -13,6 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// Quick Guide tab screen.
 ///
@@ -231,48 +232,33 @@ class _ImageSourceSelector extends StatelessWidget {
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 48),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: () => onPickImage(ImageSource.camera),
-                icon: const Icon(Icons.camera_alt, size: 24),
-                label: Text(
-                  'quick_guide.take_photo'.tr(),
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: AppColors.primary,
-                  foregroundColor: Colors.white,
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  elevation: 8,
-                  shadowColor: AppColors.primary.withValues(alpha: 0.5),
+            AdaptiveButton(
+              expanded: true,
+              backgroundColor: AppColors.primary,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              icon: const Icon(Icons.camera_alt, size: 24),
+              onPressed: () => onPickImage(ImageSource.camera),
+              child: Text(
+                'quick_guide.take_photo'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),
             const SizedBox(height: 16),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => onPickImage(ImageSource.gallery),
-                icon: const Icon(Icons.photo_library, size: 24),
-                label: Text(
-                  'quick_guide.from_gallery'.tr(),
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                style: OutlinedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
+            AdaptiveButton(
+              expanded: true,
+              style: AdaptiveButtonStyle.outlined,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              icon: const Icon(Icons.photo_library, size: 24),
+              onPressed: () => onPickImage(ImageSource.gallery),
+              child: Text(
+                'quick_guide.from_gallery'.tr(),
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
             ),
@@ -361,7 +347,7 @@ class _DescriptionArea extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const CircularProgressIndicator(color: AppColors.primary),
+            const AdaptiveProgressIndicator(color: AppColors.primary),
             const SizedBox(height: 16),
             Text(
               'quick_guide.analyzing'.tr(),

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_dialog.dart
@@ -6,6 +6,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// Content of the saved locations dialog, displayed inside
 /// the expanding animation from [SavedLocationsFab].
@@ -26,7 +27,7 @@ class SavedLocationsDialog extends ConsumerWidget {
             data: (entries) => entries.isEmpty
                 ? _EmptyState(colorScheme: colorScheme)
                 : _SavedLocationsList(entries: entries),
-            loading: () => const Center(child: CircularProgressIndicator()),
+            loading: () => const Center(child: AdaptiveProgressIndicator()),
             error: (_, __) => Center(
               child: Text(
                 'common.error_prefix'.tr(),
@@ -63,7 +64,7 @@ class _DialogHeader extends StatelessWidget {
               ),
             ),
           ),
-          IconButton(
+          AdaptiveIconButton(
             onPressed: () => Navigator.of(context).pop(),
             icon: Icon(Icons.close, color: colorScheme.onSurfaceVariant),
           ),
@@ -198,31 +199,21 @@ class _SavedLocationTile extends ConsumerWidget {
   }
 
   Future<bool?> _confirmDelete(BuildContext context) {
-    return showDialog<bool>(
+    return showAdaptiveAlertDialog<bool>(
       context: context,
-      builder: (context) {
-        final colorScheme = Theme.of(context).colorScheme;
-        return AlertDialog(
-          title: Text('saved_locations.delete_title'.tr()),
-          content: Text('saved_locations.delete_message'.tr()),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: Text(
-                'saved_locations.cancel'.tr(),
-                style: TextStyle(color: colorScheme.onSurfaceVariant),
-              ),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: Text(
-                'saved_locations.delete_confirm'.tr(),
-                style: TextStyle(color: colorScheme.error),
-              ),
-            ),
-          ],
-        );
-      },
+      title: 'saved_locations.delete_title'.tr(),
+      content: 'saved_locations.delete_message'.tr(),
+      actions: [
+        AdaptiveDialogAction<bool>(
+          label: 'saved_locations.cancel'.tr(),
+          result: false,
+        ),
+        AdaptiveDialogAction<bool>(
+          label: 'saved_locations.delete_confirm'.tr(),
+          isDestructive: true,
+          result: true,
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/subscription/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -62,7 +63,7 @@ class SettingsScreen extends ConsumerWidget {
                   loading: () => const SizedBox(
                     width: 12,
                     height: 12,
-                    child: CircularProgressIndicator(strokeWidth: 1),
+                    child: AdaptiveProgressIndicator(strokeWidth: 1),
                   ),
                   error: (_, __) => Text(
                     'settings.app_version'.tr(),
@@ -219,9 +220,9 @@ class _ThemeModeTile extends ConsumerWidget {
             ),
           ),
           const SizedBox(width: 8),
-          Switch(
+          AdaptiveSwitch(
             value: themeMode == ThemeMode.dark,
-            activeThumbColor: AppColors.primary,
+            activeColor: AppColors.primary,
             onChanged: (value) =>
                 notifier.setThemeMode(value ? ThemeMode.dark : ThemeMode.light),
           ),
@@ -333,7 +334,7 @@ class _UsageSection extends StatelessWidget {
               child: SizedBox(
                 width: 20,
                 height: 20,
-                child: CircularProgressIndicator(strokeWidth: 2),
+                child: AdaptiveProgressIndicator(strokeWidth: 2),
               ),
             ),
           ),

--- a/frontend/lib/features/subscription/presentation/screens/subscription_screen.dart
+++ b/frontend/lib/features/subscription/presentation/screens/subscription_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:context_app/common/config/app_colors.dart';
 import 'package:context_app/features/subscription/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 訂閱付費牆畫面
 class SubscriptionScreen extends ConsumerStatefulWidget {
@@ -72,7 +73,7 @@ class _SubscriptionScreenState extends ConsumerState<SubscriptionScreen> {
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
-        leading: IconButton(
+        leading: AdaptiveIconButton(
           icon: Icon(Icons.close, color: colorScheme.onSurface),
           onPressed: () => Navigator.of(context).pop(),
         ),
@@ -125,22 +126,16 @@ class _SubscriptionScreenState extends ConsumerState<SubscriptionScreen> {
               SizedBox(
                 width: double.infinity,
                 height: 54,
-                child: ElevatedButton(
+                child: AdaptiveButton(
+                  expanded: true,
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
                   onPressed: _isLoading ? null : _purchase,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    disabledBackgroundColor: AppColors.primary.withValues(
-                      alpha: 0.5,
-                    ),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                  ),
                   child: _isLoading
                       ? const SizedBox(
                           width: 24,
                           height: 24,
-                          child: CircularProgressIndicator(
+                          child: AdaptiveProgressIndicator(
                             strokeWidth: 2,
                             color: Colors.white,
                           ),
@@ -156,7 +151,9 @@ class _SubscriptionScreenState extends ConsumerState<SubscriptionScreen> {
                 ),
               ),
               const SizedBox(height: 12),
-              TextButton(
+              AdaptiveButton(
+                style: AdaptiveButtonStyle.text,
+                foregroundColor: colorScheme.onSurfaceVariant,
                 onPressed: _isLoading ? null : _restore,
                 child: Text(
                   'subscription.restore'.tr(),

--- a/frontend/lib/features/trip/presentation/screens/trip_detail_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 顯示單一 Trip 的條目時間軸。
 ///
@@ -143,13 +144,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   AppBar _buildAppBar(AsyncValue<Trip?> tripAsync, List<JourneyItem> items) {
     if (_selectionMode) {
       return AppBar(
-        leading: IconButton(
+        leading: AdaptiveIconButton(
           icon: const Icon(Icons.close),
           onPressed: _exitSelectionMode,
         ),
         title: Text('trip.selected_count'.tr(args: ['${_selectedIds.length}'])),
         actions: [
-          TextButton(
+          AdaptiveButton(
+            style: AdaptiveButtonStyle.text,
             onPressed: items.isEmpty ? null : () => _selectAll(items),
             child: Text('trip.select_all'.tr()),
           ),
@@ -169,9 +171,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       ),
       actions: [
         if (_isUncategorized && items.isNotEmpty)
-          IconButton(
+          AdaptiveIconButton(
             icon: const Icon(Icons.checklist),
-            tooltip: 'trip.select_action'.tr(),
             onPressed: _enterSelectionMode,
           )
         else if (!_isUncategorized)
@@ -184,22 +185,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-        child: FilledButton.icon(
-          onPressed: _selectedIds.isEmpty || _moving
-              ? null
-              : () => _moveSelected(items),
+        child: AdaptiveButton(
+          expanded: true,
+          padding: const EdgeInsets.symmetric(vertical: 14),
           icon: _moving
               ? const SizedBox(
                   width: 18,
                   height: 18,
-                  child: CircularProgressIndicator(
+                  child: AdaptiveProgressIndicator(
                     strokeWidth: 2,
                     color: Colors.white,
                   ),
                 )
               : const Icon(Icons.drive_file_move_outlined),
-          label: Text('trip.move_selected'.tr()),
-          style: FilledButton.styleFrom(minimumSize: const Size.fromHeight(48)),
+          onPressed: _selectedIds.isEmpty || _moving
+              ? null
+              : () => _moveSelected(items),
+          child: Text('trip.move_selected'.tr()),
         ),
       ),
     );
@@ -316,25 +318,21 @@ class _TripMenuButton extends ConsumerWidget {
   }
 
   Future<bool> _confirmDelete(BuildContext context) async {
-    final result = await showDialog<bool>(
+    final result = await showAdaptiveAlertDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text('trip.delete_title'.tr()),
-        content: Text('trip.delete_message'.tr()),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: Text('trip.cancel'.tr()),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text(
-              'trip.delete_confirm'.tr(),
-              style: const TextStyle(color: AppColors.error),
-            ),
-          ),
-        ],
-      ),
+      title: 'trip.delete_title'.tr(),
+      content: 'trip.delete_message'.tr(),
+      actions: [
+        AdaptiveDialogAction<bool>(
+          label: 'trip.cancel'.tr(),
+          result: false,
+        ),
+        AdaptiveDialogAction<bool>(
+          label: 'trip.delete_confirm'.tr(),
+          isDestructive: true,
+          result: true,
+        ),
+      ],
     );
     return result ?? false;
   }
@@ -403,7 +401,7 @@ class _ItemsList extends StatelessWidget {
           },
         );
       },
-      loading: () => const Center(child: CircularProgressIndicator()),
+      loading: () => const Center(child: AdaptiveProgressIndicator()),
       error: (e, _) => Center(
         child: Text(
           '${'trip.load_error'.tr()}: $e',

--- a/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:uuid/uuid.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 建立或編輯 Trip 的表單頁。
 ///
@@ -124,7 +125,7 @@ class _TripEditScreenState extends ConsumerState<TripEditScreen> {
         ),
       ),
       body: _loadingInitial
-          ? const Center(child: CircularProgressIndicator())
+          ? const Center(child: AdaptiveProgressIndicator())
           : _buildForm(),
     );
   }
@@ -173,13 +174,14 @@ class _TripEditScreenState extends ConsumerState<TripEditScreen> {
                   : () => setState(() => _endDate = null),
             ),
             const SizedBox(height: 32),
-            FilledButton(
+            AdaptiveButton(
+              expanded: true,
               onPressed: _saving ? null : _save,
               child: _saving
                   ? const SizedBox(
                       height: 20,
                       width: 20,
-                      child: CircularProgressIndicator(strokeWidth: 2),
+                      child: AdaptiveProgressIndicator(strokeWidth: 2),
                     )
                   : Text(
                       _isEditMode
@@ -220,7 +222,10 @@ class _DatePickerTile extends StatelessWidget {
           border: const OutlineInputBorder(),
           suffixIcon: onClear == null
               ? const Icon(Icons.calendar_today)
-              : IconButton(icon: const Icon(Icons.clear), onPressed: onClear),
+              : AdaptiveIconButton(
+                  icon: const Icon(Icons.clear),
+                  onPressed: onClear,
+                ),
         ),
         child: Text(
           value == null ? 'trip.date_not_set'.tr() : formatter.format(value!),

--- a/frontend/lib/features/trip/presentation/screens/trip_list_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 顯示所有旅程 + 「未分類」群組的列表頁。
 class TripListScreen extends ConsumerWidget {
@@ -20,9 +21,8 @@ class TripListScreen extends ConsumerWidget {
       appBar: AppBar(
         title: Text('trip.list_title'.tr()),
         actions: [
-          IconButton(
+          AdaptiveIconButton(
             icon: const Icon(Icons.add),
-            tooltip: 'trip.create_action'.tr(),
             onPressed: () => context.push('/trip/edit'),
           ),
         ],
@@ -36,7 +36,7 @@ class TripListScreen extends ConsumerWidget {
             currentTripId: currentTripId,
           );
         },
-        loading: () => const Center(child: CircularProgressIndicator()),
+        loading: () => const Center(child: AdaptiveProgressIndicator()),
         error: (error, _) => Center(
           child: Text(
             '${'trip.load_error'.tr()}: $error',

--- a/frontend/lib/features/trip/presentation/widgets/move_to_trip_sheet.dart
+++ b/frontend/lib/features/trip/presentation/widgets/move_to_trip_sheet.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 
 /// 顯示旅程選擇底部表單，讓使用者把條目移到指定旅程或未分類。
 ///
@@ -17,10 +18,9 @@ Future<TripSelection?> showMoveToTripSheet({
   String? currentTripId,
   int itemCount = 1,
 }) {
-  return showModalBottomSheet<TripSelection>(
+  return showAdaptiveModalBottomSheet<TripSelection>(
     context: context,
     isScrollControlled: true,
-    showDragHandle: true,
     builder: (ctx) =>
         _MoveToTripSheet(currentTripId: currentTripId, itemCount: itemCount),
   );
@@ -73,7 +73,7 @@ class _MoveToTripSheet extends ConsumerWidget {
                 data: (trips) => _buildList(context, trips, colorScheme),
                 loading: () => const Padding(
                   padding: EdgeInsets.all(40),
-                  child: Center(child: CircularProgressIndicator()),
+                  child: Center(child: AdaptiveProgressIndicator()),
                 ),
                 error: (e, _) => Padding(
                   padding: const EdgeInsets.all(20),

--- a/frontend/lib/shared/widgets/adaptive/adaptive_bottom_sheet.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_bottom_sheet.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Shows a platform-appropriate modal bottom sheet.
+///
+/// On iOS/macOS uses `showCupertinoModalPopup` which slides in from the
+/// bottom with iOS momentum. On other platforms uses `showModalBottomSheet`
+/// with rounded top corners matching the Material 3 style.
+Future<T?> showAdaptiveModalBottomSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool isScrollControlled = false,
+}) {
+  final platform = Theme.of(context).platform;
+  final isCupertino =
+      platform == TargetPlatform.iOS || platform == TargetPlatform.macOS;
+
+  if (isCupertino) {
+    return showCupertinoModalPopup<T>(
+      context: context,
+      builder: (ctx) {
+        final colorScheme = Theme.of(context).colorScheme;
+        return SafeArea(
+          top: false,
+          child: Container(
+            decoration: BoxDecoration(
+              color: colorScheme.surface,
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(20),
+              ),
+            ),
+            child: Material(
+              color: Colors.transparent,
+              child: builder(ctx),
+            ),
+          ),
+        );
+      },
+    );
+  }
+  return showModalBottomSheet<T>(
+    context: context,
+    isScrollControlled: isScrollControlled,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: builder,
+  );
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_button.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_button.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Visual prominence of an [AdaptiveButton].
+enum AdaptiveButtonStyle {
+  /// Primary call-to-action. Material: `ElevatedButton`/`FilledButton`.
+  /// Cupertino: filled `CupertinoButton`.
+  filled,
+
+  /// Low-emphasis action with a border. Material: `OutlinedButton`.
+  /// Cupertino: bordered `CupertinoButton` (tinted outline).
+  outlined,
+
+  /// Minimal emphasis, text only. Material: `TextButton`.
+  /// Cupertino: plain `CupertinoButton`.
+  text,
+}
+
+/// Platform-aware button that switches between Material and Cupertino
+/// appearance. Keeps the API small and covers the use cases present in the
+/// app (label + optional leading icon).
+class AdaptiveButton extends StatelessWidget {
+  const AdaptiveButton({
+    super.key,
+    required this.onPressed,
+    required this.child,
+    this.style = AdaptiveButtonStyle.filled,
+    this.icon,
+    this.foregroundColor,
+    this.backgroundColor,
+    this.padding,
+    this.minSize,
+    this.expanded = false,
+  });
+
+  final VoidCallback? onPressed;
+  final Widget child;
+  final AdaptiveButtonStyle style;
+  final Widget? icon;
+  final Color? foregroundColor;
+  final Color? backgroundColor;
+  final EdgeInsetsGeometry? padding;
+  final Size? minSize;
+
+  /// When true the button stretches to fill the horizontal space.
+  final bool expanded;
+
+  bool _isCupertino(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS ||
+        platform == TargetPlatform.macOS;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final button = _isCupertino(context)
+        ? _buildCupertino(context)
+        : _buildMaterial(context);
+    if (expanded) {
+      return SizedBox(width: double.infinity, child: button);
+    }
+    return button;
+  }
+
+  Widget _wrapChild() {
+    if (icon == null) return child;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [icon!, const SizedBox(width: 8), child],
+    );
+  }
+
+  Widget _buildMaterial(BuildContext context) {
+    final materialChild = _wrapChild();
+    switch (style) {
+      case AdaptiveButtonStyle.filled:
+        final filledStyle = ElevatedButton.styleFrom(
+          foregroundColor: foregroundColor,
+          backgroundColor: backgroundColor,
+          padding: padding,
+        );
+        return ElevatedButton(
+          onPressed: onPressed,
+          style: filledStyle,
+          child: materialChild,
+        );
+      case AdaptiveButtonStyle.outlined:
+        return OutlinedButton(
+          onPressed: onPressed,
+          style: OutlinedButton.styleFrom(
+            foregroundColor: foregroundColor,
+            backgroundColor: backgroundColor,
+            padding: padding,
+          ),
+          child: materialChild,
+        );
+      case AdaptiveButtonStyle.text:
+        return TextButton(
+          onPressed: onPressed,
+          style: TextButton.styleFrom(
+            foregroundColor: foregroundColor,
+            backgroundColor: backgroundColor,
+            padding: padding,
+          ),
+          child: materialChild,
+        );
+    }
+  }
+
+  Widget _buildCupertino(BuildContext context) {
+    final cupertinoChild = _wrapChild();
+    final primary = CupertinoTheme.of(context).primaryColor;
+    switch (style) {
+      case AdaptiveButtonStyle.filled:
+        return CupertinoButton.filled(
+          onPressed: onPressed,
+          padding: padding,
+          minimumSize: minSize,
+          child: DefaultTextStyle.merge(
+            style: TextStyle(
+              color: foregroundColor ?? CupertinoColors.white,
+            ),
+            child: IconTheme.merge(
+              data: IconThemeData(
+                color: foregroundColor ?? CupertinoColors.white,
+              ),
+              child: cupertinoChild,
+            ),
+          ),
+        );
+      case AdaptiveButtonStyle.outlined:
+        final outlineColor = foregroundColor ?? primary;
+        return CupertinoButton(
+          onPressed: onPressed,
+          padding: padding ??
+              const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          minimumSize: minSize,
+          color: backgroundColor,
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: outlineColor),
+            child: IconTheme.merge(
+              data: IconThemeData(color: outlineColor),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: outlineColor),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  child: cupertinoChild,
+                ),
+              ),
+            ),
+          ),
+        );
+      case AdaptiveButtonStyle.text:
+        return CupertinoButton(
+          onPressed: onPressed,
+          padding: padding,
+          minimumSize: minSize,
+          color: backgroundColor,
+          child: DefaultTextStyle.merge(
+            style: TextStyle(color: foregroundColor ?? primary),
+            child: IconTheme.merge(
+              data: IconThemeData(color: foregroundColor ?? primary),
+              child: cupertinoChild,
+            ),
+          ),
+        );
+    }
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_dialog.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_dialog.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Describes a single action in an adaptive dialog.
+class AdaptiveDialogAction<T> {
+  const AdaptiveDialogAction({
+    required this.label,
+    this.onPressed,
+    this.isDefault = false,
+    this.isDestructive = false,
+    this.result,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final bool isDefault;
+  final bool isDestructive;
+  final T? result;
+}
+
+/// Shows a platform-appropriate alert dialog.
+///
+/// On iOS/macOS renders a `CupertinoAlertDialog`, on other platforms a
+/// Material `AlertDialog`. If [onPressed] on an action is null, the dialog
+/// pops automatically returning [result].
+Future<T?> showAdaptiveAlertDialog<T>({
+  required BuildContext context,
+  String? title,
+  String? content,
+  required List<AdaptiveDialogAction<T>> actions,
+  bool barrierDismissible = true,
+}) {
+  return showAdaptiveDialog<T>(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    builder: (ctx) {
+      final isCupertino =
+          Theme.of(ctx).platform == TargetPlatform.iOS ||
+          Theme.of(ctx).platform == TargetPlatform.macOS;
+
+      final children = actions.map((action) {
+        void handleTap() {
+          if (action.onPressed != null) {
+            action.onPressed!();
+          } else {
+            Navigator.of(ctx).pop(action.result);
+          }
+        }
+
+        if (isCupertino) {
+          return CupertinoDialogAction(
+            onPressed: handleTap,
+            isDefaultAction: action.isDefault,
+            isDestructiveRole: action.isDestructive,
+            child: Text(action.label),
+          );
+        }
+        return TextButton(
+          onPressed: handleTap,
+          child: Text(
+            action.label,
+            style: action.isDestructive
+                ? TextStyle(color: Theme.of(ctx).colorScheme.error)
+                : null,
+          ),
+        );
+      }).toList();
+
+      return AlertDialog.adaptive(
+        title: title == null ? null : Text(title),
+        content: content == null ? null : Text(content),
+        actions: children,
+      );
+    },
+  );
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_icon_button.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_icon_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Platform-aware icon-only button.
+///
+/// On iOS/macOS renders a `CupertinoButton` without a background; on other
+/// platforms renders a Material `IconButton`. Use this for navigation or
+/// toolbar-style icon actions; for primary chips keep using a styled button.
+class AdaptiveIconButton extends StatelessWidget {
+  const AdaptiveIconButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.color,
+    this.tooltip,
+    this.padding,
+  });
+
+  final Widget icon;
+  final VoidCallback? onPressed;
+  final Color? color;
+  final String? tooltip;
+  final EdgeInsetsGeometry? padding;
+
+  bool _isCupertino(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS ||
+        platform == TargetPlatform.macOS;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isCupertino(context)) {
+      return CupertinoButton(
+        onPressed: onPressed,
+        padding: padding ?? const EdgeInsets.all(8),
+        minimumSize: Size.zero,
+        child: IconTheme.merge(
+          data: IconThemeData(color: color),
+          child: icon,
+        ),
+      );
+    }
+    return IconButton(
+      onPressed: onPressed,
+      icon: icon,
+      color: color,
+      tooltip: tooltip,
+      padding: padding ?? const EdgeInsets.all(8),
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_progress_indicator.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_progress_indicator.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+/// Platform-aware circular progress indicator.
+///
+/// On iOS/macOS shows `CupertinoActivityIndicator`, on other platforms shows
+/// a Material `CircularProgressIndicator`. Thin wrapper around
+/// `CircularProgressIndicator.adaptive` that exposes the same handful of
+/// options used throughout the app.
+class AdaptiveProgressIndicator extends StatelessWidget {
+  const AdaptiveProgressIndicator({
+    super.key,
+    this.strokeWidth = 4.0,
+    this.color,
+    this.value,
+  });
+
+  final double strokeWidth;
+  final Color? color;
+  final double? value;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircularProgressIndicator.adaptive(
+      strokeWidth: strokeWidth,
+      value: value,
+      valueColor: color == null ? null : AlwaysStoppedAnimation<Color>(color!),
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_slider.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_slider.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Platform-aware slider.
+///
+/// Uses `Slider.adaptive` which renders a `CupertinoSlider` on iOS/macOS and
+/// a Material `Slider` elsewhere.
+class AdaptiveSlider extends StatelessWidget {
+  const AdaptiveSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.onChangeEnd,
+    this.min = 0.0,
+    this.max = 1.0,
+    this.divisions,
+  });
+
+  final double value;
+  final ValueChanged<double>? onChanged;
+  final ValueChanged<double>? onChangeEnd;
+  final double min;
+  final double max;
+  final int? divisions;
+
+  @override
+  Widget build(BuildContext context) {
+    return Slider.adaptive(
+      value: value,
+      onChanged: onChanged,
+      onChangeEnd: onChangeEnd,
+      min: min,
+      max: max,
+      divisions: divisions,
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_switch.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_switch.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+/// Platform-aware toggle switch.
+///
+/// Uses `Switch.adaptive` which renders a `CupertinoSwitch` on iOS/macOS and
+/// a Material `Switch` elsewhere.
+class AdaptiveSwitch extends StatelessWidget {
+  const AdaptiveSwitch({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.activeColor,
+  });
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final Color? activeColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Switch.adaptive(
+      value: value,
+      onChanged: onChanged,
+      activeThumbColor: activeColor,
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_text_field.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_text_field.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// Platform-aware single-line text field.
+///
+/// Renders a `CupertinoTextField` on iOS/macOS with a rounded-rect border
+/// matching the Material look, and a standard Material `TextField` elsewhere.
+/// Only exposes the options used in the app.
+class AdaptiveTextField extends StatelessWidget {
+  const AdaptiveTextField({
+    super.key,
+    this.controller,
+    this.hintText,
+    this.prefixIcon,
+    this.suffix,
+    this.onChanged,
+    this.onSubmitted,
+    this.keyboardType,
+    this.textInputAction,
+    this.autofocus = false,
+  });
+
+  final TextEditingController? controller;
+  final String? hintText;
+  final Widget? prefixIcon;
+  final Widget? suffix;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final TextInputType? keyboardType;
+  final TextInputAction? textInputAction;
+  final bool autofocus;
+
+  bool _isCupertino(BuildContext context) {
+    final platform = Theme.of(context).platform;
+    return platform == TargetPlatform.iOS ||
+        platform == TargetPlatform.macOS;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isCupertino(context)) {
+      final colorScheme = Theme.of(context).colorScheme;
+      return CupertinoTextField(
+        controller: controller,
+        placeholder: hintText,
+        prefix: prefixIcon == null
+            ? null
+            : Padding(
+                padding: const EdgeInsets.only(left: 12, right: 8),
+                child: IconTheme(
+                  data: IconThemeData(
+                    color: colorScheme.onSurfaceVariant,
+                    size: 20,
+                  ),
+                  child: prefixIcon!,
+                ),
+              ),
+        suffix: suffix == null
+            ? null
+            : Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: suffix,
+              ),
+        onChanged: onChanged,
+        onSubmitted: onSubmitted,
+        keyboardType: keyboardType,
+        textInputAction: textInputAction,
+        autofocus: autofocus,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(12),
+        ),
+      );
+    }
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: hintText,
+        prefixIcon: prefixIcon,
+        suffixIcon: suffix,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 16,
+          vertical: 12,
+        ),
+      ),
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      keyboardType: keyboardType,
+      textInputAction: textInputAction,
+      autofocus: autofocus,
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/adaptive/adaptive_widgets.dart
+++ b/frontend/lib/shared/widgets/adaptive/adaptive_widgets.dart
@@ -1,0 +1,14 @@
+/// Barrel file for platform-adaptive widgets.
+///
+/// Import this file to get Material/Cupertino-aware building blocks that
+/// match the host platform's UX conventions.
+library;
+
+export 'adaptive_bottom_sheet.dart';
+export 'adaptive_button.dart';
+export 'adaptive_dialog.dart';
+export 'adaptive_icon_button.dart';
+export 'adaptive_progress_indicator.dart';
+export 'adaptive_slider.dart';
+export 'adaptive_switch.dart';
+export 'adaptive_text_field.dart';


### PR DESCRIPTION
Introduce shared/widgets/adaptive/ with platform-aware wrappers
(buttons, dialogs, switches, sliders, progress indicators, text
fields, bottom sheets, icon buttons) and migrate interactive UI
across features to use them so controls follow Cupertino style on
iOS/macOS and Material style on Android.