### PR TITLE
Add comprehensive widget tests for all major screens

### DIFF
--- a/frontend/lib/core/services/image_picker_service.dart
+++ b/frontend/lib/core/services/image_picker_service.dart
@@ -1,0 +1,63 @@
+import 'dart:typed_data';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+/// Result returned by [ImagePickerService.pickImage].
+class PickedImage {
+  /// Decoded bytes of the picked image.
+  final Uint8List bytes;
+
+  /// MIME type derived from the file extension (e.g. `image/jpeg`).
+  final String mimeType;
+
+  const PickedImage({required this.bytes, required this.mimeType});
+}
+
+/// Thin abstraction over [ImagePicker] so screens can be tested with
+/// in-memory fakes instead of triggering the real picker UI.
+abstract class ImagePickerService {
+  /// Asks the user to pick an image from [source]. Returns `null` when
+  /// the user cancels the picker.
+  Future<PickedImage?> pickImage(ImageSource source);
+}
+
+class _DefaultImagePickerService implements ImagePickerService {
+  final ImagePicker _picker = ImagePicker();
+
+  @override
+  Future<PickedImage?> pickImage(ImageSource source) async {
+    final image = await _picker.pickImage(
+      source: source,
+      maxWidth: 1024,
+      maxHeight: 1024,
+      imageQuality: 85,
+    );
+    if (image == null) return null;
+
+    final bytes = await image.readAsBytes();
+    return PickedImage(bytes: bytes, mimeType: _mimeType(image.path));
+  }
+
+  String _mimeType(String path) {
+    switch (path.split('.').last.toLowerCase()) {
+      case 'jpg':
+      case 'jpeg':
+        return 'image/jpeg';
+      case 'png':
+        return 'image/png';
+      case 'gif':
+        return 'image/gif';
+      case 'webp':
+        return 'image/webp';
+      default:
+        return 'image/jpeg';
+    }
+  }
+}
+
+/// Provides the [ImagePickerService] singleton. Override in tests with
+/// a fake implementation.
+final imagePickerServiceProvider = Provider<ImagePickerService>((ref) {
+  return _DefaultImagePickerService();
+});

--- a/frontend/lib/features/camera/presentation/screens/camera_screen.dart
+++ b/frontend/lib/features/camera/presentation/screens/camera_screen.dart
@@ -1,4 +1,5 @@
 import 'package:context_app/common/config/app_colors.dart';
+import 'package:context_app/core/services/image_picker_service.dart';
 import 'package:context_app/features/camera/providers.dart';
 import 'package:context_app/features/camera/presentation/controllers/camera_controller.dart';
 import 'package:context_app/features/camera/presentation/widgets/analysis_result_card.dart';
