### PR TITLE
fix(daily-story): grant table privileges (fixes 42501 perm denied)

### DIFF
--- a/supabase/migrations/20260510000001_grant_daily_story_permissions.sql
+++ b/supabase/migrations/20260510000001_grant_daily_story_permissions.sql
@@ -1,0 +1,21 @@
+-- Grant table privileges for the daily story feature.
+--
+-- The migration that creates `daily_story_places` and `daily_stories` enables
+-- RLS but does not grant table-level privileges. Without these GRANTs, even
+-- the service_role gets `permission denied for table` (Postgres error 42501)
+-- because RLS-bypass only kicks in *after* basic table privileges are in
+-- place.
+--
+-- This mirrors the pattern used for `passport_entries` (see
+-- 20251213000001_grant_passport_permissions.sql).
+--
+-- Role summary:
+-- - service_role: backend cron job. Needs full read/write on both tables.
+-- - anon / authenticated: app readers. Only SELECT on daily_stories, gated
+--   further by the RLS policy added in 20260510000000 to past publish_dates.
+-- - daily_story_places: deliberately NOT granted to anon/authenticated. The
+--   master place list is admin-only (managed via Supabase Dashboard).
+
+grant select, insert, update, delete on table public.daily_story_places to service_role;
+grant select, insert, update, delete on table public.daily_stories to service_role;
+grant select on table public.daily_stories to anon, authenticated;


### PR DESCRIPTION
## Summary

The original `20260510000000_create_daily_story_tables.sql` migration enabled RLS but didn't grant table-level privileges. Without explicit GRANTs, even `service_role` (which bypasses RLS) gets:

\`\`\`
postgrest.exceptions.APIError: {'message': 'permission denied for table daily_story_places', 'code': '42501', ...}
\`\`\`

Hit during the first VPS smoke test of the daily story cron job.

## Fix

New migration `20260510000001_grant_daily_story_permissions.sql`:

\`\`\`sql
grant select, insert, update, delete on table public.daily_story_places to service_role;
grant select, insert, update, delete on table public.daily_stories to service_role;
grant select on table public.daily_stories to anon, authenticated;
\`\`\`

- **service_role**: full read/write — backend cron picks places, writes stories, marks places used
- **anon / authenticated**: SELECT on `daily_stories` only — Flutter app reads via anon key, RLS policy in #54 already gates to past `publish_date`
- **daily_story_places** stays admin-only — no anon/authenticated grants on purpose; the master list is curated via Supabase Dashboard

Mirrors the `20251213000001_grant_passport_permissions.sql` pattern that already exists for the passport feature.

## Test plan

- [ ] CI's `push-supabase-db` job applies this migration to production
- [ ] Re-run the manual smoke from the VPS:
      \`docker exec lorescape-backend python -m lorescape_backend.daily_story \$(date -d tomorrow +%F)\`
- [ ] No 42501 error; two rows (zh-TW + en) appear in \`daily_stories\` for tomorrow's date

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)