### PR TITLE
Add region landmark search via Wikidata SPARQL queries

### DIFF
--- a/frontend/lib/features/explore/data/mappers/wikidata_category_mapper.dart
+++ b/frontend/lib/features/explore/data/mappers/wikidata_category_mapper.dart
@@ -55,4 +55,10 @@ class WikidataCategoryMapper {
     }
     return null;
   }
+
+  /// All Wikidata Q-ids treated as landmark categories.
+  ///
+  /// Exposed for callers that need to filter places by P31 outside the
+  /// app process (e.g. SPARQL `VALUES` clauses).
+  static Iterable<String> get whitelistedClassIds => _whitelist.keys;
 }

--- a/frontend/lib/features/explore/data/repositories/places_repository_impl.dart
+++ b/frontend/lib/features/explore/data/repositories/places_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:context_app/core/errors/app_error.dart';
 import 'package:context_app/features/explore/data/dto/wiki_geo_search_result_dto.dart';
 import 'package:context_app/features/explore/data/dto/wikidata_entity_dto.dart';
 import 'package:context_app/features/explore/data/mappers/wikidata_category_mapper.dart';
+import 'package:context_app/features/explore/data/services/wikidata_landmark_query_service.dart';
 import 'package:context_app/features/explore/data/services/wikipedia_places_service.dart';
 import 'package:context_app/features/explore/domain/errors/place_error.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
@@ -13,8 +14,12 @@ import 'package:context_app/features/settings/domain/models/language.dart';
 
 class PlacesRepositoryImpl implements PlacesRepository {
   final WikipediaPlacesService _service;
+  final WikidataLandmarkQueryService _landmarkService;
 
-  PlacesRepositoryImpl(this._service);
+  PlacesRepositoryImpl(
+    this._service, {
+    WikidataLandmarkQueryService? landmarkService,
+  }) : _landmarkService = landmarkService ?? WikidataLandmarkQueryService();
 
   static const int _minResultsBeforeRetry = 3;
   static const double _retryRadiusFactor = 5.0;
@@ -82,6 +87,9 @@ class PlacesRepositoryImpl implements PlacesRepository {
   }) async {
     try {
       final wikiLang = _wikiLang(language);
+      final regionLandmarks = await _searchRegionLandmarks(query, wikiLang);
+      if (regionLandmarks.isNotEmpty) return regionLandmarks;
+
       final dtos = await _service.searchByText(query, wikiLang: wikiLang);
       return _buildPlaces(dtos);
     } on AppError {
@@ -94,6 +102,35 @@ class PlacesRepositoryImpl implements PlacesRepository {
         stackTrace: stackTrace,
       );
     }
+  }
+
+  /// Resolves [query] to a region (country/city) and returns its famous
+  /// landmarks ranked by Wikipedia sitelink count.
+  ///
+  /// Returns empty when the query does not resolve to a region or when
+  /// the region has no whitelisted landmarks. Errors from the SPARQL
+  /// service are swallowed so the caller can fall back to the regular
+  /// text-search path.
+  Future<List<Place>> _searchRegionLandmarks(
+    String query,
+    String wikiLang,
+  ) async {
+    final List<String> ids;
+    try {
+      ids = await _landmarkService.findLandmarkIdsForQuery(
+        query,
+        wikiLang: wikiLang,
+      );
+    } on AppError {
+      return const [];
+    }
+    if (ids.isEmpty) return const [];
+
+    final dtos = await _service.fetchPagesByWikidataIds(
+      ids,
+      wikiLang: wikiLang,
+    );
+    return _buildPlaces(dtos);
   }
 
   static const String _wikidataPrefix = 'wikidata:';