@@ -21,7 +22,6 @@ class CameraScreen extends ConsumerStatefulWidget {
 }
 
 class _CameraScreenState extends ConsumerState<CameraScreen> {
-  final ImagePicker _picker = ImagePicker();
   Uint8List? _displayImage;
 
   @override
@@ -35,25 +35,19 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
 
   Future<void> _pickImage(ImageSource source) async {
     try {
-      final XFile? image = await _picker.pickImage(
-        source: source,
-        maxWidth: 1024,
-        maxHeight: 1024,
-        imageQuality: 85,
-      );
+      final picked = await ref
+          .read(imagePickerServiceProvider)
+          .pickImage(source);
 
-      if (image == null) return;
-
-      final bytes = await image.readAsBytes();
-      final mimeType = _getMimeType(image.path);
+      if (picked == null) return;
 
       setState(() {
-        _displayImage = bytes;
+        _displayImage = picked.bytes;
       });
 
       // 設定圖片並開始分析
-      ref.read(cameraControllerProvider.notifier).setImage(bytes);
-      await _analyzeImage(bytes, mimeType);
+      ref.read(cameraControllerProvider.notifier).setImage(picked.bytes);
+      await _analyzeImage(picked.bytes, picked.mimeType);
     } catch (e) {
       debugPrint('Error picking image: $e');
       ref.read(cameraControllerProvider.notifier).setError(e.toString());
@@ -80,23 +74,6 @@ class _CameraScreenState extends ConsumerState<CameraScreen> {
     } catch (e) {
       debugPrint('Error analyzing image: $e');
       controller.setError('camera.analysis_error'.tr());
-    }
-  }
-
-  String _getMimeType(String path) {
-    final extension = path.split('.').last.toLowerCase();
-    switch (extension) {
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'png':
-        return 'image/png';
-      case 'gif':
-        return 'image/gif';
-      case 'webp':
-        return 'image/webp';
-      default:
-        return 'image/jpeg';
     }
   }
 

--- a/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
+++ b/frontend/lib/features/quick_guide/presentation/screens/quick_guide_screen.dart
@@ -1,4 +1,5 @@
 import 'package:context_app/common/config/app_colors.dart';
+import 'package:context_app/core/services/image_picker_service.dart';
 import 'package:context_app/features/ads/presentation/widgets/watch_ad_dialog.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/explore/domain/models/place_category.dart';
@@ -27,8 +28,6 @@ class QuickGuideScreen extends ConsumerStatefulWidget {
 }
 
 class _QuickGuideScreenState extends ConsumerState<QuickGuideScreen> {
-  final ImagePicker _picker = ImagePicker();
-
   @override
   void dispose() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -78,22 +77,16 @@ class _QuickGuideScreenState extends ConsumerState<QuickGuideScreen> {
     final locale =
         EasyLocalization.of(context)?.locale.toLanguageTag() ?? 'zh-TW';
     try {
-      final XFile? image = await _picker.pickImage(
-        source: source,
-        maxWidth: 1024,
-        maxHeight: 1024,
-        imageQuality: 85,
-      );
-      if (image == null) return;
-
-      final bytes = await image.readAsBytes();
-      final mimeType = _mimeType(image.path);
+      final picked = await ref
+          .read(imagePickerServiceProvider)
+          .pickImage(source);
+      if (picked == null) return;
 
       await ref
           .read(quickGuideControllerProvider.notifier)
           .analyzeImage(
-            imageBytes: bytes,
-            mimeType: mimeType,
+            imageBytes: picked.bytes,
+            mimeType: picked.mimeType,
             language: locale,
           );
     } catch (e) {
@@ -107,22 +100,6 @@ class _QuickGuideScreenState extends ConsumerState<QuickGuideScreen> {
     return locale?.languageCode == 'zh'
         ? Language.traditionalChinese
         : Language.english;
-  }
-
-  String _mimeType(String path) {
-    switch (path.split('.').last.toLowerCase()) {
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg';
-      case 'png':
-        return 'image/png';
-      case 'gif':
-        return 'image/gif';
-      case 'webp':
-        return 'image/webp';
-      default:
-        return 'image/jpeg';
-    }
   }
 
   @override

--- a/frontend/test/fakes/fake_image_analysis_service.dart
+++ b/frontend/test/fakes/fake_image_analysis_service.dart
@@ -1,0 +1,38 @@
+import 'dart:typed_data';
+
+import 'package:context_app/features/camera/domain/models/image_analysis_result.dart';
+import 'package:context_app/features/camera/domain/services/image_analysis_service.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+
+/// Fake [ImageAnalysisService] used by widget tests.
+class FakeImageAnalysisService implements ImageAnalysisService {
+  final ImageAnalysisResult result;
+  final Exception? error;
+
+  Uint8List? lastImageBytes;
+  String? lastMimeType;
+  String? lastLanguage;
+
+  FakeImageAnalysisService({
+    ImageAnalysisResult? result,
+    this.error,
+  }) : result = result ??
+            const ImageAnalysisResult(
+              name: 'Fake Landmark',
+              description: 'A fake landmark used for widget tests.',
+              category: PlaceCategory.modernUrban,
+            );
+
+  @override
+  Future<ImageAnalysisResult> analyzeImage({
+    required Uint8List imageBytes,
+    required String mimeType,
+    String language = 'zh-TW',
+  }) async {
+    lastImageBytes = imageBytes;
+    lastMimeType = mimeType;
+    lastLanguage = language;
+    if (error != null) throw error!;
+    return result;
+  }
+}

--- a/frontend/test/fakes/fake_image_picker_service.dart
+++ b/frontend/test/fakes/fake_image_picker_service.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+
+import 'package:context_app/core/services/image_picker_service.dart';
+import 'package:image_picker/image_picker.dart';
+
+/// Fake [ImagePickerService] backed by a seeded result. Records the last
+/// requested [ImageSource] so tests can assert which button was tapped.
+class FakeImagePickerService implements ImagePickerService {
+  PickedImage? _result;
+  Exception? _error;
+
+  /// The source passed in the most recent [pickImage] call, or `null` if
+  /// the picker has not been invoked yet.
+  ImageSource? lastSource;
+
+  /// Number of times [pickImage] has been called.
+  int pickCount = 0;
+
+  FakeImagePickerService({PickedImage? result, Exception? error})
+    : _result = result,
+      _error = error;
+
+  /// Convenience constructor that returns a small fake JPEG.
+  factory FakeImagePickerService.withImage({
+    String mimeType = 'image/jpeg',
+  }) {
+    return FakeImagePickerService(
+      result: PickedImage(
+        bytes: Uint8List.fromList(const [0x89, 0x50, 0x4e, 0x47]),
+        mimeType: mimeType,
+      ),
+    );
+  }
+
+  /// Convenience constructor that simulates the user cancelling the picker.
+  factory FakeImagePickerService.cancelled() => FakeImagePickerService();
+
+  /// Re-arms the fake to return [result] on the next call.
+  void stub({PickedImage? result, Exception? error}) {
+    _result = result;
+    _error = error;
+  }
+
+  @override
+  Future<PickedImage?> pickImage(ImageSource source) async {
+    pickCount += 1;
+    lastSource = source;
+    if (_error != null) throw _error!;
+    return _result;
+  }
+}

--- a/frontend/test/fakes/fake_location_service.dart
+++ b/frontend/test/fakes/fake_location_service.dart
@@ -1,0 +1,19 @@
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/domain/services/location_service.dart';
+
+/// Fake [LocationService] that returns a fixed location without touching GPS.
+class FakeLocationService implements LocationService {
+  final PlaceLocation location;
+  final Exception? error;
+
+  FakeLocationService({
+    this.location = const PlaceLocation(latitude: 25.034, longitude: 121.564),
+    this.error,
+  });
+
+  @override
+  Future<PlaceLocation> getCurrentLocation() async {
+    if (error != null) throw error!;
+    return location;
+  }
+}

--- a/frontend/test/fakes/fake_narration_service.dart
+++ b/frontend/test/fakes/fake_narration_service.dart
@@ -1,0 +1,34 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/services/narration_service.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+
+/// Fake [NarrationService] that returns a seeded text result.
+class FakeNarrationService implements NarrationService {
+  final String text;
+  final Exception? error;
+
+  Place? lastPlace;
+  Set<NarrationAspect>? lastAspects;
+  Language? lastLanguage;
+
+  FakeNarrationService({
+    this.text =
+        'This is a fake narration used for widget tests. '
+        'It contains multiple sentences. How are you? Great!',
+    this.error,
+  });
+
+  @override
+  Future<NarrationGenerationResult> generateNarration({
+    required Place place,
+    required Set<NarrationAspect> aspects,
+    required Language language,
+  }) async {
+    lastPlace = place;
+    lastAspects = aspects;
+    lastLanguage = language;
+    if (error != null) throw error!;
+    return (text: text, grounding: null);
+  }
+}

--- a/frontend/test/fakes/fake_places_repository.dart
+++ b/frontend/test/fakes/fake_places_repository.dart
@@ -1,0 +1,43 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/domain/repositories/places_repository.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+
+/// Fake [PlacesRepository] that returns seeded results.
+class FakePlacesRepository implements PlacesRepository {
+  List<Place> nearbyPlaces;
+  List<Place> searchResults;
+
+  FakePlacesRepository({
+    this.nearbyPlaces = const [],
+    this.searchResults = const [],
+  });
+
+  @override
+  Future<List<Place>> getNearbyPlaces(
+    PlaceLocation location, {
+    required Language language,
+    required double radius,
+  }) async {
+    return nearbyPlaces;
+  }
+
+  @override
+  Future<List<Place>> searchPlaces(
+    String query, {
+    required Language language,
+  }) async {
+    return searchResults;
+  }
+
+  @override
+  Future<Place?> getPlaceById(
+    String placeId, {
+    required Language language,
+  }) async {
+    for (final place in [...nearbyPlaces, ...searchResults]) {
+      if (place.id == placeId) return place;
+    }
+    return null;
+  }
+}

--- a/frontend/test/fakes/fake_quick_guide_ai_service.dart
+++ b/frontend/test/fakes/fake_quick_guide_ai_service.dart
@@ -1,0 +1,29 @@
+import 'dart:typed_data';
+
+import 'package:context_app/features/quick_guide/domain/services/quick_guide_ai_service.dart';
+
+/// Fake [QuickGuideAiService] that returns a seeded description.
+class FakeQuickGuideAiService implements QuickGuideAiService {
+  final String response;
+  final Exception? error;
+
+  /// Captures the last describe request for assertion.
+  Uint8List? lastImageBytes;
+  String? lastMimeType;
+  String? lastLanguage;
+
+  FakeQuickGuideAiService({this.response = 'A friendly description.', this.error});
+
+  @override
+  Future<String> describeImage({
+    required Uint8List imageBytes,
+    required String mimeType,
+    String language = 'zh-TW',
+  }) async {
+    lastImageBytes = imageBytes;
+    lastMimeType = mimeType;
+    lastLanguage = language;
+    if (error != null) throw error!;
+    return response;
+  }
+}

--- a/frontend/test/fakes/fake_rewarded_ad_service.dart
+++ b/frontend/test/fakes/fake_rewarded_ad_service.dart
@@ -3,7 +3,7 @@ import 'package:context_app/features/ads/domain/services/rewarded_ad_service.dar
 /// Fake [RewardedAdService] that records interactions without touching ads.
 class FakeRewardedAdService implements RewardedAdService {
   bool _isReady;
-  bool _watchOutcome;
+  final bool _watchOutcome;
   int loadCount = 0;
   int showCount = 0;
 

--- a/frontend/test/fakes/fake_rewarded_ad_service.dart
+++ b/frontend/test/fakes/fake_rewarded_ad_service.dart
@@ -1,0 +1,31 @@
+import 'package:context_app/features/ads/domain/services/rewarded_ad_service.dart';
+
+/// Fake [RewardedAdService] that records interactions without touching ads.
+class FakeRewardedAdService implements RewardedAdService {
+  bool _isReady;
+  bool _watchOutcome;
+  int loadCount = 0;
+  int showCount = 0;
+
+  FakeRewardedAdService({bool isReady = true, bool watchOutcome = true})
+    : _isReady = isReady,
+      _watchOutcome = watchOutcome;
+
+  @override
+  Future<void> loadAd() async {
+    loadCount += 1;
+    _isReady = true;
+  }
+
+  @override
+  Future<bool> showAd() async {
+    showCount += 1;
+    return _watchOutcome;
+  }
+
+  @override
+  bool get isAdReady => _isReady;
+
+  @override
+  void dispose() {}
+}

--- a/frontend/test/fakes/fake_subscription_service.dart
+++ b/frontend/test/fakes/fake_subscription_service.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
+import 'package:context_app/features/subscription/domain/services/subscription_service.dart';
+
+/// Fake [SubscriptionService] backed by an in-memory state controller.
+///
+/// Tests can seed the current status and drive purchase/restore outcomes
+/// without touching RevenueCat.
+class FakeSubscriptionService implements SubscriptionService {
+  SubscriptionStatus _current;
+  SubscriptionStatus? _purchaseResult;
+  SubscriptionStatus? _restoreResult;
+  Exception? _purchaseError;
+  Exception? _restoreError;
+
+  final StreamController<SubscriptionStatus> _controller =
+      StreamController<SubscriptionStatus>.broadcast();
+
+  FakeSubscriptionService({SubscriptionStatus initial = SubscriptionStatus.free})
+    : _current = initial;
+
+  /// Sets the value returned by [purchase].
+  ///
+  /// When [status] is `null`, [purchase] simulates user cancellation.
+  /// When [error] is non-null, [purchase] throws it.
+  void stubPurchase({SubscriptionStatus? status, Exception? error}) {
+    _purchaseResult = status;
+    _purchaseError = error;
+  }
+
+  /// Sets the value returned by [restorePurchases].
+  void stubRestore({SubscriptionStatus? status, Exception? error}) {
+    _restoreResult = status;
+    _restoreError = error;
+  }
+
+  /// Emits [status] on [statusStream] and updates current status.
+  void emit(SubscriptionStatus status) {
+    _current = status;
+    _controller.add(status);
+  }
+
+  @override
+  Future<void> initialize({required String apiKey}) async {
+    _controller.add(_current);
+  }
+
+  @override
+  Future<void> logIn(String userId) async {}
+
+  @override
+  Future<void> logOut() async {}
+
+  @override
+  Stream<SubscriptionStatus> get statusStream => _controller.stream;
+
+  @override
+  Future<SubscriptionStatus> getStatus() async => _current;
+
+  @override
+  Future<SubscriptionStatus?> purchase() async {
+    if (_purchaseError != null) throw _purchaseError!;
+    if (_purchaseResult != null) {
+      emit(_purchaseResult!);
+    }
+    return _purchaseResult;
+  }
+
+  @override
+  Future<SubscriptionStatus> restorePurchases() async {
+    if (_restoreError != null) throw _restoreError!;
+    final result = _restoreResult ?? _current;
+    emit(result);
+    return result;
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+}

--- a/frontend/test/fakes/fake_tts_service.dart
+++ b/frontend/test/fakes/fake_tts_service.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:context_app/features/narration/domain/services/tts_service.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+
+/// Fake [TtsService] that records calls and exposes controllable event streams.
+class FakeTtsService implements TtsService {
+  final StreamController<TtsProgress> _progress =
+      StreamController<TtsProgress>.broadcast();
+  final StreamController<void> _complete =
+      StreamController<void>.broadcast();
+  final StreamController<void> _start = StreamController<void>.broadcast();
+  final StreamController<void> _pause = StreamController<void>.broadcast();
+  final StreamController<String> _error = StreamController<String>.broadcast();
+
+  bool initialized = false;
+  String? lastSpokenText;
+  Language? lastLanguage;
+  int speakCount = 0;
+  int pauseCount = 0;
+  int stopCount = 0;
+
+  @override
+  Stream<TtsProgress> get onProgress => _progress.stream;
+
+  @override
+  Stream<void> get onComplete => _complete.stream;
+
+  @override
+  Stream<void> get onStart => _start.stream;
+
+  @override
+  Stream<void> get onPause => _pause.stream;
+
+  @override
+  Stream<String> get onError => _error.stream;
+
+  @override
+  Future<void> initialize() async {
+    initialized = true;
+  }
+
+  @override
+  Future<bool> speak(String text) async {
+    lastSpokenText = text;
+    speakCount += 1;
+    _start.add(null);
+    return true;
+  }
+
+  @override
+  Future<void> pause() async {
+    pauseCount += 1;
+    _pause.add(null);
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCount += 1;
+  }
+
+  @override
+  Future<void> setLanguage(Language language) async {
+    lastLanguage = language;
+  }
+
+  @override
+  Future<void> setRate(double rate) async {}
+
+  @override
+  Future<void> setVolume(double volume) async {}
+
+  @override
+  Future<void> setPitch(double pitch) async {}
+
+  @override
+  Future<void> dispose() async {
+    await _progress.close();
+    await _complete.close();
+    await _start.close();
+    await _pause.close();
+    await _error.close();
+  }
+
+  /// Simulates TTS reaching the end of the current text.
+  void emitComplete() => _complete.add(null);
+
+  /// Simulates a TTS error.
+  void emitError(String message) => _error.add(message);
+}

--- a/frontend/test/fakes/in_memory_journey_repository.dart
+++ b/frontend/test/fakes/in_memory_journey_repository.dart
@@ -1,0 +1,24 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
+
+/// In-memory [JourneyRepository] used by widget tests.
+class InMemoryJourneyRepository implements JourneyRepository {
+  final Map<String, JourneyEntry> _entries = {};
+
+  @override
+  Future<List<JourneyEntry>> getAll() async {
+    final list = _entries.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return list;
+  }
+
+  @override
+  Future<void> save(JourneyEntry entry) async {
+    _entries[entry.id] = entry;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _entries.remove(id);
+  }
+}

--- a/frontend/test/fakes/in_memory_quick_guide_repository.dart
+++ b/frontend/test/fakes/in_memory_quick_guide_repository.dart
@@ -1,0 +1,24 @@
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/quick_guide/domain/repositories/quick_guide_repository.dart';
+
+/// In-memory [QuickGuideRepository] used by widget tests.
+class InMemoryQuickGuideRepository implements QuickGuideRepository {
+  final Map<String, QuickGuideEntry> _entries = {};
+
+  @override
+  Future<List<QuickGuideEntry>> getAll() async {
+    final list = _entries.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return list;
+  }
+
+  @override
+  Future<void> save(QuickGuideEntry entry) async {
+    _entries[entry.id] = entry;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _entries.remove(id);
+  }
+}

--- a/frontend/test/fakes/in_memory_saved_locations_repository.dart
+++ b/frontend/test/fakes/in_memory_saved_locations_repository.dart
@@ -1,0 +1,29 @@
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+
+/// In-memory [SavedLocationsRepository] used by widget tests.
+class InMemorySavedLocationsRepository implements SavedLocationsRepository {
+  final Map<String, SavedLocationEntry> _entries = {};
+
+  @override
+  Future<List<SavedLocationEntry>> getAll() async {
+    final list = _entries.values.toList()
+      ..sort((a, b) => b.savedAt.compareTo(a.savedAt));
+    return list;
+  }
+
+  @override
+  Future<void> save(SavedLocationEntry entry) async {
+    _entries[entry.placeId] = entry;
+  }
+
+  @override
+  Future<void> delete(String placeId) async {
+    _entries.remove(placeId);
+  }
+
+  @override
+  Future<bool> isSaved(String placeId) async {
+    return _entries.containsKey(placeId);
+  }
+}

--- a/frontend/test/fakes/in_memory_trip_repository.dart
+++ b/frontend/test/fakes/in_memory_trip_repository.dart
@@ -1,0 +1,27 @@
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/domain/repositories/trip_repository.dart';
+
+/// In-memory [TripRepository] used by widget tests.
+class InMemoryTripRepository implements TripRepository {
+  final Map<String, Trip> _trips = {};
+
+  @override
+  Future<List<Trip>> getAll() async {
+    final list = _trips.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return list;
+  }
+
+  @override
+  Future<Trip?> getById(String id) async => _trips[id];
+
+  @override
+  Future<void> save(Trip trip) async {
+    _trips[trip.id] = trip;
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _trips.remove(id);
+  }
+}

--- a/frontend/test/fakes/in_memory_usage_repository.dart
+++ b/frontend/test/fakes/in_memory_usage_repository.dart
@@ -1,0 +1,36 @@
+import 'package:context_app/features/usage/domain/models/usage_status.dart';
+import 'package:context_app/features/usage/domain/repositories/usage_repository.dart';
+
+/// In-memory [UsageRepository] used by widget tests.
+class InMemoryUsageRepository implements UsageRepository {
+  int _usedToday;
+  int _bonusFromAds;
+  final int _dailyFreeLimit;
+
+  InMemoryUsageRepository({
+    int usedToday = 0,
+    int bonusFromAds = 0,
+    int dailyFreeLimit = 1,
+  }) : _usedToday = usedToday,
+       _bonusFromAds = bonusFromAds,
+       _dailyFreeLimit = dailyFreeLimit;
+
+  @override
+  Future<UsageStatus> getUsageStatus() async {
+    return UsageStatus(
+      usedToday: _usedToday,
+      dailyFreeLimit: _dailyFreeLimit,
+      bonusFromAds: _bonusFromAds,
+    );
+  }
+
+  @override
+  Future<void> consumeUsage() async {
+    _usedToday += 1;
+  }
+
+  @override
+  Future<void> addBonusFromAd() async {
+    _bonusFromAds += 1;
+  }
+}

--- a/frontend/test/features/camera/presentation/screens/camera_screen_test.dart
+++ b/frontend/test/features/camera/presentation/screens/camera_screen_test.dart
@@ -1,9 +1,16 @@
+import 'package:context_app/core/services/image_picker_service.dart';
+import 'package:context_app/features/camera/domain/models/image_analysis_result.dart';
 import 'package:context_app/features/camera/presentation/screens/camera_screen.dart';
+import 'package:context_app/features/camera/presentation/widgets/analysis_result_card.dart';
 import 'package:context_app/features/camera/providers.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../../../../fakes/fake_image_analysis_service.dart';
+import '../../../../fakes/fake_image_picker_service.dart';
 import '../../../../helpers/pump_app.dart';
 
 void main() {
@@ -42,17 +49,103 @@ void main() {
         _thenBackNavigationIsAvailable();
       },
     );
+
+    testWidgets(
+      'given a stubbed picker, when the user taps take photo, '
+      'then the picker is invoked with the camera source',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+
+        await _givenCameraScreen(tester, picker: picker);
+        await _whenUserTapsTakePhoto(tester);
+
+        _thenPickerWasCalledWith(picker, ImageSource.camera);
+      },
+    );
+
+    testWidgets(
+      'given a stubbed picker, when the user taps gallery, '
+      'then the picker is invoked with the gallery source',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+
+        await _givenCameraScreen(tester, picker: picker);
+        await _whenUserTapsFromGallery(tester);
+
+        _thenPickerWasCalledWith(picker, ImageSource.gallery);
+      },
+    );
+
+    testWidgets(
+      'given the picker returns an image and analysis succeeds, '
+      'when the user picks from gallery, then the analysis result card is shown',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+        final analyzer = FakeImageAnalysisService(
+          result: const ImageAnalysisResult(
+            name: 'Senso-ji Temple',
+            description: 'A beloved Buddhist temple in Asakusa.',
+            category: PlaceCategory.historicalCultural,
+          ),
+        );
+
+        await _givenCameraScreen(tester, picker: picker, analyzer: analyzer);
+        await _whenUserTapsFromGallery(tester);
+        await _whenAnalysisCompletes(tester);
+
+        _thenAnalysisResultIsShown();
+      },
+    );
+
+    testWidgets(
+      'given the user cancels the picker, when the picker returns null, '
+      'then the source selector remains visible',
+      (tester) async {
+        final picker = FakeImagePickerService.cancelled();
+
+        await _givenCameraScreen(tester, picker: picker);
+        await _whenUserTapsTakePhoto(tester);
+
+        _thenImageSourceButtonsAreVisible();
+      },
+    );
   });
 }
 
-Future<void> _givenCameraScreen(WidgetTester tester) async {
+Future<void> _givenCameraScreen(
+  WidgetTester tester, {
+  FakeImagePickerService? picker,
+  FakeImageAnalysisService? analyzer,
+}) async {
   await pumpScreen(
     tester,
     child: const CameraScreen(),
     overrides: [
-      imageAnalysisServiceProvider.overrideWithValue(FakeImageAnalysisService()),
+      imageAnalysisServiceProvider.overrideWithValue(
+        analyzer ?? FakeImageAnalysisService(),
+      ),
+      imagePickerServiceProvider.overrideWithValue(
+        picker ?? FakeImagePickerService.withImage(),
+      ),
     ],
   );
+}
+
+Future<void> _whenUserTapsTakePhoto(WidgetTester tester) async {
+  await tester.tap(find.text('camera.take_photo'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+Future<void> _whenUserTapsFromGallery(WidgetTester tester) async {
+  await tester.tap(find.text('camera.from_gallery'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+Future<void> _whenAnalysisCompletes(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
 }
 
 void _thenInstructionCopyIsVisible() {
@@ -71,4 +164,17 @@ void _thenRetakeIconIsHidden() {
 
 void _thenBackNavigationIsAvailable() {
   expect(find.byIcon(Icons.arrow_back_ios_new), findsOneWidget);
+}
+
+void _thenPickerWasCalledWith(
+  FakeImagePickerService picker,
+  ImageSource source,
+) {
+  expect(picker.pickCount, equals(1));
+  expect(picker.lastSource, equals(source));
+}
+
+void _thenAnalysisResultIsShown() {
+  expect(find.byType(AnalysisResultCard), findsOneWidget);
+  expect(find.text('camera.start_narration'), findsOneWidget);
 }

--- a/frontend/test/features/camera/presentation/screens/camera_screen_test.dart
+++ b/frontend/test/features/camera/presentation/screens/camera_screen_test.dart
@@ -1,0 +1,74 @@
+import 'package:context_app/features/camera/presentation/screens/camera_screen.dart';
+import 'package:context_app/features/camera/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_image_analysis_service.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('CameraScreen', () {
+    testWidgets(
+      'given no captured image, when the screen loads, '
+      'then the instruction text and source buttons are rendered',
+      (tester) async {
+        await _givenCameraScreen(tester);
+
+        _thenInstructionCopyIsVisible();
+        _thenImageSourceButtonsAreVisible();
+      },
+    );
+
+    testWidgets(
+      'given no captured image, when the screen loads, '
+      'then the retake icon is hidden from the app bar',
+      (tester) async {
+        await _givenCameraScreen(tester);
+
+        _thenRetakeIconIsHidden();
+      },
+    );
+
+    testWidgets(
+      'given no captured image, when the screen loads, '
+      'then the app bar back button is visible',
+      (tester) async {
+        await _givenCameraScreen(tester);
+
+        _thenBackNavigationIsAvailable();
+      },
+    );
+  });
+}
+
+Future<void> _givenCameraScreen(WidgetTester tester) async {
+  await pumpScreen(
+    tester,
+    child: const CameraScreen(),
+    overrides: [
+      imageAnalysisServiceProvider.overrideWithValue(FakeImageAnalysisService()),
+    ],
+  );
+}
+
+void _thenInstructionCopyIsVisible() {
+  expect(find.text('camera.instruction'), findsOneWidget);
+  expect(find.text('camera.instruction_subtitle'), findsOneWidget);
+}
+
+void _thenImageSourceButtonsAreVisible() {
+  expect(find.text('camera.take_photo'), findsOneWidget);
+  expect(find.text('camera.from_gallery'), findsOneWidget);
+}
+
+void _thenRetakeIconIsHidden() {
+  expect(find.byIcon(Icons.refresh), findsNothing);
+}
+
+void _thenBackNavigationIsAvailable() {
+  expect(find.byIcon(Icons.arrow_back_ios_new), findsOneWidget);
+}

--- a/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
+++ b/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
@@ -1,0 +1,107 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/presentation/screens/explore_screen.dart';
+import 'package:context_app/features/explore/providers.dart';
+import 'package:context_app/features/saved_locations/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_location_service.dart';
+import '../../../../fakes/fake_places_repository.dart';
+import '../../../../fakes/in_memory_saved_locations_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('ExploreScreen', () {
+    testWidgets(
+      'given no nearby places, when the screen loads, '
+      'then the empty-state copy is shown',
+      (tester) async {
+        await _givenExploreScreen(tester);
+
+        _thenEmptyStateIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given nearby places are returned, when the screen loads, '
+      'then a place card is rendered for each place',
+      (tester) async {
+        final places = [
+          buildPlace(id: 'p1', name: 'Senso-ji', userRatingCount: 200),
+          buildPlace(id: 'p2', name: 'Meiji Shrine', userRatingCount: 150),
+        ];
+
+        await _givenExploreScreen(tester, places: places);
+
+        _thenPlaceNamesAreVisible(['Senso-ji', 'Meiji Shrine']);
+      },
+    );
+
+    testWidgets(
+      'given a review-count filter of 500, when the list is filtered, '
+      'then only places with enough ratings are shown',
+      (tester) async {
+        final places = [
+          buildPlace(id: 'p1', name: 'Popular', userRatingCount: 800),
+          buildPlace(id: 'p2', name: 'Obscure', userRatingCount: 20),
+        ];
+
+        await _givenExploreScreen(
+          tester,
+          places: places,
+          minReviewCount: 500,
+        );
+
+        _thenPlaceNamesAreVisible(['Popular']);
+        _thenPlaceNamesAreHidden(['Obscure']);
+      },
+    );
+  });
+}
+
+Future<void> _givenExploreScreen(
+  WidgetTester tester, {
+  List<Place> places = const [],
+  int minReviewCount = 0,
+}) async {
+  await pumpScreen(
+    tester,
+    child: const ExploreScreen(),
+    overrides: [
+      locationServiceProvider.overrideWithValue(FakeLocationService()),
+      placesRepositoryProvider.overrideWithValue(
+        FakePlacesRepository(nearbyPlaces: places),
+      ),
+      savedLocationsRepositoryProvider.overrideWithValue(
+        InMemorySavedLocationsRepository(),
+      ),
+      minReviewCountProvider.overrideWith((ref) => minReviewCount),
+    ],
+  );
+  // Let async searchNearby + filtered places provider resolve.
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void _thenEmptyStateIsVisible() {
+  expect(find.text('No places found'), findsOneWidget);
+}
+
+void _thenPlaceNamesAreVisible(List<String> names) {
+  for (final name in names) {
+    expect(find.text(name), findsOneWidget);
+  }
+}
+
+void _thenPlaceNamesAreHidden(List<String> names) {
+  for (final name in names) {
+    expect(find.text(name), findsNothing);
+  }
+}

--- a/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
+++ b/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
@@ -2,7 +2,6 @@ import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/explore/presentation/screens/explore_screen.dart';
 import 'package:context_app/features/explore/providers.dart';
 import 'package:context_app/features/saved_locations/providers.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/frontend/test/features/journey/presentation/screens/journey_screen_test.dart
+++ b/frontend/test/features/journey/presentation/screens/journey_screen_test.dart
@@ -1,0 +1,161 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/presentation/screens/journey_screen.dart';
+import 'package:context_app/features/journey/presentation/widgets/quick_guide_timeline_entry.dart';
+import 'package:context_app/features/journey/presentation/widgets/timeline_entry.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/in_memory_journey_repository.dart';
+import '../../../../fakes/in_memory_quick_guide_repository.dart';
+import '../../../../fakes/in_memory_trip_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('JourneyScreen', () {
+    testWidgets(
+      'given no entries, when the timeline view is active, '
+      'then the empty state message is rendered',
+      (tester) async {
+        await _givenJourneyScreen(tester);
+
+        _thenNoEntriesStateIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given the user has journey entries, when the timeline view loads, '
+      'then each entry is displayed as a timeline card',
+      (tester) async {
+        final entries = [
+          buildJourneyEntry(id: 'e1'),
+          buildJourneyEntry(id: 'e2'),
+        ];
+
+        await _givenJourneyScreen(tester, seededJourneys: entries);
+
+        _thenTimelineShowsEntries(count: 2);
+      },
+    );
+
+    testWidgets(
+      'given the timeline view is active, when the user opens search, '
+      'then a search input is revealed',
+      (tester) async {
+        await _givenJourneyScreen(tester);
+
+        await _whenUserTapsSearchToggle(tester);
+
+        _thenSearchFieldIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given the timeline view is active, when the user selects by-trip, '
+      'then the trip grid replaces the timeline list',
+      (tester) async {
+        final trip = buildTrip(id: 't1', name: 'Kyoto Trip');
+
+        await _givenJourneyScreen(tester, seededTrips: [trip]);
+        await _whenUserSelectsByTripView(tester);
+
+        _thenTripCardIsVisible('Kyoto Trip');
+      },
+    );
+
+    testWidgets(
+      'given narration and quick-guide entries exist, when the user filters '
+      'to narration only, then only narration entries remain',
+      (tester) async {
+        final narration = buildJourneyEntry(id: 'n1');
+        final quick = buildQuickGuideEntry(id: 'q1');
+
+        await _givenJourneyScreen(
+          tester,
+          seededJourneys: [narration],
+          seededQuickGuides: [quick],
+        );
+        await _whenUserTapsNarrationFilterChip(tester);
+
+        _thenOnlyNarrationEntriesRemain();
+      },
+    );
+  });
+}
+
+Future<void> _givenJourneyScreen(
+  WidgetTester tester, {
+  List<JourneyEntry> seededJourneys = const [],
+  List<Trip> seededTrips = const [],
+  List<QuickGuideEntry> seededQuickGuides = const [],
+}) async {
+  final journeyRepo = InMemoryJourneyRepository();
+  for (final entry in seededJourneys) {
+    await journeyRepo.save(entry);
+  }
+  final quickGuideRepo = InMemoryQuickGuideRepository();
+  for (final entry in seededQuickGuides) {
+    await quickGuideRepo.save(entry);
+  }
+  final tripRepo = InMemoryTripRepository();
+  for (final trip in seededTrips) {
+    await tripRepo.save(trip);
+  }
+
+  await pumpScreen(
+    tester,
+    child: const JourneyScreen(),
+    overrides: [
+      journeyRepositoryProvider.overrideWithValue(journeyRepo),
+      quickGuideRepositoryProvider.overrideWithValue(quickGuideRepo),
+      tripRepositoryProvider.overrideWithValue(tripRepo),
+    ],
+  );
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserTapsSearchToggle(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.search));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserSelectsByTripView(WidgetTester tester) async {
+  await tester.tap(find.text('passport.view_by_trip'));
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserTapsNarrationFilterChip(WidgetTester tester) async {
+  await tester.tap(find.text('passport.filter_narration'));
+  await tester.pump(const Duration(milliseconds: 10));
+}
+
+void _thenNoEntriesStateIsVisible() {
+  expect(find.text('passport.no_entries'), findsOneWidget);
+}
+
+void _thenTimelineShowsEntries({required int count}) {
+  expect(find.byType(TimelineEntry), findsNWidgets(count));
+}
+
+void _thenSearchFieldIsVisible() {
+  expect(find.byType(TextField), findsOneWidget);
+}
+
+void _thenTripCardIsVisible(String name) {
+  expect(find.text(name), findsOneWidget);
+}
+
+void _thenOnlyNarrationEntriesRemain() {
+  expect(find.byType(TimelineEntry), findsOneWidget);
+  expect(find.byType(QuickGuideTimelineEntry), findsNothing);
+}

--- a/frontend/test/features/journey/presentation/screens/save_success_screen_test.dart
+++ b/frontend/test/features/journey/presentation/screens/save_success_screen_test.dart
@@ -120,12 +120,14 @@ void _thenPrimaryActionsAreVisible() {
 
 Future<void> _whenUserTapsViewPassport(WidgetTester tester) async {
   await tester.tap(find.text('passport.view_button'));
-  await tester.pumpAndSettle();
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 Future<void> _whenUserTapsContinueTour(WidgetTester tester) async {
   await tester.tap(find.text('passport.continue_tour'));
-  await tester.pumpAndSettle();
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 Future<void> _whenHostLaunchesSuccessScreen(
@@ -134,7 +136,8 @@ Future<void> _whenHostLaunchesSuccessScreen(
 ) async {
   final BuildContext context = tester.element(find.byType(_HostLauncher));
   GoRouter.of(context).push('/success', extra: place);
-  await tester.pumpAndSettle();
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 class _HostLauncher extends StatelessWidget {

--- a/frontend/test/features/journey/presentation/screens/save_success_screen_test.dart
+++ b/frontend/test/features/journey/presentation/screens/save_success_screen_test.dart
@@ -1,0 +1,146 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/journey/presentation/screens/save_success_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('SaveSuccessScreen', () {
+    testWidgets(
+      'given a saved place, when the screen is shown, '
+      'then it displays the place name and success actions',
+      (tester) async {
+        final place = buildPlace(name: 'Kiyomizu-dera');
+
+        await _givenSaveSuccessScreen(tester, place: place);
+
+        _thenSavedPlaceInfoIsVisible(place);
+        _thenPrimaryActionsAreVisible();
+      },
+    );
+
+    testWidgets(
+      'given a view-passport handler, when the user taps view button, '
+      'then the handler is invoked',
+      (tester) async {
+        var viewCount = 0;
+        final place = buildPlace();
+
+        await _givenSaveSuccessScreen(
+          tester,
+          place: place,
+          onViewPassport: () => viewCount += 1,
+        );
+        await _whenUserTapsViewPassport(tester);
+
+        expect(viewCount, equals(1));
+      },
+    );
+
+    testWidgets(
+      'given a continue-tour handler, when the user taps continue, '
+      'then the handler is invoked',
+      (tester) async {
+        var continueCount = 0;
+        final place = buildPlace();
+
+        await _givenSaveSuccessScreen(
+          tester,
+          place: place,
+          onContinueTour: () => continueCount += 1,
+        );
+        await _whenUserTapsContinueTour(tester);
+
+        expect(continueCount, equals(1));
+      },
+    );
+
+    testWidgets(
+      'given no continue handler is provided, when the user taps continue, '
+      'then the router pops the screen',
+      (tester) async {
+        final place = buildPlace();
+        final routes = [
+          GoRoute(path: '/', builder: (_, __) => const _HostLauncher()),
+          GoRoute(
+            path: '/success',
+            builder: (context, state) => SaveSuccessScreen(
+              place: state.extra! as Place,
+            ),
+          ),
+        ];
+
+        await pumpRouterApp(
+          tester,
+          routes: routes,
+          initialLocation: '/',
+        );
+        await _whenHostLaunchesSuccessScreen(tester, place);
+        await _whenUserTapsContinueTour(tester);
+
+        expect(find.byType(SaveSuccessScreen), findsNothing);
+        expect(find.byType(_HostLauncher), findsOneWidget);
+      },
+    );
+  });
+}
+
+Future<void> _givenSaveSuccessScreen(
+  WidgetTester tester, {
+  required Place place,
+  VoidCallback? onViewPassport,
+  VoidCallback? onContinueTour,
+}) async {
+  await pumpScreen(
+    tester,
+    child: SaveSuccessScreen(
+      place: place,
+      onViewPassport: onViewPassport,
+      onContinueTour: onContinueTour,
+    ),
+  );
+}
+
+void _thenSavedPlaceInfoIsVisible(Place place) {
+  expect(find.text(place.name), findsOneWidget);
+  expect(find.text(place.formattedAddress), findsOneWidget);
+}
+
+void _thenPrimaryActionsAreVisible() {
+  expect(find.text('passport.view_button'), findsOneWidget);
+  expect(find.text('passport.continue_tour'), findsOneWidget);
+}
+
+Future<void> _whenUserTapsViewPassport(WidgetTester tester) async {
+  await tester.tap(find.text('passport.view_button'));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _whenUserTapsContinueTour(WidgetTester tester) async {
+  await tester.tap(find.text('passport.continue_tour'));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _whenHostLaunchesSuccessScreen(
+  WidgetTester tester,
+  Place place,
+) async {
+  final BuildContext context = tester.element(find.byType(_HostLauncher));
+  GoRouter.of(context).push('/success', extra: place);
+  await tester.pumpAndSettle();
+}
+
+class _HostLauncher extends StatelessWidget {
+  const _HostLauncher();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('host')));
+}

--- a/frontend/test/features/main_screen_test.dart
+++ b/frontend/test/features/main_screen_test.dart
@@ -9,7 +9,6 @@ import 'package:context_app/features/settings/presentation/screens/settings_scre
 import 'package:context_app/features/subscription/providers.dart';
 import 'package:context_app/features/trip/providers/trip_providers.dart';
 import 'package:context_app/features/usage/providers.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/frontend/test/features/main_screen_test.dart
+++ b/frontend/test/features/main_screen_test.dart
@@ -1,0 +1,134 @@
+import 'package:context_app/features/camera/providers.dart';
+import 'package:context_app/features/explore/providers.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/journey/presentation/screens/journey_screen.dart';
+import 'package:context_app/features/main_screen.dart';
+import 'package:context_app/features/quick_guide/presentation/screens/quick_guide_screen.dart';
+import 'package:context_app/features/saved_locations/providers.dart';
+import 'package:context_app/features/settings/presentation/screens/settings_screen.dart';
+import 'package:context_app/features/subscription/providers.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:context_app/features/usage/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../fakes/fake_image_analysis_service.dart';
+import '../fakes/fake_location_service.dart';
+import '../fakes/fake_places_repository.dart';
+import '../fakes/fake_quick_guide_ai_service.dart';
+import '../fakes/fake_subscription_service.dart';
+import '../fakes/in_memory_journey_repository.dart';
+import '../fakes/in_memory_quick_guide_repository.dart';
+import '../fakes/in_memory_saved_locations_repository.dart';
+import '../fakes/in_memory_trip_repository.dart';
+import '../fakes/in_memory_usage_repository.dart';
+import '../helpers/pump_app.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('MainScreen', () {
+    testWidgets(
+      'given an empty explore tab by default, when the screen is shown, '
+      'then the explore tab content is rendered',
+      (tester) async {
+        await _givenMainScreen(tester);
+
+        _thenExploreTabIsActive();
+      },
+    );
+
+    testWidgets(
+      'given initial tab is the passport, when the screen is shown, '
+      'then the journey tab content is rendered',
+      (tester) async {
+        await _givenMainScreen(tester, initialIndex: 2);
+
+        _thenJourneyTabIsActive();
+      },
+    );
+
+    testWidgets(
+      'given the explore tab is active, when the user selects quick guide, '
+      'then the quick guide tab content is rendered',
+      (tester) async {
+        await _givenMainScreen(tester);
+
+        await _whenUserSelectsBottomNavItem(tester, 'bottom_nav.quick_guide');
+
+        _thenQuickGuideTabIsActive();
+      },
+    );
+
+    testWidgets(
+      'given the explore tab is active, when the user selects settings, '
+      'then the settings tab content is rendered',
+      (tester) async {
+        await _givenMainScreen(tester);
+
+        await _whenUserSelectsBottomNavItem(tester, 'bottom_nav.settings');
+
+        _thenSettingsTabIsActive();
+      },
+    );
+  });
+}
+
+Future<void> _givenMainScreen(
+  WidgetTester tester, {
+  int initialIndex = 0,
+}) async {
+  await pumpScreen(
+    tester,
+    child: MainScreen(initialIndex: initialIndex),
+    overrides: _mainScreenOverrides(),
+  );
+}
+
+List<Override> _mainScreenOverrides() {
+  return [
+    placesRepositoryProvider.overrideWithValue(FakePlacesRepository()),
+    locationServiceProvider.overrideWithValue(FakeLocationService()),
+    journeyRepositoryProvider.overrideWithValue(InMemoryJourneyRepository()),
+    quickGuideRepositoryProvider.overrideWithValue(
+      InMemoryQuickGuideRepository(),
+    ),
+    tripRepositoryProvider.overrideWithValue(InMemoryTripRepository()),
+    savedLocationsRepositoryProvider.overrideWithValue(
+      InMemorySavedLocationsRepository(),
+    ),
+    usageRepositoryProvider.overrideWithValue(InMemoryUsageRepository()),
+    subscriptionServiceProvider.overrideWithValue(FakeSubscriptionService()),
+    quickGuideAiServiceProvider.overrideWithValue(FakeQuickGuideAiService()),
+    imageAnalysisServiceProvider.overrideWithValue(FakeImageAnalysisService()),
+  ];
+}
+
+Future<void> _whenUserSelectsBottomNavItem(
+  WidgetTester tester,
+  String labelKey,
+) async {
+  await tester.tap(find.text(labelKey));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void _thenExploreTabIsActive() {
+  expect(find.byType(MainScreen), findsOneWidget);
+  // Explore tab is the default index; its screen renders the title key.
+  expect(find.text('explore.title'), findsOneWidget);
+}
+
+void _thenJourneyTabIsActive() {
+  expect(find.byType(JourneyScreen), findsOneWidget);
+}
+
+void _thenQuickGuideTabIsActive() {
+  expect(find.byType(QuickGuideScreen), findsOneWidget);
+}
+
+void _thenSettingsTabIsActive() {
+  expect(find.byType(SettingsScreen), findsOneWidget);
+}

--- a/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
@@ -4,7 +4,6 @@ import 'package:context_app/features/narration/presentation/screens/narration_sc
 import 'package:context_app/features/narration/presentation/widgets/narration_control_panel.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_transcript_area.dart';
 import 'package:context_app/features/narration/providers.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../fakes/fake_tts_service.dart';

--- a/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
@@ -1,0 +1,124 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/narration/presentation/screens/narration_screen.dart';
+import 'package:context_app/features/narration/presentation/widgets/narration_control_panel.dart';
+import 'package:context_app/features/narration/presentation/widgets/narration_transcript_area.dart';
+import 'package:context_app/features/narration/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_tts_service.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('NarrationScreen', () {
+    testWidgets(
+      'given a place and narration content, when the screen loads, '
+      'then the place name and transcript area are rendered',
+      (tester) async {
+        final place = buildPlace(name: 'Kinkaku-ji');
+        final content = buildNarrationContent();
+
+        await _givenNarrationScreen(tester, place: place, content: content);
+
+        _thenPlaceNameIsVisible(place.name);
+        _thenTranscriptAreaIsVisible();
+        _thenControlPanelIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given autoPlay is true, when the screen finishes initialising, '
+      'then the TTS fake receives a speak command',
+      (tester) async {
+        final tts = FakeTtsService();
+        final content = buildNarrationContent();
+
+        await _givenNarrationScreen(
+          tester,
+          place: buildPlace(),
+          content: content,
+          autoPlay: true,
+          tts: tts,
+        );
+        await _whenInitializationCompletes(tester);
+
+        _thenTtsReceivedSpeakCommand(tts);
+      },
+    );
+
+    testWidgets(
+      'given autoPlay is false, when the screen finishes initialising, '
+      'then the TTS fake is not asked to speak',
+      (tester) async {
+        final tts = FakeTtsService();
+
+        await _givenNarrationScreen(
+          tester,
+          place: buildPlace(),
+          content: buildNarrationContent(),
+          tts: tts,
+        );
+        await _whenInitializationCompletes(tester);
+
+        _thenTtsDidNotSpeak(tts);
+      },
+    );
+  });
+}
+
+Future<void> _givenNarrationScreen(
+  WidgetTester tester, {
+  required Place place,
+  required NarrationContent content,
+  bool autoPlay = false,
+  FakeTtsService? tts,
+}) async {
+  final resolvedTts = tts ?? FakeTtsService();
+  await pumpScreen(
+    tester,
+    child: NarrationScreen(
+      place: place,
+      narrationContent: content,
+      autoPlay: autoPlay,
+    ),
+    overrides: [
+      ttsServiceProvider.overrideWithValue(resolvedTts),
+    ],
+  );
+  // Initial addPostFrameCallback schedules initializeWithContent.
+  await tester.pump(const Duration(milliseconds: 10));
+}
+
+Future<void> _whenInitializationCompletes(WidgetTester tester) async {
+  // initializeWithContent awaits initialize() and setLanguage() before
+  // transitioning to the ready state.
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void _thenPlaceNameIsVisible(String name) {
+  expect(find.text(name), findsOneWidget);
+}
+
+void _thenTranscriptAreaIsVisible() {
+  expect(find.byType(NarrationTranscriptArea), findsOneWidget);
+}
+
+void _thenControlPanelIsVisible() {
+  expect(find.byType(NarrationControlPanel), findsOneWidget);
+}
+
+void _thenTtsReceivedSpeakCommand(FakeTtsService tts) {
+  expect(tts.speakCount, greaterThanOrEqualTo(1));
+}
+
+void _thenTtsDidNotSpeak(FakeTtsService tts) {
+  expect(tts.speakCount, equals(0));
+}

--- a/frontend/test/features/narration/presentation/screens/select_narration_aspect_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/select_narration_aspect_screen_test.dart
@@ -6,7 +6,6 @@ import 'package:context_app/features/narration/presentation/screens/select_narra
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/frontend/test/features/narration/presentation/screens/select_narration_aspect_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/select_narration_aspect_screen_test.dart
@@ -1,0 +1,111 @@
+import 'package:context_app/features/ads/providers.dart';
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/presentation/screens/select_narration_aspect_screen.dart';
+import 'package:context_app/features/narration/providers.dart';
+import 'package:context_app/features/usage/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_narration_service.dart';
+import '../../../../fakes/fake_rewarded_ad_service.dart';
+import '../../../../fakes/in_memory_journey_repository.dart';
+import '../../../../fakes/in_memory_usage_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('SelectNarrationAspectScreen', () {
+    testWidgets(
+      'given a place, when the screen loads, '
+      'then the place name and address are rendered',
+      (tester) async {
+        final place = buildPlace(
+          name: 'Fushimi Inari',
+          formattedAddress: '68 Fukakusa Yabunouchicho',
+        );
+
+        await _givenSelectNarrationAspectScreen(tester, place: place);
+
+        _thenPlaceHeaderIsVisible(place.name);
+        _thenAddressIsVisible(place.formattedAddress);
+      },
+    );
+
+    testWidgets(
+      'given the screen is open, when the user has not selected any aspect, '
+      'then the start button is disabled',
+      (tester) async {
+        await _givenSelectNarrationAspectScreen(tester, aspects: const {});
+
+        _thenStartButtonIsDisabled(tester);
+      },
+    );
+
+    testWidgets(
+      'given the screen is open, when an aspect is preselected, '
+      'then the start button is enabled',
+      (tester) async {
+        await _givenSelectNarrationAspectScreen(
+          tester,
+          aspects: const {NarrationAspect.historicalBackground},
+        );
+
+        _thenStartButtonIsEnabled(tester);
+      },
+    );
+  });
+}
+
+Future<void> _givenSelectNarrationAspectScreen(
+  WidgetTester tester, {
+  required Place place,
+  Set<NarrationAspect>? aspects,
+}) async {
+  await pumpScreen(
+    tester,
+    child: SelectNarrationAspectScreen(place: place),
+    overrides: [
+      narrationServiceProvider.overrideWithValue(FakeNarrationService()),
+      journeyRepositoryProvider.overrideWithValue(InMemoryJourneyRepository()),
+      usageRepositoryProvider.overrideWithValue(InMemoryUsageRepository()),
+      rewardedAdServiceProvider.overrideWithValue(FakeRewardedAdService()),
+      if (aspects != null)
+        narrationAspectsProvider.overrideWith((ref) => aspects),
+    ],
+  );
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void _thenPlaceHeaderIsVisible(String name) {
+  expect(find.text(name), findsOneWidget);
+}
+
+void _thenAddressIsVisible(String address) {
+  expect(find.text(address), findsOneWidget);
+}
+
+void _thenStartButtonIsDisabled(WidgetTester tester) {
+  expect(_findStartButton(tester).onPressed, isNull);
+}
+
+void _thenStartButtonIsEnabled(WidgetTester tester) {
+  expect(_findStartButton(tester).onPressed, isNotNull);
+}
+
+/// Locates the primary start CTA by finding the [AdaptiveButton] that
+/// wraps the start-button label.
+AdaptiveButton _findStartButton(WidgetTester tester) {
+  final buttonFinder = find.ancestor(
+    of: find.text('config_screen.start_button'),
+    matching: find.byType(AdaptiveButton),
+  );
+  return tester.widget<AdaptiveButton>(buttonFinder.first);
+}

--- a/frontend/test/features/quick_guide/presentation/screens/quick_guide_screen_test.dart
+++ b/frontend/test/features/quick_guide/presentation/screens/quick_guide_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:context_app/core/services/image_picker_service.dart';
 import 'package:context_app/features/ads/domain/services/rewarded_ad_service.dart';
 import 'package:context_app/features/ads/providers.dart';
 import 'package:context_app/features/quick_guide/presentation/screens/quick_guide_screen.dart';
@@ -6,7 +7,9 @@ import 'package:context_app/features/trip/providers/trip_providers.dart';
 import 'package:context_app/features/usage/providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 
+import '../../../../fakes/fake_image_picker_service.dart';
 import '../../../../fakes/fake_quick_guide_ai_service.dart';
 import '../../../../fakes/fake_rewarded_ad_service.dart';
 import '../../../../fakes/in_memory_quick_guide_repository.dart';
@@ -39,6 +42,66 @@ void main() {
         _thenImageSourceButtonsAreVisible();
       },
     );
+
+    testWidgets(
+      'given remaining quota, when the user taps take photo, '
+      'then the image picker is invoked with the camera source',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+
+        await _givenQuickGuideScreen(tester, picker: picker);
+        await _whenUserTapsTakePhoto(tester);
+
+        _thenPickerWasCalledWith(picker, ImageSource.camera);
+      },
+    );
+
+    testWidgets(
+      'given remaining quota, when the user taps gallery, '
+      'then the image picker is invoked with the gallery source',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+
+        await _givenQuickGuideScreen(tester, picker: picker);
+        await _whenUserTapsFromGallery(tester);
+
+        _thenPickerWasCalledWith(picker, ImageSource.gallery);
+      },
+    );
+
+    testWidgets(
+      'given the user cancels the picker, when no image is returned, '
+      'then the source selector remains visible',
+      (tester) async {
+        final picker = FakeImagePickerService.cancelled();
+
+        await _givenQuickGuideScreen(tester, picker: picker);
+        await _whenUserTapsTakePhoto(tester);
+
+        _thenImageSourceButtonsAreVisible();
+      },
+    );
+
+    testWidgets(
+      'given the daily quota is exhausted, when the user taps take photo, '
+      'then the image picker is not invoked',
+      (tester) async {
+        final picker = FakeImagePickerService.withImage();
+        final exhaustedUsage = InMemoryUsageRepository(
+          usedToday: 1,
+          dailyFreeLimit: 1,
+        );
+
+        await _givenQuickGuideScreen(
+          tester,
+          picker: picker,
+          usage: exhaustedUsage,
+        );
+        await _whenUserTapsTakePhoto(tester);
+
+        _thenPickerWasNotCalled(picker);
+      },
+    );
   });
 }
 
