### PR TITLE
Update Xcode version to 26.0 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.4.0'
+          xcode-version: '26.0'
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
Updated the Xcode version used in the CI workflow from 16.4.0 to 26.0.

## Key Changes
- Updated `xcode-version` in the setup-xcode action from `16.4.0` to `26.0` in the CI workflow

## Details
This change updates the Xcode version used for building and testing on macOS in the continuous integration pipeline. The new version 26.0 will be used for all subsequent CI runs that execute the setup-xcode step.

https://claude.ai/code/session_01Crpj3ZnhqRUH4TFV37Cgak