--- a/frontend/lib/features/explore/data/services/wikidata_landmark_query_service.dart
+++ b/frontend/lib/features/explore/data/services/wikidata_landmark_query_service.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:context_app/core/errors/app_error.dart';
+import 'package:context_app/features/explore/data/mappers/wikidata_category_mapper.dart';
+import 'package:context_app/features/explore/domain/errors/place_error.dart';
+import 'package:http/http.dart' as http;
+
+/// Resolves a free-text query (e.g. "New Zealand", "東京") to a list of
+/// famous landmark Wikidata Q-ids contained within that region.
+///
+/// Combines two Wikidata APIs:
+///   1. `wbsearchentities` to map the query string to a single Wikidata
+///      entity (the most relevant match in the user's language).
+///   2. The Wikidata Query Service (SPARQL) to find places located inside
+///      that entity (via P17 country or P131 contained-administrative
+///      entity), filtered by the same P31 landmark whitelist used by
+///      [WikidataCategoryMapper] and ranked by Wikipedia sitelink count
+///      as a global fame proxy.
+///
+/// Returns an empty list when the query cannot be resolved or when the
+/// resolved entity has no qualifying landmarks.
+class WikidataLandmarkQueryService {
+  static const String _userAgent =
+      'InstantExplore/1.0 (https://instant-explore.app;'
+      ' support@instant-explore.app)';
+
+  static const int _defaultLimit = 25;
+  static const int _minSitelinks = 10;
+
+  final http.Client _client;
+
+  WikidataLandmarkQueryService({http.Client? client})
+    : _client = client ?? http.Client();
+
+  /// Returns landmark Q-ids ranked by global fame, or empty if [query]
+  /// does not resolve to a region containing whitelisted landmarks.
+  Future<List<String>> findLandmarkIdsForQuery(
+    String query, {
+    required String wikiLang,
+    int limit = _defaultLimit,
+  }) async {
+    final regionId = await _resolveEntityId(query, wikiLang: wikiLang);
+    if (regionId == null) return const [];
+    return _findLandmarkIds(regionId, limit: limit);
+  }
+
+  Future<String?> _resolveEntityId(
+    String query, {
+    required String wikiLang,
+  }) async {
+    final uri = Uri.https('www.wikidata.org', '/w/api.php', {
+      'action': 'wbsearchentities',
+      'search': query,
+      'language': wikiLang,
+      'uselang': wikiLang,
+      'type': 'item',
+      'limit': '1',
+      'format': 'json',
+    });
+
+    final response = await _client.get(
+      uri,
+      headers: {'User-Agent': _userAgent},
+    );
+    if (response.statusCode != 200) {
+      throw AppError(
+        type: PlaceError.searchFailed,
+        message: 'Wikidata wbsearchentities failed',
+        context: {'status_code': response.statusCode},
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final results = data['search'];
+    if (results is! List || results.isEmpty) return null;
+    final first = results.first;
+    if (first is! Map) return null;
+    final id = first['id'];
+    return id is String ? id : null;
+  }
+
+  Future<List<String>> _findLandmarkIds(
+    String regionQid, {
+    required int limit,
+  }) async {
+    final uri = Uri.https('query.wikidata.org', '/sparql', {
+      'query': _buildSparql(regionQid: regionQid, limit: limit),
+      'format': 'json',
+    });
+
+    final response = await _client.get(
+      uri,
+      headers: {
+        'User-Agent': _userAgent,
+        'Accept': 'application/sparql-results+json',
+      },
+    );
+    if (response.statusCode != 200) {
+      throw AppError(
+        type: PlaceError.searchFailed,
+        message: 'Wikidata SPARQL query failed',
+        context: {'status_code': response.statusCode},
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final bindings = (data['results'] as Map?)?['bindings'];
+    if (bindings is! List) return const [];
+
+    final ids = <String>[];
+    for (final binding in bindings) {
+      if (binding is! Map) continue;
+      final place = binding['place'];
+      if (place is! Map) continue;
+      final value = place['value'];
+      if (value is! String) continue;
+      final qid = _extractQid(value);
+      if (qid != null && !ids.contains(qid)) ids.add(qid);
+    }
+    return ids;
+  }
+
+  static String _buildSparql({
+    required String regionQid,
+    required int limit,
+  }) {
+    final values = WikidataCategoryMapper.whitelistedClassIds
+        .map((id) => 'wd:$id')
+        .join(' ');
+    return '''
+SELECT ?place ?sitelinks WHERE {
+  { ?place wdt:P17 wd:$regionQid . }
+  UNION
+  { ?place wdt:P131 wd:$regionQid . }
+  ?place wdt:P31 ?p31 ;
+         wdt:P625 ?coord ;
+         wikibase:sitelinks ?sitelinks .
+  VALUES ?p31 { $values }
+  FILTER(?sitelinks >= $_minSitelinks)
+}
+ORDER BY DESC(?sitelinks)
+LIMIT $limit
+''';
+  }
+
+  static String? _extractQid(String entityUri) {
+    final slash = entityUri.lastIndexOf('/');
+    if (slash < 0 || slash == entityUri.length - 1) return null;
+    final tail = entityUri.substring(slash + 1);
+    return tail.startsWith('Q') ? tail : null;
+  }
+}

--- a/frontend/lib/features/explore/data/services/wikipedia_places_service.dart
+++ b/frontend/lib/features/explore/data/services/wikipedia_places_service.dart
@@ -262,6 +262,169 @@ class WikipediaPlacesService {
     }
     return null;
   }
+
+  /// Resolves Wikidata [ids] to Wikipedia page DTOs in the same order.
+  ///
+  /// Looks up each entity's sitelink for [wikiLang] (falling back to
+  /// `enwiki`) and fetches the corresponding Wikipedia article info in
+  /// batches. Ids without a usable sitelink are silently skipped.
+  Future<List<WikiGeoSearchResultDto>> fetchPagesByWikidataIds(
+    List<String> ids, {
+    required String wikiLang,
+  }) async {
+    if (ids.isEmpty) return const [];
+
+    final titlesByLang = await _resolveSitelinkTitles(ids, wikiLang: wikiLang);
+    if (titlesByLang.isEmpty) return const [];
+
+    final dtosByQid = <String, WikiGeoSearchResultDto>{};
+    for (final entry in titlesByLang.entries) {
+      final titles = entry.value.values.toSet().toList();
+      final dtos = await _fetchPagesByTitles(titles, wikiLang: entry.key);
+      for (final dto in dtos) {
+        final qid = dto.wikidataId;
+        if (qid != null) dtosByQid.putIfAbsent(qid, () => dto);
+      }
+    }
+
+    final result = <WikiGeoSearchResultDto>[];
+    for (final id in ids) {
+      final dto = dtosByQid[id];
+      if (dto != null) result.add(dto);
+    }
+    return result;
+  }
+
+  Future<Map<String, Map<String, String>>> _resolveSitelinkTitles(
+    List<String> ids, {
+    required String wikiLang,
+  }) async {
+    final preferred = <String, String>{};
+    final fallback = <String, String>{};
+
+    for (var i = 0; i < ids.length; i += _batchSize) {
+      final chunk = ids.sublist(
+        i,
+        i + _batchSize > ids.length ? ids.length : i + _batchSize,
+      );
+      final raw = await _fetchSitelinksChunk(chunk);
+      raw.forEach((qid, sitelinks) {
+        final preferredTitle = sitelinks['${wikiLang}wiki'];
+        if (preferredTitle != null) {
+          preferred[qid] = preferredTitle;
+          return;
+        }
+        final enTitle = sitelinks['enwiki'];
+        if (enTitle != null) fallback[qid] = enTitle;
+      });
+    }
+
+    final result = <String, Map<String, String>>{};
+    if (preferred.isNotEmpty) result[wikiLang] = preferred;
+    if (fallback.isNotEmpty) result['en'] = fallback;
+    return result;
+  }
+
+  Future<Map<String, Map<String, String>>> _fetchSitelinksChunk(
+    List<String> ids,
+  ) async {
+    final uri = Uri.https('www.wikidata.org', '/w/api.php', {
+      'action': 'wbgetentities',
+      'ids': ids.join('|'),
+      'props': 'sitelinks',
+      'format': 'json',
+    });
+
+    final response = await _client.get(
+      uri,
+      headers: {'User-Agent': _userAgent},
+    );
+    if (response.statusCode != 200) {
+      throw AppError(
+        type: PlaceError.searchFailed,
+        message: 'Wikidata sitelinks lookup failed',
+        context: {'status_code': response.statusCode},
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final entities = data['entities'];
+    if (entities is! Map) return const {};
+
+    final result = <String, Map<String, String>>{};
+    for (final entry in entities.entries) {
+      final value = entry.value;
+      if (value is! Map) continue;
+      final sitelinks = value['sitelinks'];
+      if (sitelinks is! Map) continue;
+      final perWiki = <String, String>{};
+      for (final sitelink in sitelinks.entries) {
+        final link = sitelink.value;
+        if (link is! Map) continue;
+        final title = link['title'];
+        if (title is String) perWiki[sitelink.key as String] = title;
+      }
+      if (perWiki.isNotEmpty) result[entry.key as String] = perWiki;
+    }
+    return result;
+  }
+
+  Future<List<WikiGeoSearchResultDto>> _fetchPagesByTitles(
+    List<String> titles, {
+    required String wikiLang,
+  }) async {
+    if (titles.isEmpty) return const [];
+
+    final results = <WikiGeoSearchResultDto>[];
+    for (var i = 0; i < titles.length; i += _batchSize) {
+      final chunk = titles.sublist(
+        i,
+        i + _batchSize > titles.length ? titles.length : i + _batchSize,
+      );
+      results.addAll(await _fetchPagesByTitlesChunk(chunk, wikiLang: wikiLang));
+    }
+    return results;
+  }
+
+  Future<List<WikiGeoSearchResultDto>> _fetchPagesByTitlesChunk(
+    List<String> titles, {
+    required String wikiLang,
+  }) async {
+    final uri = Uri.https('$wikiLang.wikipedia.org', '/w/api.php', {
+      'action': 'query',
+      'titles': titles.join('|'),
+      'prop': 'pageimages|coordinates|pageprops',
+      'pithumbsize': '$_thumbSize',
+      'ppprop': 'wikibase_item',
+      'format': 'json',
+    });
+
+    final response = await _client.get(
+      uri,
+      headers: {'User-Agent': _userAgent},
+    );
+    if (response.statusCode != 200) {
+      throw AppError(
+        type: PlaceError.searchFailed,
+        message: 'Wikipedia titles lookup failed',
+        context: {'status_code': response.statusCode},
+      );
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final pages = (data['query'] as Map?)?['pages'];
+    if (pages is! Map) return const [];
+
+    final out = <WikiGeoSearchResultDto>[];
+    for (final page in pages.values) {
+      if (page is! Map) continue;
+      final dto = WikiGeoSearchResultDto.fromPage(
+        Map<String, dynamic>.from(page),
+      );
+      if (dto != null) out.add(dto);
+    }
+    return out;
+  }
 }
 
 /// Combined result of [WikipediaPlacesService.fetchEntityById].

--- a/frontend/lib/features/explore/providers.dart
+++ b/frontend/lib/features/explore/providers.dart
@@ -1,6 +1,7 @@
 import 'package:context_app/core/utils/geo_utils.dart';
 import 'package:context_app/features/explore/domain/use_cases/search_nearby_places_use_case.dart';
 import 'package:context_app/features/explore/data/services/geolocator_service.dart';
+import 'package:context_app/features/explore/data/services/wikidata_landmark_query_service.dart';
 import 'package:context_app/features/explore/data/services/wikipedia_places_service.dart';
 import 'package:context_app/features/explore/data/services/hive_places_cache_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,10 +22,19 @@ final wikipediaPlacesServiceProvider = Provider<WikipediaPlacesService>((ref) {
   return WikipediaPlacesService();
 });
 
+final wikidataLandmarkQueryServiceProvider =
+    Provider<WikidataLandmarkQueryService>((ref) {
+      return WikidataLandmarkQueryService();
+    });
+
 final placesRepositoryProvider = Provider<PlacesRepository>((ref) {
   final service = ref.watch(wikipediaPlacesServiceProvider);
+  final landmarkService = ref.watch(wikidataLandmarkQueryServiceProvider);
   final cacheService = ref.watch(placesCacheServiceProvider);
-  final apiRepository = PlacesRepositoryImpl(service);
+  final apiRepository = PlacesRepositoryImpl(
+    service,
+    landmarkService: landmarkService,
+  );
   return CachingPlacesRepository(apiRepository, cacheService);
 });
 

--- a/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
+++ b/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
@@ -1,7 +1,10 @@
+import 'package:context_app/core/errors/app_error.dart';
 import 'package:context_app/features/explore/data/dto/wiki_geo_search_result_dto.dart';
 import 'package:context_app/features/explore/data/dto/wikidata_entity_dto.dart';
 import 'package:context_app/features/explore/data/repositories/places_repository_impl.dart';
+import 'package:context_app/features/explore/data/services/wikidata_landmark_query_service.dart';
 import 'package:context_app/features/explore/data/services/wikipedia_places_service.dart';
+import 'package:context_app/features/explore/domain/errors/place_error.dart';
 import 'package:context_app/features/explore/domain/models/place_category.dart';
 import 'package:context_app/features/explore/domain/models/place_location.dart';
 import 'package:context_app/features/settings/domain/models/language.dart';
@@ -11,9 +14,13 @@ import 'package:mocktail/mocktail.dart';
 class MockWikipediaPlacesService extends Mock
     implements WikipediaPlacesService {}
 
+class MockWikidataLandmarkQueryService extends Mock
+    implements WikidataLandmarkQueryService {}
+
 void main() {
   late PlacesRepositoryImpl repository;
   late MockWikipediaPlacesService mockService;
+  late MockWikidataLandmarkQueryService mockLandmarkService;
 
   const testLocation = PlaceLocation(latitude: 25.0336, longitude: 121.5644);
   const testLanguage = Language.traditionalChinese;
@@ -21,7 +28,18 @@ void main() {
 
   setUp(() {
     mockService = MockWikipediaPlacesService();
-    repository = PlacesRepositoryImpl(mockService);
+    mockLandmarkService = MockWikidataLandmarkQueryService();
+    repository = PlacesRepositoryImpl(
+      mockService,
+      landmarkService: mockLandmarkService,
+    );
+
+    when(
+      () => mockLandmarkService.findLandmarkIdsForQuery(
+        any(),
+        wikiLang: any(named: 'wikiLang'),
+      ),
+    ).thenAnswer((_) async => const []);
   });
 
   WikiGeoSearchResultDto geoDto({
@@ -303,6 +321,87 @@ void main() {
 
       expect(result, hasLength(1));
       expect(result.first.name, '清水寺');
+    });
+
+    test('uses region landmark path when query resolves to a region',
+        () async {
+      when(() => mockLandmarkService.findLandmarkIdsForQuery(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).thenAnswer((_) async => ['Q190077', 'Q47481']);
+
+      when(() => mockService.fetchPagesByWikidataIds(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).thenAnswer((_) async => [
+            geoDto(title: '米爾福德峽灣', wikidataId: 'Q190077'),
+            geoDto(title: '皇后鎮', wikidataId: 'Q47481'),
+          ]);
+
+      when(() => mockService.fetchEntities(any())).thenAnswer((_) async => {
+            'Q190077': const WikidataEntityDto(
+              id: 'Q190077', p31ClassIds: ['Q46169']),
+            'Q47481': const WikidataEntityDto(
+              id: 'Q47481', p31ClassIds: ['Q570116']),
+          });
+
+      final result = await repository.searchPlaces(
+        '紐西蘭', language: testLanguage);
+
+      expect(result.map((p) => p.name).toList(), ['米爾福德峽灣', '皇后鎮']);
+      verifyNever(() => mockService.searchByText(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          ));
+    });
+
+    test('falls back to text search when landmark service returns empty',
+        () async {
+      when(() => mockService.searchByText(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).thenAnswer((_) async => [
+            geoDto(title: '清水寺', wikidataId: 'Q221716'),
+          ]);
+      when(() => mockService.fetchEntities(any())).thenAnswer((_) async => {
+            'Q221716': const WikidataEntityDto(
+              id: 'Q221716', p31ClassIds: ['Q5393308']),
+          });
+
+      final result = await repository.searchPlaces(
+        '清水寺', language: testLanguage);
+
+      expect(result.map((p) => p.name).toList(), ['清水寺']);
+      verify(() => mockService.searchByText(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).called(1);
+    });
+
+    test('falls back to text search when landmark service throws AppError',
+        () async {
+      when(() => mockLandmarkService.findLandmarkIdsForQuery(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).thenThrow(AppError(
+        type: PlaceError.searchFailed,
+        message: 'sparql failed',
+      ));
+      when(() => mockService.searchByText(
+            any(),
+            wikiLang: any(named: 'wikiLang'),
+          )).thenAnswer((_) async => [
+            geoDto(title: '清水寺', wikidataId: 'Q221716'),
+          ]);
+      when(() => mockService.fetchEntities(any())).thenAnswer((_) async => {
+            'Q221716': const WikidataEntityDto(
+              id: 'Q221716', p31ClassIds: ['Q5393308']),
+          });
+
+      final result = await repository.searchPlaces(
+        '紐西蘭', language: testLanguage);
+
+      expect(result.map((p) => p.name).toList(), ['清水寺']);
     });
   });
 

--- a/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
+++ b/frontend/test/features/explore/data/repositories/places_repository_impl_test.dart
@@ -383,7 +383,7 @@ void main() {
       when(() => mockLandmarkService.findLandmarkIdsForQuery(
             any(),
             wikiLang: any(named: 'wikiLang'),
-          )).thenThrow(AppError(
+          )).thenThrow(const AppError(
         type: PlaceError.searchFailed,
         message: 'sparql failed',
       ));

--- a/frontend/test/features/explore/data/services/wikidata_landmark_query_service_test.dart
+++ b/frontend/test/features/explore/data/services/wikidata_landmark_query_service_test.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+
+import 'package:context_app/core/errors/app_error.dart';
+import 'package:context_app/features/explore/data/services/wikidata_landmark_query_service.dart';
+import 'package:context_app/features/explore/domain/errors/place_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  group('WikidataLandmarkQueryService.findLandmarkIdsForQuery', () {
+    test(
+      'resolves query via wbsearchentities then runs SPARQL with the Q-id',
+      () async {
+        final capturedUris = <Uri>[];
+        final mockClient = MockClient((req) async {
+          capturedUris.add(req.url);
+          if (req.url.host == 'www.wikidata.org') {
+            return http.Response.bytes(
+              utf8.encode(
+                jsonEncode({
+                  'search': [
+                    {'id': 'Q664', 'label': '紐西蘭'},
+                  ],
+                }),
+              ),
+              200,
+              headers: {'content-type': 'application/json; charset=utf-8'},
+            );
+          }
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode({
+                'results': {
+                  'bindings': [
+                    {
+                      'place': {
+                        'value': 'http://www.wikidata.org/entity/Q190077',
+                      },
+                      'sitelinks': {'value': '95'},
+                    },
+                    {
+                      'place': {
+                        'value': 'http://www.wikidata.org/entity/Q47481',
+                      },
+                      'sitelinks': {'value': '60'},
+                    },
+                  ],
+                },
+              }),
+            ),
+            200,
+            headers: {
+              'content-type': 'application/sparql-results+json; charset=utf-8',
+            },
+          );
+        });
+
+        final service = WikidataLandmarkQueryService(client: mockClient);
+
+        final ids = await service.findLandmarkIdsForQuery(
+          '紐西蘭',
+          wikiLang: 'zh',
+        );
+
+        expect(ids, ['Q190077', 'Q47481']);
+        expect(capturedUris, hasLength(2));
+
+        final searchUri = capturedUris[0];
+        expect(searchUri.host, 'www.wikidata.org');
+        expect(searchUri.queryParameters['action'], 'wbsearchentities');
+        expect(searchUri.queryParameters['search'], '紐西蘭');
+        expect(searchUri.queryParameters['language'], 'zh');
+        expect(searchUri.queryParameters['type'], 'item');
+
+        final sparqlUri = capturedUris[1];
+        expect(sparqlUri.host, 'query.wikidata.org');
+        expect(sparqlUri.path, '/sparql');
+        expect(sparqlUri.queryParameters['format'], 'json');
+        expect(sparqlUri.queryParameters['query'], contains('wd:Q664'));
+        expect(sparqlUri.queryParameters['query'], contains('wdt:P17'));
+        expect(sparqlUri.queryParameters['query'], contains('wdt:P131'));
+        expect(sparqlUri.queryParameters['query'], contains('ORDER BY'));
+      },
+    );
+
+    test('returns empty when query does not resolve to any entity', () async {
+      var sparqlCalled = false;
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'query.wikidata.org') sparqlCalled = true;
+        return http.Response.bytes(
+          utf8.encode(jsonEncode({'search': []})),
+          200,
+          headers: {'content-type': 'application/json; charset=utf-8'},
+        );
+      });
+      final service = WikidataLandmarkQueryService(client: mockClient);
+
+      final ids = await service.findLandmarkIdsForQuery(
+        'nonexistent xyzzyx',
+        wikiLang: 'en',
+      );
+
+      expect(ids, isEmpty);
+      expect(sparqlCalled, isFalse);
+    });
+
+    test('returns empty when SPARQL bindings are empty', () async {
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode({
+                'search': [
+                  {'id': 'Q42'},
+                ],
+              }),
+            ),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        return http.Response.bytes(
+          utf8.encode(jsonEncode({'results': {'bindings': []}})),
+          200,
+          headers: {
+            'content-type': 'application/sparql-results+json; charset=utf-8',
+          },
+        );
+      });
+      final service = WikidataLandmarkQueryService(client: mockClient);
+
+      final ids = await service.findLandmarkIdsForQuery(
+        'Douglas Adams',
+        wikiLang: 'en',
+      );
+
+      expect(ids, isEmpty);
+    });
+
+    test('throws AppError when wbsearchentities returns non-200', () async {
+      final mockClient = MockClient(
+        (_) async => http.Response('boom', 503),
+      );
+      final service = WikidataLandmarkQueryService(client: mockClient);
+
+      expect(
+        () => service.findLandmarkIdsForQuery('x', wikiLang: 'en'),
+        throwsA(
+          isA<AppError>().having(
+            (e) => e.type,
+            'type',
+            PlaceError.searchFailed,
+          ),
+        ),
+      );
+    });
+
+    test('throws AppError when SPARQL endpoint returns non-200', () async {
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode({
+                'search': [
+                  {'id': 'Q664'},
+                ],
+              }),
+            ),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        return http.Response('sparql down', 500);
+      });
+      final service = WikidataLandmarkQueryService(client: mockClient);
+
+      expect(
+        () => service.findLandmarkIdsForQuery('NZ', wikiLang: 'en'),
+        throwsA(
+          isA<AppError>().having(
+            (e) => e.type,
+            'type',
+            PlaceError.searchFailed,
+          ),
+        ),
+      );
+    });
+
+    test('deduplicates Q-ids returned by SPARQL', () async {
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode({
+                'search': [
+                  {'id': 'Q664'},
+                ],
+              }),
+            ),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        return http.Response.bytes(
+          utf8.encode(
+            jsonEncode({
+              'results': {
+                'bindings': [
+                  {
+                    'place': {
+                      'value': 'http://www.wikidata.org/entity/Q1',
+                    },
+                  },
+                  {
+                    'place': {
+                      'value': 'http://www.wikidata.org/entity/Q1',
+                    },
+                  },
+                  {
+                    'place': {
+                      'value': 'http://www.wikidata.org/entity/Q2',
+                    },
+                  },
+                ],
+              },
+            }),
+          ),
+          200,
+          headers: {
+            'content-type': 'application/sparql-results+json; charset=utf-8',
+          },
+        );
+      });
+      final service = WikidataLandmarkQueryService(client: mockClient);
+
+      final ids = await service.findLandmarkIdsForQuery(
+        'NZ',
+        wikiLang: 'en',
+      );
+
+      expect(ids, ['Q1', 'Q2']);
+    });
+  });
+}