@@ -46,6 +109,7 @@ Future<void> _givenQuickGuideScreen(
   WidgetTester tester, {
   InMemoryUsageRepository? usage,
   RewardedAdService? rewardedAdService,
+  FakeImagePickerService? picker,
 }) async {
   await pumpScreen(
     tester,
@@ -62,8 +126,23 @@ Future<void> _givenQuickGuideScreen(
       rewardedAdServiceProvider.overrideWithValue(
         rewardedAdService ?? FakeRewardedAdService(),
       ),
+      imagePickerServiceProvider.overrideWithValue(
+        picker ?? FakeImagePickerService.withImage(),
+      ),
     ],
   );
+}
+
+Future<void> _whenUserTapsTakePhoto(WidgetTester tester) async {
+  await tester.tap(find.text('quick_guide.take_photo'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+Future<void> _whenUserTapsFromGallery(WidgetTester tester) async {
+  await tester.tap(find.text('quick_guide.from_gallery'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
 }
 
 void _thenTitleAndInstructionsAreVisible() {
@@ -75,4 +154,16 @@ void _thenTitleAndInstructionsAreVisible() {
 void _thenImageSourceButtonsAreVisible() {
   expect(find.text('quick_guide.take_photo'), findsOneWidget);
   expect(find.text('quick_guide.from_gallery'), findsOneWidget);
+}
+
+void _thenPickerWasCalledWith(
+  FakeImagePickerService picker,
+  ImageSource source,
+) {
+  expect(picker.pickCount, equals(1));
+  expect(picker.lastSource, equals(source));
+}
+
+void _thenPickerWasNotCalled(FakeImagePickerService picker) {
+  expect(picker.pickCount, equals(0));
 }

--- a/frontend/test/features/quick_guide/presentation/screens/quick_guide_screen_test.dart
+++ b/frontend/test/features/quick_guide/presentation/screens/quick_guide_screen_test.dart
@@ -1,0 +1,78 @@
+import 'package:context_app/features/ads/domain/services/rewarded_ad_service.dart';
+import 'package:context_app/features/ads/providers.dart';
+import 'package:context_app/features/quick_guide/presentation/screens/quick_guide_screen.dart';
+import 'package:context_app/features/quick_guide/providers.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:context_app/features/usage/providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_quick_guide_ai_service.dart';
+import '../../../../fakes/fake_rewarded_ad_service.dart';
+import '../../../../fakes/in_memory_quick_guide_repository.dart';
+import '../../../../fakes/in_memory_trip_repository.dart';
+import '../../../../fakes/in_memory_usage_repository.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('QuickGuideScreen', () {
+    testWidgets(
+      'given no picked image, when the screen loads, '
+      'then the large title and instruction copy are visible',
+      (tester) async {
+        await _givenQuickGuideScreen(tester);
+
+        _thenTitleAndInstructionsAreVisible();
+      },
+    );
+
+    testWidgets(
+      'given no picked image, when the screen loads, '
+      'then the take-photo and gallery buttons are visible',
+      (tester) async {
+        await _givenQuickGuideScreen(tester);
+
+        _thenImageSourceButtonsAreVisible();
+      },
+    );
+  });
+}
+
+Future<void> _givenQuickGuideScreen(
+  WidgetTester tester, {
+  InMemoryUsageRepository? usage,
+  RewardedAdService? rewardedAdService,
+}) async {
+  await pumpScreen(
+    tester,
+    child: const QuickGuideScreen(),
+    overrides: [
+      quickGuideRepositoryProvider.overrideWithValue(
+        InMemoryQuickGuideRepository(),
+      ),
+      quickGuideAiServiceProvider.overrideWithValue(FakeQuickGuideAiService()),
+      tripRepositoryProvider.overrideWithValue(InMemoryTripRepository()),
+      usageRepositoryProvider.overrideWithValue(
+        usage ?? InMemoryUsageRepository(),
+      ),
+      rewardedAdServiceProvider.overrideWithValue(
+        rewardedAdService ?? FakeRewardedAdService(),
+      ),
+    ],
+  );
+}
+
+void _thenTitleAndInstructionsAreVisible() {
+  expect(find.text('quick_guide.title'), findsOneWidget);
+  expect(find.text('quick_guide.instruction'), findsOneWidget);
+  expect(find.text('quick_guide.instruction_subtitle'), findsOneWidget);
+}
+
+void _thenImageSourceButtonsAreVisible() {
+  expect(find.text('quick_guide.take_photo'), findsOneWidget);
+  expect(find.text('quick_guide.from_gallery'), findsOneWidget);
+}

--- a/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -2,10 +2,8 @@ import 'package:context_app/features/settings/presentation/screens/settings_scre
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
 import 'package:context_app/features/subscription/providers.dart';
-import 'package:context_app/features/usage/domain/models/usage_status.dart';
 import 'package:context_app/features/usage/providers.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -1,0 +1,141 @@
+import 'package:context_app/features/settings/presentation/screens/settings_screen.dart';
+import 'package:context_app/features/settings/providers.dart';
+import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
+import 'package:context_app/features/subscription/providers.dart';
+import 'package:context_app/features/usage/domain/models/usage_status.dart';
+import 'package:context_app/features/usage/providers.dart';
+import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/in_memory_usage_repository.dart';
+import '../../../../helpers/pump_app.dart';
+
+const _fakeVersionLabel = 'Version 9.9.9 (Build 42)';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('SettingsScreen', () {
+    testWidgets(
+      'given a free user with remaining usage, when the screen loads, '
+      'then the preferences, usage and upgrade CTA are visible',
+      (tester) async {
+        await _givenSettingsScreen(tester, status: SubscriptionStatus.free);
+
+        _thenPreferencesSectionIsVisible();
+        _thenUsageSectionIsVisible();
+        _thenUpgradeCtaIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given a premium user, when the screen loads, '
+      'then the premium-active tile is shown instead of the upgrade CTA',
+      (tester) async {
+        await _givenSettingsScreen(
+          tester,
+          status: const SubscriptionStatus(isPremium: true),
+        );
+
+        _thenPremiumTileIsVisible();
+        _thenUpgradeCtaIsHidden();
+      },
+    );
+
+    testWidgets(
+      'given the current theme is dark, when the user toggles theme off, '
+      'then the theme switch value flips to light',
+      (tester) async {
+        await _givenSettingsScreen(tester);
+
+        await _whenUserTogglesThemeSwitch(tester);
+
+        _thenThemeSwitchIsOff(tester);
+      },
+    );
+
+    testWidgets(
+      'given the app version future resolves, when the screen settles, '
+      'then the version label is rendered',
+      (tester) async {
+        await _givenSettingsScreen(tester);
+
+        await _whenVersionFutureResolves(tester);
+
+        _thenVersionLabelIsVisible();
+      },
+    );
+  });
+}
+
+Future<void> _givenSettingsScreen(
+  WidgetTester tester, {
+  InMemoryUsageRepository? usage,
+  SubscriptionStatus status = SubscriptionStatus.free,
+}) async {
+  final usageRepo = usage ?? InMemoryUsageRepository(usedToday: 0);
+
+  await pumpScreen(
+    tester,
+    child: const SettingsScreen(),
+    overrides: [
+      usageRepositoryProvider.overrideWithValue(usageRepo),
+      usageStatusProvider.overrideWith(
+        (ref) async => usageRepo.getUsageStatus(),
+      ),
+      subscriptionStatusProvider.overrideWith(
+        (ref) => Stream<SubscriptionStatus>.value(status),
+      ),
+      appVersionStringProvider.overrideWith((ref) async => _fakeVersionLabel),
+    ],
+  );
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserTogglesThemeSwitch(WidgetTester tester) async {
+  await tester.tap(find.byType(AdaptiveSwitch));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenVersionFutureResolves(WidgetTester tester) async {
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void _thenPreferencesSectionIsVisible() {
+  expect(find.text('SETTINGS.PREFERENCES'), findsOneWidget);
+  expect(find.text('settings.change_language'), findsOneWidget);
+  expect(find.text('settings.theme'), findsOneWidget);
+}
+
+void _thenUsageSectionIsVisible() {
+  expect(find.text('SETTINGS.DAILY_USAGE'), findsOneWidget);
+  expect(find.text('settings.daily_usage'), findsOneWidget);
+}
+
+void _thenUpgradeCtaIsVisible() {
+  expect(find.text('subscription.upgrade_cta'), findsOneWidget);
+}
+
+void _thenPremiumTileIsVisible() {
+  expect(find.text('subscription.premium_active'), findsOneWidget);
+}
+
+void _thenUpgradeCtaIsHidden() {
+  expect(find.text('subscription.upgrade_cta'), findsNothing);
+}
+
+void _thenThemeSwitchIsOff(WidgetTester tester) {
+  final switchWidget = tester.widget<AdaptiveSwitch>(
+    find.byType(AdaptiveSwitch),
+  );
+  expect(switchWidget.value, isFalse);
+}
+
+void _thenVersionLabelIsVisible() {
+  expect(find.text(_fakeVersionLabel), findsOneWidget);
+}

--- a/frontend/test/features/subscription/presentation/screens/subscription_screen_test.dart
+++ b/frontend/test/features/subscription/presentation/screens/subscription_screen_test.dart
@@ -1,0 +1,150 @@
+import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
+import 'package:context_app/features/subscription/presentation/screens/subscription_screen.dart';
+import 'package:context_app/features/subscription/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../fakes/fake_subscription_service.dart';
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('SubscriptionScreen', () {
+    testWidgets(
+      'given the paywall is displayed, when the screen loads, '
+      'then the benefits and primary actions are visible',
+      (tester) async {
+        await _givenSubscriptionScreen(tester);
+
+        _thenBenefitsAreVisible();
+        _thenPrimaryActionsAreVisible();
+      },
+    );
+
+    testWidgets(
+      'given a successful purchase, when the user subscribes, '
+      'then the screen dismisses with a positive result',
+      (tester) async {
+        final service = FakeSubscriptionService()
+          ..stubPurchase(
+            status: const SubscriptionStatus(isPremium: true),
+          );
+
+        await _givenSubscriptionScreenOnRoute(tester, service);
+        await _whenUserTapsSubscribe(tester);
+
+        _thenSubscriptionScreenIsDismissed();
+      },
+    );
+
+    testWidgets(
+      'given no prior purchase, when the user taps restore, '
+      'then the no-purchases snackbar is shown',
+      (tester) async {
+        final service = FakeSubscriptionService()
+          ..stubRestore(status: SubscriptionStatus.free);
+
+        await _givenSubscriptionScreen(tester, service: service);
+        await _whenUserTapsRestore(tester);
+
+        _thenNoPurchasesSnackbarIsShown();
+      },
+    );
+
+    testWidgets(
+      'given a premium restore result, when the user taps restore, '
+      'then the screen dismisses with a positive result',
+      (tester) async {
+        final service = FakeSubscriptionService()
+          ..stubRestore(
+            status: const SubscriptionStatus(isPremium: true),
+          );
+
+        await _givenSubscriptionScreenOnRoute(tester, service);
+        await _whenUserTapsRestore(tester);
+
+        _thenSubscriptionScreenIsDismissed();
+      },
+    );
+  });
+}
+
+Future<void> _givenSubscriptionScreen(
+  WidgetTester tester, {
+  FakeSubscriptionService? service,
+}) async {
+  final resolved = service ?? FakeSubscriptionService();
+  await pumpScreen(
+    tester,
+    child: const SubscriptionScreen(),
+    overrides: [
+      subscriptionServiceProvider.overrideWithValue(resolved),
+    ],
+  );
+}
+
+Future<void> _givenSubscriptionScreenOnRoute(
+  WidgetTester tester,
+  FakeSubscriptionService service,
+) async {
+  await pumpRouterApp(
+    tester,
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const _Host()),
+      GoRoute(
+        path: '/subscription',
+        builder: (_, __) => const SubscriptionScreen(),
+      ),
+    ],
+    overrides: [subscriptionServiceProvider.overrideWithValue(service)],
+  );
+  final context = tester.element(find.byType(_Host));
+  GoRouter.of(context).push('/subscription');
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserTapsSubscribe(WidgetTester tester) async {
+  await tester.tap(find.text('subscription.subscribe'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+Future<void> _whenUserTapsRestore(WidgetTester tester) async {
+  await tester.tap(find.text('subscription.restore'));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void _thenBenefitsAreVisible() {
+  expect(find.text('subscription.benefit_no_ads'), findsOneWidget);
+  expect(find.text('subscription.benefit_unlimited'), findsOneWidget);
+  expect(find.text('subscription.benefit_route'), findsOneWidget);
+}
+
+void _thenPrimaryActionsAreVisible() {
+  expect(find.text('subscription.subscribe'), findsOneWidget);
+  expect(find.text('subscription.restore'), findsOneWidget);
+}
+
+void _thenSubscriptionScreenIsDismissed() {
+  expect(find.byType(SubscriptionScreen), findsNothing);
+}
+
+void _thenNoPurchasesSnackbarIsShown() {
+  expect(find.text('subscription.no_purchases_found'), findsOneWidget);
+}
+
+class _Host extends StatelessWidget {
+  const _Host();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('host')));
+}

--- a/frontend/test/features/subscription/presentation/screens/subscription_screen_test.dart
+++ b/frontend/test/features/subscription/presentation/screens/subscription_screen_test.dart
@@ -104,22 +104,20 @@ Future<void> _givenSubscriptionScreenOnRoute(
   );
   final context = tester.element(find.byType(_Host));
   GoRouter.of(context).push('/subscription');
-  await tester.pump(const Duration(milliseconds: 20));
-  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 Future<void> _whenUserTapsSubscribe(WidgetTester tester) async {
   await tester.tap(find.text('subscription.subscribe'));
   await tester.pump();
-  await tester.pump(const Duration(milliseconds: 50));
-  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 Future<void> _whenUserTapsRestore(WidgetTester tester) async {
   await tester.tap(find.text('subscription.restore'));
   await tester.pump();
-  await tester.pump(const Duration(milliseconds: 50));
-  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 void _thenBenefitsAreVisible() {

--- a/frontend/test/features/trip/presentation/screens/trip_detail_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_detail_screen_test.dart
@@ -1,0 +1,150 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/presentation/widgets/timeline_entry.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/presentation/screens/trip_detail_screen.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/in_memory_journey_repository.dart';
+import '../../../../fakes/in_memory_quick_guide_repository.dart';
+import '../../../../fakes/in_memory_trip_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('TripDetailScreen', () {
+    testWidgets(
+      'given a trip with entries, when the detail screen loads, '
+      'then the trip name and each timeline entry are rendered',
+      (tester) async {
+        final trip = buildTrip(id: 'kyoto', name: 'Kyoto Temples');
+        final entry = buildJourneyEntry(id: 'e1', tripId: 'kyoto');
+
+        await _givenTripDetailScreen(
+          tester,
+          tripId: 'kyoto',
+          seededTrips: [trip],
+          seededJourneys: [entry],
+        );
+
+        _thenTripNameIsVisible('Kyoto Temples');
+        _thenAtLeastOneTimelineEntryIsShown();
+      },
+    );
+
+    testWidgets(
+      'given a trip with no entries, when the detail screen loads, '
+      'then the empty state is rendered',
+      (tester) async {
+        final trip = buildTrip(id: 'empty', name: 'Empty Trip');
+
+        await _givenTripDetailScreen(
+          tester,
+          tripId: 'empty',
+          seededTrips: [trip],
+        );
+
+        _thenEmptyStateIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given the uncategorized bucket, when the screen loads, '
+      'then the uncategorized title and checklist action are shown',
+      (tester) async {
+        final orphan = buildJourneyEntry(id: 'o1');
+
+        await _givenTripDetailScreen(
+          tester,
+          tripId: null,
+          seededJourneys: [orphan],
+        );
+
+        _thenUncategorizedTitleIsVisible();
+        _thenSelectionModeIsAvailable();
+      },
+    );
+
+    testWidgets(
+      'given uncategorized entries, when the user enters selection mode, '
+      'then the selection header replaces the default app bar',
+      (tester) async {
+        final orphan = buildJourneyEntry(id: 'o1');
+
+        await _givenTripDetailScreen(
+          tester,
+          tripId: null,
+          seededJourneys: [orphan],
+        );
+        await _whenUserEntersSelectionMode(tester);
+
+        _thenSelectionHeaderIsVisible();
+      },
+    );
+  });
+}
+
+Future<void> _givenTripDetailScreen(
+  WidgetTester tester, {
+  required String? tripId,
+  List<Trip> seededTrips = const [],
+  List<JourneyEntry> seededJourneys = const [],
+}) async {
+  final tripRepo = InMemoryTripRepository();
+  for (final trip in seededTrips) {
+    await tripRepo.save(trip);
+  }
+  final journeyRepo = InMemoryJourneyRepository();
+  for (final entry in seededJourneys) {
+    await journeyRepo.save(entry);
+  }
+  final quickGuideRepo = InMemoryQuickGuideRepository();
+
+  await pumpScreen(
+    tester,
+    child: TripDetailScreen(tripId: tripId),
+    overrides: [
+      tripRepositoryProvider.overrideWithValue(tripRepo),
+      journeyRepositoryProvider.overrideWithValue(journeyRepo),
+      quickGuideRepositoryProvider.overrideWithValue(quickGuideRepo),
+    ],
+  );
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserEntersSelectionMode(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.checklist));
+  await tester.pump(const Duration(milliseconds: 10));
+}
+
+void _thenTripNameIsVisible(String name) {
+  expect(find.text(name), findsOneWidget);
+}
+
+void _thenAtLeastOneTimelineEntryIsShown() {
+  expect(find.byType(TimelineEntry), findsAtLeastNWidgets(1));
+}
+
+void _thenEmptyStateIsVisible() {
+  expect(find.text('trip.no_items'), findsOneWidget);
+}
+
+void _thenUncategorizedTitleIsVisible() {
+  expect(find.text('trip.uncategorized'), findsOneWidget);
+}
+
+void _thenSelectionModeIsAvailable() {
+  expect(find.byIcon(Icons.checklist), findsOneWidget);
+}
+
+void _thenSelectionHeaderIsVisible() {
+  expect(find.text('trip.selected_count'), findsOneWidget);
+  expect(find.text('trip.select_all'), findsOneWidget);
+}

--- a/frontend/test/features/trip/presentation/screens/trip_edit_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_edit_screen_test.dart
@@ -1,0 +1,172 @@
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/presentation/screens/trip_edit_screen.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../fakes/in_memory_trip_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('TripEditScreen', () {
+    testWidgets(
+      'given the create mode, when the screen loads, '
+      'then the form fields and create action are visible',
+      (tester) async {
+        await _givenCreateScreen(tester);
+
+        _thenCreateTitleIsVisible();
+        _thenSaveActionUsesCreateLabel();
+      },
+    );
+
+    testWidgets(
+      'given create mode, when the user submits an empty name, '
+      'then the required-field error is shown',
+      (tester) async {
+        await _givenCreateScreen(tester);
+
+        await _whenUserTapsSave(tester);
+
+        _thenRequiredFieldErrorIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given create mode, when the user saves a valid trip, '
+      'then the trip is persisted and the screen pops',
+      (tester) async {
+        final tripRepo = InMemoryTripRepository();
+
+        await _givenCreateScreenWithRouter(tester, tripRepo);
+
+        await _whenUserEntersTripName(tester, 'Osaka Foodie Tour');
+        await _whenUserTapsSave(tester);
+
+        await _thenTripIsPersistedWithName(tripRepo, 'Osaka Foodie Tour');
+        _thenEditScreenIsDismissed();
+      },
+    );
+
+    testWidgets(
+      'given edit mode with an existing trip, when the screen loads, '
+      'then the existing trip name prefills the form',
+      (tester) async {
+        final tripRepo = InMemoryTripRepository();
+        await tripRepo.save(
+          buildTrip(id: 'existing', name: 'Prefilled Trip'),
+        );
+
+        await _givenEditScreen(tester, tripRepo: tripRepo, tripId: 'existing');
+
+        _thenTripNameFieldHasText('Prefilled Trip');
+      },
+    );
+  });
+}
+
+Future<void> _givenCreateScreen(
+  WidgetTester tester, {
+  InMemoryTripRepository? repo,
+}) async {
+  final tripRepo = repo ?? InMemoryTripRepository();
+  await pumpScreen(
+    tester,
+    child: const TripEditScreen(),
+    overrides: [tripRepositoryProvider.overrideWithValue(tripRepo)],
+  );
+}
+
+Future<void> _givenEditScreen(
+  WidgetTester tester, {
+  required InMemoryTripRepository tripRepo,
+  required String tripId,
+}) async {
+  await pumpScreen(
+    tester,
+    child: TripEditScreen(tripId: tripId),
+    overrides: [tripRepositoryProvider.overrideWithValue(tripRepo)],
+  );
+  // Let _loadExistingTrip async resolve.
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _givenCreateScreenWithRouter(
+  WidgetTester tester,
+  InMemoryTripRepository tripRepo,
+) async {
+  await pumpRouterApp(
+    tester,
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const _Host()),
+      GoRoute(path: '/trip/edit', builder: (_, __) => const TripEditScreen()),
+    ],
+    overrides: [tripRepositoryProvider.overrideWithValue(tripRepo)],
+  );
+  await tester.pump(const Duration(milliseconds: 10));
+  final context = tester.element(find.byType(_Host));
+  GoRouter.of(context).push('/trip/edit');
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserEntersTripName(
+  WidgetTester tester,
+  String name,
+) async {
+  await tester.enterText(find.byType(TextFormField), name);
+  await tester.pump();
+}
+
+Future<void> _whenUserTapsSave(WidgetTester tester) async {
+  await tester.tap(find.text('trip.create_action'));
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void _thenCreateTitleIsVisible() {
+  expect(find.text('trip.create_title'), findsOneWidget);
+}
+
+void _thenSaveActionUsesCreateLabel() {
+  expect(find.text('trip.create_action'), findsOneWidget);
+}
+
+void _thenRequiredFieldErrorIsVisible() {
+  expect(find.text('trip.name_required'), findsOneWidget);
+}
+
+Future<void> _thenTripIsPersistedWithName(
+  InMemoryTripRepository repo,
+  String expectedName,
+) async {
+  final trips = await repo.getAll();
+  final names = trips.map((Trip t) => t.name).toList();
+  expect(names, contains(expectedName));
+}
+
+void _thenEditScreenIsDismissed() {
+  expect(find.byType(TripEditScreen), findsNothing);
+}
+
+void _thenTripNameFieldHasText(String expected) {
+  final textField = find.byType(TextFormField);
+  expect(textField, findsOneWidget);
+  final widget = find.text(expected);
+  expect(widget, findsOneWidget);
+}
+
+class _Host extends StatelessWidget {
+  const _Host();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Scaffold(body: Center(child: Text('host')));
+}

--- a/frontend/test/features/trip/presentation/screens/trip_edit_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_edit_screen_test.dart
@@ -113,8 +113,9 @@ Future<void> _givenCreateScreenWithRouter(
   await tester.pump(const Duration(milliseconds: 10));
   final context = tester.element(find.byType(_Host));
   GoRouter.of(context).push('/trip/edit');
-  await tester.pump(const Duration(milliseconds: 20));
-  await tester.pump(const Duration(milliseconds: 20));
+  // Allow the push transition to complete.
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 Future<void> _whenUserEntersTripName(
@@ -127,8 +128,8 @@ Future<void> _whenUserEntersTripName(
 
 Future<void> _whenUserTapsSave(WidgetTester tester) async {
   await tester.tap(find.text('trip.create_action'));
-  await tester.pump(const Duration(milliseconds: 20));
-  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 void _thenCreateTitleIsVisible() {

--- a/frontend/test/features/trip/presentation/screens/trip_list_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_list_screen_test.dart
@@ -1,0 +1,154 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/providers.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/presentation/screens/trip_edit_screen.dart';
+import 'package:context_app/features/trip/presentation/screens/trip_list_screen.dart';
+import 'package:context_app/features/trip/presentation/widgets/trip_card.dart';
+import 'package:context_app/features/trip/providers/trip_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../fakes/in_memory_journey_repository.dart';
+import '../../../../fakes/in_memory_quick_guide_repository.dart';
+import '../../../../fakes/in_memory_trip_repository.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  group('TripListScreen', () {
+    testWidgets(
+      'given the user has saved trips, when the screen loads, '
+      'then each trip card is rendered in the grid',
+      (tester) async {
+        final kyoto = buildTrip(id: 't1', name: 'Kyoto Week');
+        final tokyo = buildTrip(id: 't2', name: 'Tokyo Weekend');
+
+        await _givenTripListScreen(
+          tester,
+          seededTrips: [kyoto, tokyo],
+        );
+
+        _thenTripNamesAreVisible(['Kyoto Week', 'Tokyo Weekend']);
+      },
+    );
+
+    testWidgets(
+      'given the user has no trips at all, when the screen loads, '
+      'then only the uncategorized placeholder is shown',
+      (tester) async {
+        await _givenTripListScreen(tester);
+
+        _thenUncategorizedCardIsVisible();
+      },
+    );
+
+    testWidgets(
+      'given the screen is loaded, when the user taps the add button, '
+      'then the trip edit screen is pushed onto the stack',
+      (tester) async {
+        await _givenTripListScreenWithRouter(tester);
+
+        await _whenUserTapsAddTripButton(tester);
+
+        _thenTripEditScreenIsPushed();
+      },
+    );
+
+    testWidgets(
+      'given trips have item counts, when the screen loads, '
+      'then the counts are rendered on their respective cards',
+      (tester) async {
+        final trip = buildTrip(id: 't1', name: 'With Items');
+        final entry = buildJourneyEntry(id: 'e1', tripId: 't1');
+
+        await _givenTripListScreen(
+          tester,
+          seededTrips: [trip],
+          seededJourneys: [entry],
+        );
+
+        _thenTripNamesAreVisible(['With Items']);
+      },
+    );
+  });
+}
+
+Future<void> _givenTripListScreen(
+  WidgetTester tester, {
+  List<Trip> seededTrips = const [],
+  List<JourneyEntry> seededJourneys = const [],
+}) async {
+  final tripRepo = InMemoryTripRepository();
+  for (final trip in seededTrips) {
+    await tripRepo.save(trip);
+  }
+  final journeyRepo = InMemoryJourneyRepository();
+  for (final entry in seededJourneys) {
+    await journeyRepo.save(entry);
+  }
+  final quickGuideRepo = InMemoryQuickGuideRepository();
+
+  await pumpScreen(
+    tester,
+    child: const TripListScreen(),
+    overrides: [
+      tripRepositoryProvider.overrideWithValue(tripRepo),
+      journeyRepositoryProvider.overrideWithValue(journeyRepo),
+      quickGuideRepositoryProvider.overrideWithValue(quickGuideRepo),
+    ],
+  );
+  // Allow async providers (tripsProvider, tripItemCountsProvider) to resolve.
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _givenTripListScreenWithRouter(WidgetTester tester) async {
+  final tripRepo = InMemoryTripRepository();
+  final journeyRepo = InMemoryJourneyRepository();
+  final quickGuideRepo = InMemoryQuickGuideRepository();
+
+  await pumpRouterApp(
+    tester,
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const TripListScreen()),
+      GoRoute(path: '/trip/edit', builder: (_, __) => const TripEditScreen()),
+    ],
+    overrides: [
+      tripRepositoryProvider.overrideWithValue(tripRepo),
+      journeyRepositoryProvider.overrideWithValue(journeyRepo),
+      quickGuideRepositoryProvider.overrideWithValue(quickGuideRepo),
+    ],
+  );
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+Future<void> _whenUserTapsAddTripButton(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.add));
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+void _thenTripNamesAreVisible(List<String> names) {
+  for (final name in names) {
+    expect(find.text(name), findsOneWidget);
+  }
+  expect(find.byType(TripCard), findsNWidgets(names.length));
+}
+
+void _thenUncategorizedCardIsVisible() {
+  // The trip list screen shows the "uncategorized" placeholder when the
+  // trip list is empty. It's rendered via UncategorizedTripCard.
+  expect(find.byType(TripCard), findsNothing);
+  expect(find.text('trip.uncategorized'), findsOneWidget);
+}
+
+void _thenTripEditScreenIsPushed() {
+  expect(find.byType(TripEditScreen), findsOneWidget);
+}

--- a/frontend/test/features/trip/presentation/screens/trip_list_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_list_screen_test.dart
@@ -131,8 +131,9 @@ Future<void> _givenTripListScreenWithRouter(WidgetTester tester) async {
 
 Future<void> _whenUserTapsAddTripButton(WidgetTester tester) async {
   await tester.tap(find.byIcon(Icons.add));
-  await tester.pump(const Duration(milliseconds: 50));
-  await tester.pump(const Duration(milliseconds: 50));
+  await tester.pump();
+  // Allow the push transition to complete.
+  await tester.pump(const Duration(milliseconds: 400));
 }
 
 void _thenTripNamesAreVisible(List<String> names) {

--- a/frontend/test/helpers/pump_app.dart
+++ b/frontend/test/helpers/pump_app.dart
@@ -1,0 +1,89 @@
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Common widget test bootstrap used across all screen tests.
+///
+/// Installs an in-memory [SharedPreferences] before each test and ensures
+/// [EasyLocalization] is initialised so screens can call `tr()` and read
+/// `context.locale` without crashing.
+Future<void> initTestEnvironment() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues(<String, Object>{});
+  await EasyLocalization.ensureInitialized();
+}
+
+/// Pumps [child] inside a minimal app host with [EasyLocalization],
+/// [ProviderScope] and a [MaterialApp] wrapper.
+///
+/// Use this for screens that do not rely on GoRouter navigation.
+Future<void> pumpScreen(
+  WidgetTester tester, {
+  required Widget child,
+  List<Override> overrides = const [],
+}) async {
+  await tester.pumpWidget(
+    EasyLocalization(
+      supportedLocales: const [Locale('zh', 'TW'), Locale('en')],
+      path: 'assets/translations',
+      fallbackLocale: const Locale('zh', 'TW'),
+      useOnlyLangCode: false,
+      child: ProviderScope(
+        overrides: overrides,
+        child: Builder(
+          builder: (context) => MaterialApp(
+            locale: context.locale,
+            supportedLocales: context.supportedLocales,
+            localizationsDelegates: context.localizationDelegates,
+            home: child,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+/// Pumps a GoRouter-driven app for screens that rely on routing.
+///
+/// Pass the list of [routes] the test cares about along with an optional
+/// [initialLocation]. Provider [overrides] replace production services.
+Future<void> pumpRouterApp(
+  WidgetTester tester, {
+  required List<RouteBase> routes,
+  String initialLocation = '/',
+  Object? initialExtra,
+  List<Override> overrides = const [],
+}) async {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    initialExtra: initialExtra,
+    routes: routes,
+  );
+
+  await tester.pumpWidget(
+    EasyLocalization(
+      supportedLocales: const [Locale('zh', 'TW'), Locale('en')],
+      path: 'assets/translations',
+      fallbackLocale: const Locale('zh', 'TW'),
+      useOnlyLangCode: false,
+      child: ProviderScope(
+        overrides: overrides,
+        child: Builder(
+          builder: (context) => MaterialApp.router(
+            locale: context.locale,
+            supportedLocales: context.supportedLocales,
+            localizationsDelegates: context.localizationDelegates,
+            routerConfig: router,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 100));
+}

--- a/frontend/test/helpers/pump_app.dart
+++ b/frontend/test/helpers/pump_app.dart
@@ -16,6 +16,20 @@ Future<void> initTestEnvironment() async {
   await EasyLocalization.ensureInitialized();
 }
 
+/// AssetLoader that returns no translations so `tr()` always returns the key.
+///
+/// Keeping translations out of the tests lets assertions match the raw
+/// i18n key, which is both deterministic and locale-independent.
+class _EmptyAssetLoader extends AssetLoader {
+  const _EmptyAssetLoader();
+
+  @override
+  Future<Map<String, dynamic>?> load(String path, Locale locale) async =>
+      <String, dynamic>{};
+}
+
+const _kEmptyAssetLoader = _EmptyAssetLoader();
+
 /// Pumps [child] inside a minimal app host with [EasyLocalization],
 /// [ProviderScope] and a [MaterialApp] wrapper.
 ///
@@ -24,12 +38,15 @@ Future<void> pumpScreen(
   WidgetTester tester, {
   required Widget child,
   List<Override> overrides = const [],
+  Locale locale = const Locale('zh', 'TW'),
 }) async {
   await tester.pumpWidget(
     EasyLocalization(
       supportedLocales: const [Locale('zh', 'TW'), Locale('en')],
       path: 'assets/translations',
-      fallbackLocale: const Locale('zh', 'TW'),
+      fallbackLocale: locale,
+      startLocale: locale,
+      assetLoader: _kEmptyAssetLoader,
       useOnlyLangCode: false,
       child: ProviderScope(
         overrides: overrides,
@@ -44,8 +61,7 @@ Future<void> pumpScreen(
       ),
     ),
   );
-  await tester.pump();
-  await tester.pump(const Duration(milliseconds: 100));
+  await _settleBoot(tester);
 }
 
 /// Pumps a GoRouter-driven app for screens that rely on routing.
@@ -58,6 +74,7 @@ Future<void> pumpRouterApp(
   String initialLocation = '/',
   Object? initialExtra,
   List<Override> overrides = const [],
+  Locale locale = const Locale('zh', 'TW'),
 }) async {
   final router = GoRouter(
     initialLocation: initialLocation,
@@ -69,7 +86,9 @@ Future<void> pumpRouterApp(
     EasyLocalization(
       supportedLocales: const [Locale('zh', 'TW'), Locale('en')],
       path: 'assets/translations',
-      fallbackLocale: const Locale('zh', 'TW'),
+      fallbackLocale: locale,
+      startLocale: locale,
+      assetLoader: _kEmptyAssetLoader,
       useOnlyLangCode: false,
       child: ProviderScope(
         overrides: overrides,
@@ -84,6 +103,13 @@ Future<void> pumpRouterApp(
       ),
     ),
   );
-  await tester.pump();
-  await tester.pump(const Duration(milliseconds: 100));
+  await _settleBoot(tester);
+}
+
+/// Pumps enough frames for [EasyLocalization] to finish its async
+/// bootstrap and for first-frame post-callbacks to run.
+Future<void> _settleBoot(WidgetTester tester) async {
+  for (var i = 0; i < 3; i += 1) {
+    await tester.pump(const Duration(milliseconds: 10));
+  }
 }

--- a/frontend/test/helpers/test_data.dart
+++ b/frontend/test/helpers/test_data.dart
@@ -1,0 +1,113 @@
+import 'dart:typed_data';
+
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/explore/domain/models/place_category.dart';
+import 'package:context_app/features/explore/domain/models/place_location.dart';
+import 'package:context_app/features/explore/domain/models/place_photo.dart';
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/models/saved_place.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+
+/// Builds a [Place] with sensible defaults. Override any field as needed.
+Place buildPlace({
+  String id = 'place-1',
+  String name = 'Test Place',
+  String formattedAddress = '123 Test Street',
+  double latitude = 25.0,
+  double longitude = 121.0,
+  PlaceCategory category = PlaceCategory.modernUrban,
+  List<PlacePhoto> photos = const [],
+  double? rating,
+  int? userRatingCount,
+  List<String> types = const [],
+}) {
+  return Place(
+    id: id,
+    name: name,
+    formattedAddress: formattedAddress,
+    location: PlaceLocation(latitude: latitude, longitude: longitude),
+    rating: rating,
+    userRatingCount: userRatingCount,
+    types: types,
+    photos: photos,
+    category: category,
+  );
+}
+
+/// Builds a [Trip] with sensible defaults.
+Trip buildTrip({
+  String id = 'trip-1',
+  String name = 'Kyoto Adventure',
+  DateTime? startDate,
+  DateTime? endDate,
+  DateTime? createdAt,
+}) {
+  return Trip(
+    id: id,
+    name: name,
+    startDate: startDate,
+    endDate: endDate,
+    createdAt: createdAt ?? DateTime(2024, 1, 1),
+  );
+}
+
+/// Builds a [NarrationContent] from a raw text body.
+NarrationContent buildNarrationContent({
+  String text =
+      'This is a sample narration body. It has multiple sentences! '
+      'The third line rounds it off.',
+  Language language = Language.english,
+}) {
+  return NarrationContent.create(text, language: language);
+}
+
+/// Builds a [JourneyEntry] with a deterministic [createdAt].
+JourneyEntry buildJourneyEntry({
+  String id = 'journey-1',
+  Place? place,
+  NarrationContent? content,
+  Set<NarrationAspect> aspects = const {NarrationAspect.historicalBackground},
+  DateTime? createdAt,
+  Language language = Language.english,
+  String? tripId,
+}) {
+  final resolvedPlace = place ?? buildPlace();
+  final resolvedContent = content ?? buildNarrationContent();
+  return JourneyEntry(
+    id: id,
+    place: SavedPlace(
+      id: resolvedPlace.id,
+      name: resolvedPlace.name,
+      address: resolvedPlace.formattedAddress,
+      imageUrl: resolvedPlace.primaryPhoto?.url,
+    ),
+    narrationContent: resolvedContent,
+    narrationAspects: aspects,
+    createdAt: createdAt ?? DateTime(2024, 1, 2, 10),
+    language: language,
+    tripId: tripId,
+  );
+}
+
+/// Builds a [QuickGuideEntry] with sensible defaults.
+QuickGuideEntry buildQuickGuideEntry({
+  String id = 'quick-guide-1',
+  Uint8List? imageBytes,
+  String aiDescription = 'A short description from fake AI.',
+  DateTime? createdAt,
+  Language language = Language.english,
+  String? tripId,
+}) {
+  return QuickGuideEntry(
+    id: id,
+    imageBytes: imageBytes ?? Uint8List.fromList(const [0, 1, 2, 3]),
+    aiDescription: aiDescription,
+    createdAt: createdAt ?? DateTime(2024, 1, 1, 12),
+    language: language,
+    tripId: tripId,
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds a complete suite of widget tests covering all major screens and features in the application. The test suite includes screen tests, helper utilities, fake implementations for dependencies, and test data builders.

## Key Changes

### Screen Tests Added
- **Trip Management**: `trip_edit_screen_test.dart`, `trip_list_screen_test.dart`, `trip_detail_screen_test.dart` - Tests for creating, listing, and viewing trips
- **Journey/Passport**: `journey_screen_test.dart` - Tests for timeline view, filtering, and trip-based organization
- **Narration**: `narration_screen_test.dart`, `select_narration_aspect_screen_test.dart` - Tests for text-to-speech narration and aspect selection
- **Quick Guide**: `quick_guide_screen_test.dart` - Tests for AI-powered quick guide generation
- **Explore**: `explore_screen_test.dart` - Tests for nearby place discovery and filtering
- **Camera**: `camera_screen_test.dart` - Tests for image capture interface
- **Settings**: `settings_screen_test.dart` - Tests for user preferences and subscription status
- **Subscription**: `subscription_screen_test.dart` - Tests for paywall and purchase flows
- **Main Navigation**: `main_screen_test.dart` - Tests for bottom navigation and tab switching
- **Success Flow**: `save_success_screen_test.dart` - Tests for post-save confirmation screen

### Test Infrastructure
- **`pump_app.dart`**: Common test bootstrap with `initTestEnvironment()`, `pumpScreen()`, and `pumpRouterApp()` helpers for consistent widget test setup with localization and provider overrides
- **`test_data.dart`**: Builder functions for creating test domain models (`buildPlace()`, `buildTrip()`, `buildJourneyEntry()`, etc.) with sensible defaults

### Fake Implementations
- `fake_tts_service.dart` - Text-to-speech service mock with event stream recording
- `fake_subscription_service.dart` - Subscription service mock with purchase/restore stubbing
- `fake_narration_service.dart` - Narration generation service mock
- `fake_quick_guide_ai_service.dart` - AI quick guide service mock
- `fake_image_analysis_service.dart` - Image analysis service mock
- `fake_rewarded_ad_service.dart` - Rewarded ad service mock
- `fake_location_service.dart` - Location service mock
- `fake_places_repository.dart` - Places repository mock

### In-Memory Repository Implementations
- `in_memory_trip_repository.dart` - Trip persistence mock
- `in_memory_journey_repository.dart` - Journey entry persistence mock
- `in_memory_quick_guide_repository.dart` - Quick guide persistence mock
- `in_memory_saved_locations_repository.dart` - Saved locations persistence mock
- `in_memory_usage_repository.dart` - Usage tracking mock

## Notable Implementation Details
- Tests follow a consistent Given-When-Then pattern with helper functions prefixed with `_given`, `_when`, and `_then`
- All tests use empty asset loader for translations to ensure deterministic, locale-independent assertions
- Provider overrides enable dependency injection for testing without touching real services
- Router-based tests use `pumpRouterApp()` to verify navigation flows
- Async operations are properly awaited with pump delays where needed for state resolution

https://claude.ai/code/session_01DqBjBCKtEtVVwhHzX4u5FE