### PR TITLE
Generate full project coverage instead of domain-only coverage

### DIFF
--- a/frontend/scripts/run_unit_test_coverage.sh
+++ b/frontend/scripts/run_unit_test_coverage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 單元測試與 Coverage 腳本
-# 只產生 domain 資料夾的 coverage 報告
+# 產生整個專案的 coverage 報告
 
 set -e  # 遇到錯誤立即退出
 
@@ -41,65 +41,9 @@ fi
 
 echo "✅ Tests completed, coverage generated"
 
-# 過濾 coverage，只保留 domain 資料夾的檔案
+# 顯示包含的檔案
 echo ""
-echo "🔧 Filtering coverage to domain folders only..."
-
-# 使用 lcov 過濾 coverage（如果已安裝）
-if command -v lcov &> /dev/null; then
-    lcov --extract coverage/lcov.info \
-         'lib/features/*/domain/*' \
-         -o coverage/lcov_domain.info \
-         --ignore-errors unused
-    
-    # 備份原始檔案並替換
-    mv coverage/lcov.info coverage/lcov_full.info
-    mv coverage/lcov_domain.info coverage/lcov.info
-    
-    echo "✅ Coverage filtered using lcov"
-else
-    # 如果沒有 lcov，使用 grep 過濾
-    echo "⚠️  lcov not found, using grep to filter..."
-    
-    # 建立臨時檔案
-    TEMP_FILE=$(mktemp)
-    
-    # 使用 awk 來正確解析 lcov 格式並過濾 domain 資料夾
-    awk '
-    BEGIN { in_domain = 0 }
-    /^SF:/ {
-        # 檢查檔案路徑是否包含 /domain/
-        if ($0 ~ /features\/[^\/]+\/domain\//) {
-            in_domain = 1
-            print
-        } else {
-            in_domain = 0
-        }
-        next
-    }
-    /^end_of_record/ {
-        if (in_domain) {
-            print
-        }
-        next
-    }
-    {
-        if (in_domain) {
-            print
-        }
-    }
-    ' coverage/lcov.info > "$TEMP_FILE"
-    
-    # 備份原始檔案並替換
-    mv coverage/lcov.info coverage/lcov_full.info
-    mv "$TEMP_FILE" coverage/lcov.info
-    
-    echo "✅ Coverage filtered using awk"
-fi
-
-# 顯示過濾後包含的檔案
-echo ""
-echo "📁 Domain files included in coverage:"
+echo "📁 Files included in coverage:"
 grep "^SF:" coverage/lcov.info | sed 's/SF:/  /' | sort
 
 # 計算 coverage 統計（如果有 lcov）


### PR DESCRIPTION
## Summary
Updated the unit test coverage script to generate coverage reports for the entire project instead of filtering to only the `domain` folders.

## Key Changes
- Modified the coverage generation script to remove domain-specific filtering logic
- Removed `lcov` extraction and filtering that was limiting coverage to `lib/features/*/domain/*` paths
- Removed the fallback `awk`-based filtering for systems without `lcov` installed
- Updated script comments to reflect that full project coverage is now generated
- Simplified the coverage display to show all included files instead of just domain files

## Implementation Details
- The script now generates and displays coverage for all source files in the project
- Removed ~56 lines of filtering logic (both `lcov` and `awk` implementations)
- Backup files (`lcov_full.info`) are no longer created since filtering is no longer performed
- The coverage report display remains similar but now encompasses the entire codebase

https://claude.ai/code/session_01KRmXSnpUb5cs9PRCTEE9on