### PR TITLE
feat(daily-story): make DailyStoryCard scroll with place list

### DIFF
--- a/frontend/lib/features/daily_story/presentation/widgets/daily_story_card.dart
+++ b/frontend/lib/features/daily_story/presentation/widgets/daily_story_card.dart
@@ -49,7 +49,7 @@ class _StoryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      margin: const EdgeInsets.symmetric(vertical: 8),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
@@ -118,7 +118,7 @@ class _LoadingCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      margin: const EdgeInsets.symmetric(vertical: 8),
       child: SizedBox(
         height: 120,
         child: Center(child: Text('daily_story.card_loading'.tr())),
@@ -134,7 +134,7 @@ class _EmptyCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      margin: const EdgeInsets.symmetric(vertical: 8),
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/frontend/lib/features/explore/data/services/wikidata_landmark_query_service.dart
+++ b/frontend/lib/features/explore/data/services/wikidata_landmark_query_service.dart
@@ -120,10 +120,7 @@ class WikidataLandmarkQueryService {
     return ids;
   }
 
-  static String _buildSparql({
-    required String regionQid,
-    required int limit,
-  }) {
+  static String _buildSparql({required String regionQid, required int limit}) {
     final values = WikidataCategoryMapper.whitelistedClassIds
         .map((id) => 'wd:$id')
         .join(' ');

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -129,29 +129,51 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                 ],
               ),
             ),
-            const DailyStoryCard(),
             Expanded(
               child: placesState.when(
-                data: (places) => places.isEmpty
-                    ? Center(
-                        child: Text(
-                          'No places found',
-                          style: TextStyle(
-                            color: colorScheme.onSurfaceVariant,
-                            fontSize: 16,
+                loading: () => ListView(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  children: const [
+                    DailyStoryCard(),
+                    Padding(
+                      padding: EdgeInsets.symmetric(vertical: 80),
+                      child: Center(child: AdaptiveProgressIndicator()),
+                    ),
+                  ],
+                ),
+                error: (error, stack) => ListView(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  children: [
+                    const DailyStoryCard(),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 40),
+                      child: Center(
+                        child: Text('${'common.error_prefix'.tr()}: $error'),
+                      ),
+                    ),
+                  ],
+                ),
+                data: (places) => ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  itemCount: places.length + (places.isEmpty ? 2 : 1),
+                  itemBuilder: (context, index) {
+                    if (index == 0) return const DailyStoryCard();
+                    if (places.isEmpty) {
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 40),
+                        child: Center(
+                          child: Text(
+                            'No places found',
+                            style: TextStyle(
+                              color: colorScheme.onSurfaceVariant,
+                              fontSize: 16,
+                            ),
                           ),
                         ),
-                      )
-                    : ListView.builder(
-                        padding: const EdgeInsets.symmetric(horizontal: 20),
-                        itemCount: places.length,
-                        itemBuilder: (context, index) {
-                          return PlaceCard(place: places[index]);
-                        },
-                      ),
-                loading: () => const Center(child: AdaptiveProgressIndicator()),
-                error: (error, stack) => Center(
-                  child: Text('${'common.error_prefix'.tr()}: $error'),
+                      );
+                    }
+                    return PlaceCard(place: places[index - 1]);
+                  },
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary

Move the daily story card from a pinned position to inside the scrollable place list, so users can scroll it off-screen to get more room for browsing places.

## Changes

- **`explore_screen.dart`**: drop the standalone `DailyStoryCard()` from the body Column. The Expanded's three branches (loading / error / data) each render a ListView with the card as their first child. Data branch uses `ListView.builder` (preserves laziness) with `itemCount = places.length + 1` (or `+2` when empty so the "no places" message also renders).
- **`daily_story_card.dart`**: drop the `horizontal: 20` from each Card's margin. Parent ListView's `padding: EdgeInsets.symmetric(horizontal: 20)` now controls outer spacing — without this change the card would have 40px horizontal margin (20 from itself + 20 from ListView padding).

The third file in the diff is `wikidata_landmark_query_service.dart` — a pure auto-format change from the pre-commit hook, unrelated to this PR but cleanest to land it here rather than leave the working tree dirty.

## Tests

- 417/417 tests pass; no analyze issues
- Existing widget tests for ExploreScreen and DailyStoryCard still pass (they don't assert on scroll behaviour)

## Test plan

- [ ] Open Explore → see card at top with places below
- [ ] Scroll up — card moves with the places list, eventually off-screen
- [ ] Scroll back down — card reappears at top of the scroll content
- [ ] Loading state: spinner appears below the card
- [ ] No-places state: "No places found" appears below the card

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)