--- a/frontend/test/features/explore/data/services/wikipedia_places_service_test.dart
+++ b/frontend/test/features/explore/data/services/wikipedia_places_service_test.dart
@@ -276,4 +276,156 @@ void main() {
       );
     });
   });
+
+  group('WikipediaPlacesService.fetchPagesByWikidataIds', () {
+    test('returns empty for empty input without HTTP', () async {
+      final mockClient = MockClient((_) async {
+        fail('HTTP should not be called for empty list');
+      });
+      final service = WikipediaPlacesService(client: mockClient);
+      expect(
+        await service.fetchPagesByWikidataIds(const [], wikiLang: 'en'),
+        isEmpty,
+      );
+    });
+
+    test('preserves input order and stamps wikidataId on each DTO', () async {
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          expect(req.url.queryParameters['action'], 'wbgetentities');
+          expect(req.url.queryParameters['props'], 'sitelinks');
+          return http.Response.bytes(
+            utf8.encode(jsonEncode({
+              'entities': {
+                'Q190077': {
+                  'sitelinks': {
+                    'zhwiki': {'title': '米爾福德峽灣'},
+                    'enwiki': {'title': 'Milford Sound'},
+                  },
+                },
+                'Q47481': {
+                  'sitelinks': {
+                    'zhwiki': {'title': '皇后鎮'},
+                    'enwiki': {'title': 'Queenstown'},
+                  },
+                },
+              },
+            })),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        expect(req.url.host, 'zh.wikipedia.org');
+        final titles = req.url.queryParameters['titles']!.split('|');
+        expect(titles.toSet(), {'米爾福德峽灣', '皇后鎮'});
+        return http.Response.bytes(
+          utf8.encode(jsonEncode({
+            'query': {
+              'pages': {
+                '1': {
+                  'pageid': 1,
+                  'title': '米爾福德峽灣',
+                  'coordinates': [{'lat': -44.6, 'lon': 167.9}],
+                  'pageprops': {'wikibase_item': 'Q190077'},
+                },
+                '2': {
+                  'pageid': 2,
+                  'title': '皇后鎮',
+                  'coordinates': [{'lat': -45.0, 'lon': 168.7}],
+                  'pageprops': {'wikibase_item': 'Q47481'},
+                },
+              },
+            },
+          })),
+          200,
+          headers: {'content-type': 'application/json; charset=utf-8'},
+        );
+      });
+      final service = WikipediaPlacesService(client: mockClient);
+
+      final results = await service.fetchPagesByWikidataIds(
+        const ['Q190077', 'Q47481'],
+        wikiLang: 'zh',
+      );
+
+      expect(results.map((d) => d.wikidataId).toList(),
+          ['Q190077', 'Q47481']);
+      expect(results.map((d) => d.title).toList(),
+          ['米爾福德峽灣', '皇后鎮']);
+    });
+
+    test('falls back to enwiki sitelink when preferred lang missing',
+        () async {
+      Uri? wikiUri;
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          return http.Response.bytes(
+            utf8.encode(jsonEncode({
+              'entities': {
+                'Q1': {
+                  'sitelinks': {
+                    'enwiki': {'title': 'Cathedral Cove'},
+                  },
+                },
+              },
+            })),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        wikiUri = req.url;
+        return http.Response.bytes(
+          utf8.encode(jsonEncode({
+            'query': {
+              'pages': {
+                '1': {
+                  'pageid': 1,
+                  'title': 'Cathedral Cove',
+                  'coordinates': [{'lat': -36.8, 'lon': 175.8}],
+                  'pageprops': {'wikibase_item': 'Q1'},
+                },
+              },
+            },
+          })),
+          200,
+          headers: {'content-type': 'application/json; charset=utf-8'},
+        );
+      });
+      final service = WikipediaPlacesService(client: mockClient);
+
+      final results = await service.fetchPagesByWikidataIds(
+        const ['Q1'],
+        wikiLang: 'zh',
+      );
+
+      expect(results, hasLength(1));
+      expect(results.first.title, 'Cathedral Cove');
+      expect(wikiUri?.host, 'en.wikipedia.org');
+    });
+
+    test('skips ids with no usable sitelink', () async {
+      final mockClient = MockClient((req) async {
+        if (req.url.host == 'www.wikidata.org') {
+          return http.Response.bytes(
+            utf8.encode(jsonEncode({
+              'entities': {
+                'Q1': {'sitelinks': {}},
+              },
+            })),
+            200,
+            headers: {'content-type': 'application/json; charset=utf-8'},
+          );
+        }
+        fail('Wikipedia should not be called when there are no titles');
+      });
+      final service = WikipediaPlacesService(client: mockClient);
+
+      final results = await service.fetchPagesByWikidataIds(
+        const ['Q1'],
+        wikiLang: 'en',
+      );
+
+      expect(results, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
This PR adds intelligent region-based landmark discovery to the places search feature. When a user searches for a region (country, city, etc.), the app now queries Wikidata's SPARQL endpoint to find famous landmarks within that region, ranked by global fame (Wikipedia sitelink count), rather than falling back to generic text search.

## Key Changes

- **New `WikidataLandmarkQueryService`**: Implements a two-step landmark discovery pipeline:
  - Uses Wikidata's `wbsearchentities` API to resolve free-text queries to entity IDs
  - Queries the Wikidata Query Service (SPARQL) to find landmarks (P31 class-filtered) located within the resolved region (via P17 country or P131 administrative containment)
  - Results are ranked by Wikipedia sitelink count and deduplicated

- **Extended `WikipediaPlacesService`**: Added `fetchPagesByWikidataIds()` method to resolve Wikidata Q-ids to Wikipedia page DTOs:
  - Batches Wikidata sitelink lookups to map Q-ids to Wikipedia article titles
  - Falls back to English Wikipedia when preferred language sitelink is unavailable
  - Silently skips Q-ids without usable sitelinks
  - Preserves input order in results

- **Updated `PlacesRepositoryImpl`**: Integrated landmark service into search flow:
  - Attempts region landmark search first via `_searchRegionLandmarks()`
  - Falls back to traditional text search if landmark service returns empty or throws errors
  - Gracefully handles SPARQL service failures without disrupting user experience

- **Provider setup**: Registered `WikidataLandmarkQueryService` in the dependency injection container

- **Test coverage**: Added comprehensive test suites for both new services and repository integration, covering:
  - Happy path with multi-language support
  - Empty results and error handling
  - Deduplication and fallback behavior
  - Sitelink resolution with language fallback

## Implementation Details

- Uses the same P31 landmark whitelist (`WikidataCategoryMapper.whitelistedClassIds`) for consistency across the app
- Implements minimum sitelink threshold (10) to filter for globally notable landmarks
- Respects user's language preference with automatic English fallback
- Batches API requests to stay within rate limits
- Includes proper User-Agent headers for API compliance

https://claude.ai/code/session_01ELgAT1GAwvpNArAVfAnCtD