### PR TITLE
Add cloud sync infrastructure with Supabase and authentication

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -216,7 +216,21 @@
     "theme": "Appearance",
     "theme_dark": "Dark",
     "theme_light": "Light",
-    "theme_system": "System"
+    "theme_system": "System",
+    "sync_section": "Cloud Sync",
+    "sync_toggle": "Sync to Cloud",
+    "sync_toggle_subtitle_on": "Your places and journeys stay in sync across devices.",
+    "sync_toggle_subtitle_off": "Sign in to back up and sync across devices.",
+    "sync_requires_signin": "Sign in to enable cloud sync.",
+    "sync_in_progress": "Syncing…",
+    "sync_disable_keeps_cloud": "Disabling sync keeps cloud data — local stays unchanged.",
+    "account_section": "Account",
+    "account_signed_in_as": "Signed in as {name}",
+    "account_not_signed_in": "Not signed in",
+    "sign_in_google": "Continue with Google",
+    "sign_in_apple": "Continue with Apple",
+    "sign_out": "Sign out",
+    "sign_in_failed": "Sign-in failed. Please try again."
   },
   "place_category": {
     "historical_cultural": "Historical & Cultural",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -216,7 +216,21 @@
     "theme": "外觀",
     "theme_dark": "深色",
     "theme_light": "淺色",
-    "theme_system": "跟隨系統"
+    "theme_system": "跟隨系統",
+    "sync_section": "雲端同步",
+    "sync_toggle": "同步到雲端",
+    "sync_toggle_subtitle_on": "您的地點與旅程會在裝置間保持同步。",
+    "sync_toggle_subtitle_off": "登入以備份並在裝置間同步。",
+    "sync_requires_signin": "請先登入以啟用雲端同步。",
+    "sync_in_progress": "同步中…",
+    "sync_disable_keeps_cloud": "關閉同步會保留雲端資料，本機資料不會變動。",
+    "account_section": "帳號",
+    "account_signed_in_as": "已登入：{name}",
+    "account_not_signed_in": "尚未登入",
+    "sign_in_google": "使用 Google 繼續",
+    "sign_in_apple": "使用 Apple 繼續",
+    "sign_out": "登出",
+    "sign_in_failed": "登入失敗，請再試一次。"
   },
   "place_category": {
     "historical_cultural": "人文古蹟",

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -8,6 +8,8 @@ import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/onboarding/providers.dart';
 import 'package:context_app/features/saved_locations/providers.dart';
 import 'package:context_app/features/share/providers.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 import 'package:context_app/shared/widgets/midnight/midnight.dart';
 
@@ -30,6 +32,14 @@ class LorescapeApp extends ConsumerWidget {
     // itself stays in `initial` until this completes, so the router
     // redirect knows to wait instead of flashing `/onboarding`.
     ref.read(onboardingControllerProvider.notifier).ensureLoaded();
+
+    // When the sync session becomes active (toggle on + signed in),
+    // run a full sync pass. Re-entry is guarded inside the coordinator.
+    ref.listen<SyncSession>(syncSessionProvider, (prev, next) {
+      if (next.isActive && !(prev?.isActive ?? false)) {
+        ref.read(syncCoordinatorProvider).runFullSync();
+      }
+    });
 
     // Listen for resolved shared places and save directly.
     ref.listen<AsyncValue<Place>?>(pendingSharedPlaceProvider, (prev, next) {

--- a/frontend/lib/features/auth/data/supabase_auth_service.dart
+++ b/frontend/lib/features/auth/data/supabase_auth_service.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show Platform;
+import 'dart:math';
+
+import 'package:context_app/app/config/api_config.dart';
+import 'package:context_app/features/auth/domain/models/auth_user.dart';
+import 'package:context_app/features/auth/domain/services/auth_service.dart';
+import 'package:crypto/crypto.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:logging/logging.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Supabase-backed implementation of [AuthService].
+///
+/// Handles Google Sign-In via the native `google_sign_in` plugin and
+/// Apple Sign-In via `sign_in_with_apple`, then exchanges the resulting
+/// ID token for a Supabase session.
+class SupabaseAuthService implements AuthService {
+  SupabaseAuthService({
+    required ApiConfig apiConfig,
+    SupabaseClient? client,
+    GoogleSignIn? googleSignIn,
+  }) : _client = client ?? Supabase.instance.client,
+       _googleSignIn =
+           googleSignIn ??
+           GoogleSignIn(
+             clientId: Platform.isIOS ? apiConfig.googleIosClientId : null,
+             serverClientId: apiConfig.googleWebClientId,
+             scopes: const ['email', 'openid', 'profile'],
+           );
+
+  static final _log = Logger('SupabaseAuthService');
+
+  final SupabaseClient _client;
+  final GoogleSignIn _googleSignIn;
+
+  @override
+  AuthUser? get currentUser => _toAuthUser(_client.auth.currentUser);
+
+  @override
+  Stream<AuthUser?> authStateChanges() {
+    return _client.auth.onAuthStateChange.map(
+      (state) => _toAuthUser(state.session?.user),
+    );
+  }
+
+  @override
+  Future<AuthUser> signInWithGoogle() async {
+    try {
+      final account = await _googleSignIn.signIn();
+      if (account == null) {
+        throw const AuthCancelledException();
+      }
+      final auth = await account.authentication;
+      final idToken = auth.idToken;
+      final accessToken = auth.accessToken;
+      if (idToken == null) {
+        throw const AuthFailureException('Google did not return an ID token');
+      }
+      final response = await _client.auth.signInWithIdToken(
+        provider: OAuthProvider.google,
+        idToken: idToken,
+        accessToken: accessToken,
+      );
+      final user = response.user;
+      if (user == null) {
+        throw const AuthFailureException('Supabase did not return a user');
+      }
+      return _toAuthUser(user)!;
+    } on AuthCancelledException {
+      rethrow;
+    } catch (e, stack) {
+      _log.warning('Google sign-in failed', e, stack);
+      if (e is AuthFailureException) rethrow;
+      throw AuthFailureException(e.toString());
+    }
+  }
+
+  @override
+  Future<AuthUser> signInWithApple() async {
+    try {
+      final rawNonce = _generateNonce();
+      final hashedNonce = sha256
+          .convert(utf8.encode(rawNonce))
+          .toString();
+
+      final credential = await SignInWithApple.getAppleIDCredential(
+        scopes: const [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        nonce: hashedNonce,
+      );
+
+      final idToken = credential.identityToken;
+      if (idToken == null) {
+        throw const AuthFailureException('Apple did not return an ID token');
+      }
+
+      final response = await _client.auth.signInWithIdToken(
+        provider: OAuthProvider.apple,
+        idToken: idToken,
+        nonce: rawNonce,
+      );
+      final user = response.user;
+      if (user == null) {
+        throw const AuthFailureException('Supabase did not return a user');
+      }
+      return _toAuthUser(user)!;
+    } on SignInWithAppleAuthorizationException catch (e, stack) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        throw const AuthCancelledException();
+      }
+      _log.warning('Apple sign-in failed', e, stack);
+      throw AuthFailureException(e.message);
+    } catch (e, stack) {
+      _log.warning('Apple sign-in failed', e, stack);
+      if (e is AuthFailureException || e is AuthCancelledException) rethrow;
+      throw AuthFailureException(e.toString());
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    try {
+      await _googleSignIn.signOut();
+    } catch (_) {
+      // Google sign-out is best-effort; Supabase signOut is the source of truth.
+    }
+    await _client.auth.signOut();
+  }
+
+  static AuthUser? _toAuthUser(User? user) {
+    if (user == null) return null;
+    final metadata = user.userMetadata ?? const <String, dynamic>{};
+    final displayName =
+        metadata['full_name'] as String? ??
+        metadata['name'] as String? ??
+        user.email;
+    return AuthUser(
+      id: user.id,
+      email: user.email,
+      displayName: displayName,
+    );
+  }
+
+  static String _generateNonce([int length = 32]) {
+    const charset =
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(
+      length,
+      (_) => charset[random.nextInt(charset.length)],
+    ).join();
+  }
+}

--- a/frontend/lib/features/auth/data/supabase_auth_service.dart
+++ b/frontend/lib/features/auth/data/supabase_auth_service.dart
@@ -10,7 +10,7 @@ import 'package:crypto/crypto.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:logging/logging.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
-import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' hide AuthUser;
 
 /// Supabase-backed implementation of [AuthService].
 ///

--- a/frontend/lib/features/auth/domain/models/auth_user.dart
+++ b/frontend/lib/features/auth/domain/models/auth_user.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+/// Authenticated user as exposed by the auth domain.
+///
+/// Wraps just the fields the UI cares about so providers do not leak
+/// the Supabase SDK type across feature boundaries.
+class AuthUser extends Equatable {
+  final String id;
+  final String? email;
+  final String? displayName;
+
+  const AuthUser({required this.id, this.email, this.displayName});
+
+  @override
+  List<Object?> get props => [id, email, displayName];
+}

--- a/frontend/lib/features/auth/domain/services/auth_service.dart
+++ b/frontend/lib/features/auth/domain/services/auth_service.dart
@@ -1,0 +1,35 @@
+import 'package:context_app/features/auth/domain/models/auth_user.dart';
+
+/// Domain-level authentication facade. The implementation is responsible
+/// for translating provider-specific (Google / Apple / Supabase) details
+/// into a single [AuthUser] stream.
+abstract class AuthService {
+  /// Returns the currently authenticated user, or `null` when signed out.
+  AuthUser? get currentUser;
+
+  /// Emits the latest [AuthUser] whenever the session changes.
+  Stream<AuthUser?> authStateChanges();
+
+  /// Starts the Google Sign-In flow and signs into the backend.
+  Future<AuthUser> signInWithGoogle();
+
+  /// Starts the Sign in with Apple flow and signs into the backend.
+  Future<AuthUser> signInWithApple();
+
+  /// Clears the current session both locally and on the backend.
+  Future<void> signOut();
+}
+
+/// Thrown when a sign-in flow is cancelled by the user.
+class AuthCancelledException implements Exception {
+  const AuthCancelledException();
+}
+
+/// Thrown when authentication fails for an unexpected reason.
+class AuthFailureException implements Exception {
+  final String message;
+  const AuthFailureException(this.message);
+
+  @override
+  String toString() => 'AuthFailureException: $message';
+}

--- a/frontend/lib/features/auth/providers.dart
+++ b/frontend/lib/features/auth/providers.dart
@@ -1,0 +1,33 @@
+import 'package:context_app/app/config/api_config.dart';
+import 'package:context_app/features/auth/data/supabase_auth_service.dart';
+import 'package:context_app/features/auth/domain/models/auth_user.dart';
+import 'package:context_app/features/auth/domain/services/auth_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Default auth service (Supabase + Google/Apple). Override in tests.
+final authServiceProvider = Provider<AuthService>((ref) {
+  return SupabaseAuthService(apiConfig: ref.watch(apiConfigProvider));
+});
+
+/// Stream of the currently authenticated user. Emits `null` when signed out.
+final authStateProvider = StreamProvider<AuthUser?>((ref) {
+  final service = ref.watch(authServiceProvider);
+  // Seed with the current synchronous value so subscribers don't flicker
+  // between loading and signed-in on hot restart.
+  return service.authStateChanges().distinct();
+});
+
+/// Synchronous accessor for the current user, derived from [authStateProvider].
+/// Falls back to [AuthService.currentUser] before the first stream event.
+final currentUserProvider = Provider<AuthUser?>((ref) {
+  final stream = ref.watch(authStateProvider);
+  return stream.maybeWhen(
+    data: (user) => user,
+    orElse: () => ref.watch(authServiceProvider).currentUser,
+  );
+});
+
+/// Convenience flag exposing whether a user is signed in.
+final isSignedInProvider = Provider<bool>((ref) {
+  return ref.watch(currentUserProvider) != null;
+});

--- a/frontend/lib/features/journey/domain/models/journey_entry.dart
+++ b/frontend/lib/features/journey/domain/models/journey_entry.dart
@@ -10,6 +10,7 @@ class JourneyEntry {
   final NarrationContent narrationContent;
   final Set<NarrationAspect> narrationAspects;
   final DateTime createdAt;
+  final DateTime updatedAt;
   final Language language;
 
   /// 所屬旅程的 id，`null` 代表尚未歸類（會顯示在「未分類」）。
@@ -21,6 +22,7 @@ class JourneyEntry {
     required this.narrationContent,
     required this.narrationAspects,
     required this.createdAt,
+    required this.updatedAt,
     required this.language,
     this.tripId,
   });
@@ -46,12 +48,14 @@ class JourneyEntry {
       imageUrl: imageUrl,
     );
 
+    final now = DateTime.now();
     return JourneyEntry(
       id: id,
       place: savedPlace,
       narrationContent: content,
       narrationAspects: aspects,
-      createdAt: DateTime.now(),
+      createdAt: now,
+      updatedAt: now,
       language: language,
       tripId: tripId,
     );
@@ -64,6 +68,7 @@ class JourneyEntry {
     narrationContent: narrationContent,
     narrationAspects: narrationAspects,
     createdAt: createdAt,
+    updatedAt: DateTime.now(),
     language: language,
     tripId: tripId,
   );
@@ -77,6 +82,7 @@ class JourneyEntry {
     'narration_text': narrationContent.text,
     'narration_styles': narrationAspects.map((a) => a.key).toList(),
     'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
     'language': language.code,
     'trip_id': tripId,
   };
@@ -116,12 +122,19 @@ class JourneyEntry {
       narrationAspects = {aspect};
     }
 
+    final createdAt = DateTime.parse(json['created_at'] as String);
+    final updatedAtRaw = json['updated_at'] as String?;
+    final updatedAt = updatedAtRaw != null
+        ? DateTime.parse(updatedAtRaw)
+        : createdAt;
+
     return JourneyEntry(
       id: json['id'] as String,
       place: place,
       narrationContent: narrationContent,
       narrationAspects: narrationAspects,
-      createdAt: DateTime.parse(json['created_at'] as String),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
       language: language,
       tripId: json['trip_id'] as String?,
     );

--- a/frontend/lib/features/journey/providers.dart
+++ b/frontend/lib/features/journey/providers.dart
@@ -1,8 +1,8 @@
-import 'package:context_app/features/journey/data/hive_journey_repository.dart';
 import 'package:context_app/features/journey/domain/models/journey_entry.dart';
 import 'package:context_app/features/journey/domain/models/journey_item.dart';
 import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
 import 'package:context_app/features/quick_guide/providers.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 export 'package:context_app/features/quick_guide/providers.dart'
@@ -15,7 +15,7 @@ enum JourneyFilter { all, narration, quickGuide }
 enum JourneyViewMode { timeline, byTrip }
 
 final journeyRepositoryProvider = Provider<JourneyRepository>((ref) {
-  return HiveJourneyRepository();
+  return ref.watch(syncingJourneyRepositoryProvider);
 });
 
 final myJourneyProvider = FutureProvider.autoDispose<List<JourneyEntry>>((ref) {

--- a/frontend/lib/features/quick_guide/domain/models/quick_guide_entry.dart
+++ b/frontend/lib/features/quick_guide/domain/models/quick_guide_entry.dart
@@ -11,6 +11,7 @@ class QuickGuideEntry {
   final Uint8List imageBytes;
   final String aiDescription;
   final DateTime createdAt;
+  final DateTime updatedAt;
   final Language language;
 
   /// 所屬旅程的 id，`null` 代表尚未歸類（會顯示在「未分類」）。
@@ -21,6 +22,7 @@ class QuickGuideEntry {
     required this.imageBytes,
     required this.aiDescription,
     required this.createdAt,
+    required this.updatedAt,
     required this.language,
     this.tripId,
   });
@@ -36,11 +38,13 @@ class QuickGuideEntry {
     required Language language,
     String? tripId,
   }) {
+    final now = DateTime.now();
     return QuickGuideEntry(
       id: id,
       imageBytes: imageBytes,
       aiDescription: aiDescription,
-      createdAt: DateTime.now(),
+      createdAt: now,
+      updatedAt: now,
       language: language,
       tripId: tripId,
     );
@@ -52,6 +56,7 @@ class QuickGuideEntry {
     imageBytes: imageBytes,
     aiDescription: aiDescription,
     createdAt: createdAt,
+    updatedAt: DateTime.now(),
     language: language,
     tripId: tripId,
   );
@@ -61,16 +66,24 @@ class QuickGuideEntry {
     'image_base64': base64Encode(imageBytes),
     'ai_description': aiDescription,
     'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
     'language': language.code,
     'trip_id': tripId,
   };
 
   factory QuickGuideEntry.fromJson(Map<String, dynamic> json) {
+    final createdAt = DateTime.parse(json['created_at'] as String);
+    final updatedAtRaw = json['updated_at'] as String?;
+    final updatedAt = updatedAtRaw != null
+        ? DateTime.parse(updatedAtRaw)
+        : createdAt;
+
     return QuickGuideEntry(
       id: json['id'] as String,
       imageBytes: base64Decode(json['image_base64'] as String),
       aiDescription: json['ai_description'] as String,
-      createdAt: DateTime.parse(json['created_at'] as String),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
       language: Language(json['language'] as String? ?? 'zh-TW'),
       tripId: json['trip_id'] as String?,
     );

--- a/frontend/lib/features/quick_guide/providers.dart
+++ b/frontend/lib/features/quick_guide/providers.dart
@@ -1,7 +1,7 @@
 import 'package:context_app/features/quick_guide/data/gemini_quick_guide_ai_service.dart';
-import 'package:context_app/features/quick_guide/data/hive_quick_guide_repository.dart';
 import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
 import 'package:context_app/features/quick_guide/domain/repositories/quick_guide_repository.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/features/quick_guide/domain/services/quick_guide_ai_service.dart';
 import 'package:context_app/features/quick_guide/domain/use_cases/generate_quick_guide_use_case.dart';
 import 'package:context_app/features/quick_guide/presentation/controllers/quick_guide_controller.dart';
@@ -15,7 +15,7 @@ final quickGuideAiServiceProvider = Provider<QuickGuideAiService>((ref) {
 });
 
 final quickGuideRepositoryProvider = Provider<QuickGuideRepository>((ref) {
-  return HiveQuickGuideRepository();
+  return ref.watch(syncingQuickGuideRepositoryProvider);
 });
 
 final generateQuickGuideUseCaseProvider = Provider<GenerateQuickGuideUseCase>((

--- a/frontend/lib/features/saved_locations/domain/models/saved_location_entry.dart
+++ b/frontend/lib/features/saved_locations/domain/models/saved_location_entry.dart
@@ -18,6 +18,7 @@ class SavedLocationEntry extends Equatable {
   final List<Map<String, dynamic>> photosJson;
   final String categoryKey;
   final DateTime savedAt;
+  final DateTime updatedAt;
 
   const SavedLocationEntry({
     required this.placeId,
@@ -29,10 +30,12 @@ class SavedLocationEntry extends Equatable {
     required this.photosJson,
     required this.categoryKey,
     required this.savedAt,
+    required this.updatedAt,
   });
 
   /// Creates from a [Place] domain model.
   factory SavedLocationEntry.fromPlace(Place place) {
+    final now = DateTime.now();
     return SavedLocationEntry(
       placeId: place.id,
       name: place.name,
@@ -51,7 +54,8 @@ class SavedLocationEntry extends Equatable {
           )
           .toList(),
       categoryKey: place.category.name,
-      savedAt: DateTime.now(),
+      savedAt: now,
+      updatedAt: now,
     );
   }
 
@@ -93,9 +97,16 @@ class SavedLocationEntry extends Equatable {
     'photos': photosJson,
     'category_key': categoryKey,
     'saved_at': savedAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
   };
 
   factory SavedLocationEntry.fromJson(Map<String, dynamic> json) {
+    final savedAt = DateTime.parse(json['saved_at'] as String);
+    final updatedAtRaw = json['updated_at'] as String?;
+    final updatedAt = updatedAtRaw != null
+        ? DateTime.parse(updatedAtRaw)
+        : savedAt;
+
     return SavedLocationEntry(
       placeId: json['place_id'] as String,
       name: json['name'] as String,
@@ -107,7 +118,8 @@ class SavedLocationEntry extends Equatable {
           .map((p) => Map<String, dynamic>.from(p as Map))
           .toList(),
       categoryKey: json['category_key'] as String,
-      savedAt: DateTime.parse(json['saved_at'] as String),
+      savedAt: savedAt,
+      updatedAt: updatedAt,
     );
   }
 

--- a/frontend/lib/features/saved_locations/providers.dart
+++ b/frontend/lib/features/saved_locations/providers.dart
@@ -1,14 +1,14 @@
 import 'package:context_app/features/explore/domain/models/place.dart';
-import 'package:context_app/features/saved_locations/data/hive_saved_locations_repository.dart';
 import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
 import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Singleton repository provider.
 final savedLocationsRepositoryProvider = Provider<SavedLocationsRepository>((
   ref,
 ) {
-  return HiveSavedLocationsRepository();
+  return ref.watch(syncingSavedLocationsRepositoryProvider);
 });
 
 /// Notifier that manages the saved locations list.

--- a/frontend/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/screens/settings_screen.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:go_router/go_router.dart';
+import 'package:context_app/features/auth/domain/services/auth_service.dart';
+import 'package:context_app/features/auth/providers.dart';
 import 'package:context_app/features/onboarding/providers.dart';
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/subscription/providers.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
 import 'package:context_app/shared/widgets/midnight/midnight.dart';
@@ -27,6 +30,14 @@ class SettingsScreen extends ConsumerWidget {
           _SectionHeader(title: 'settings.preferences'.tr()),
           const SizedBox(height: 8),
           _SectionContainer(children: [_LanguageTile(controller: controller)]),
+          const SizedBox(height: 32),
+          _SectionHeader(title: 'settings.account_section'.tr()),
+          const SizedBox(height: 8),
+          const _AccountSection(),
+          const SizedBox(height: 32),
+          _SectionHeader(title: 'settings.sync_section'.tr()),
+          const SizedBox(height: 8),
+          const _SyncSection(),
           const SizedBox(height: 32),
           _SectionHeader(title: 'settings.daily_usage'.tr()),
           const SizedBox(height: 8),
@@ -319,6 +330,195 @@ class _UsageSection extends StatelessWidget {
             iconColor: colorScheme.primary,
             iconBgColor: colorScheme.primary.withValues(alpha: 0.2),
             title: 'settings.daily_usage'.tr(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// Account & Sync sections
+// ============================================================================
+
+class _AccountSection extends ConsumerWidget {
+  const _AccountSection();
+
+  Future<void> _handleSignIn(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool useApple,
+  }) async {
+    final service = ref.read(authServiceProvider);
+    try {
+      if (useApple) {
+        await service.signInWithApple();
+      } else {
+        await service.signInWithGoogle();
+      }
+    } on AuthCancelledException {
+      return;
+    } catch (_) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('settings.sign_in_failed'.tr()),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleSignOut(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text('settings.sign_out'.tr()),
+        content: Text('settings.logout_confirm'.tr()),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text('settings.cancel'.tr()),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text('settings.sign_out'.tr()),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await ref.read(authServiceProvider).signOut();
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (user != null) {
+      return _SectionContainer(
+        children: [
+          _SettingsTile(
+            icon: Icons.person,
+            iconColor: colorScheme.primary,
+            iconBgColor: colorScheme.primary.withValues(alpha: 0.2),
+            title: 'settings.account_signed_in_as'.tr(
+              namedArgs: {'name': user.displayName ?? user.email ?? user.id},
+            ),
+            trailing: TextButton(
+              onPressed: () => _handleSignOut(context, ref),
+              child: Text('settings.sign_out'.tr()),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return _SectionContainer(
+      children: [
+        _SettingsTile(
+          icon: Icons.person_outline,
+          iconColor: colorScheme.primary,
+          iconBgColor: colorScheme.primary.withValues(alpha: 0.2),
+          title: 'settings.account_not_signed_in'.tr(),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              FilledButton.icon(
+                key: const ValueKey('sign_in_google'),
+                icon: const Icon(Icons.login),
+                label: Text('settings.sign_in_google'.tr()),
+                onPressed: () =>
+                    _handleSignIn(context, ref, useApple: false),
+              ),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                key: const ValueKey('sign_in_apple'),
+                icon: const Icon(Icons.apple),
+                label: Text('settings.sign_in_apple'.tr()),
+                onPressed: () => _handleSignIn(context, ref, useApple: true),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SyncSection extends ConsumerWidget {
+  const _SyncSection();
+
+  Future<void> _handleToggle(WidgetRef ref, bool value) async {
+    await ref.read(syncSettingsProvider.notifier).setEnabled(value);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = ref.watch(currentUserProvider);
+    final enabled = ref.watch(syncSettingsProvider);
+    final colorScheme = Theme.of(context).colorScheme;
+    final isSignedIn = user != null;
+
+    final subtitle = !isSignedIn
+        ? 'settings.sync_requires_signin'.tr()
+        : (enabled
+              ? 'settings.sync_toggle_subtitle_on'.tr()
+              : 'settings.sync_toggle_subtitle_off'.tr());
+
+    return _SectionContainer(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              Container(
+                width: 32,
+                height: 32,
+                decoration: BoxDecoration(
+                  color: colorScheme.primary.withValues(alpha: 0.2),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.cloud_sync,
+                  color: colorScheme.primary,
+                  size: 20,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'settings.sync_toggle'.tr(),
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      subtitle,
+                      style: TextStyle(
+                        color: colorScheme.onSurfaceVariant,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(
+                key: const ValueKey('sync_toggle_switch'),
+                value: enabled && isSignedIn,
+                onChanged: isSignedIn ? (v) => _handleToggle(ref, v) : null,
+              ),
+            ],
           ),
         ),
       ],

--- a/frontend/lib/features/sync/data/supabase_journey_remote_data_source.dart
+++ b/frontend/lib/features/sync/data/supabase_journey_remote_data_source.dart
@@ -1,0 +1,93 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/models/saved_place.dart';
+import 'package:context_app/features/narration/domain/models/narration_aspect.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class SupabaseJourneyRemoteDataSource
+    implements RemoteSyncDataSource<JourneyEntry> {
+  SupabaseJourneyRemoteDataSource(this._client);
+
+  static const _table = 'journey_entries';
+  final SupabaseClient _client;
+
+  String get _userId {
+    final id = _client.auth.currentUser?.id;
+    if (id == null) {
+      throw StateError('SupabaseJourneyRemoteDataSource called without auth');
+    }
+    return id;
+  }
+
+  @override
+  Future<List<JourneyEntry>> fetchAll() async {
+    final rows = await _client.from(_table).select().eq('user_id', _userId);
+    return rows.map(_fromRow).toList();
+  }
+
+  @override
+  Future<void> upsert(JourneyEntry item) async {
+    await _client.from(_table).upsert(_toRow(item));
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await _client
+        .from(_table)
+        .delete()
+        .eq('user_id', _userId)
+        .eq('id', id);
+  }
+
+  Map<String, dynamic> _toRow(JourneyEntry entry) => {
+    'id': entry.id,
+    'user_id': _userId,
+    'place_id': entry.place.id,
+    'place_name': entry.place.name,
+    'place_address': entry.place.address,
+    'place_image_url': entry.place.imageUrl,
+    'narration_text': entry.narrationContent.text,
+    'narration_styles': entry.narrationAspects.map((a) => a.key).toList(),
+    'language': entry.language.code,
+    'trip_id': entry.tripId,
+    'created_at': entry.createdAt.toIso8601String(),
+    'updated_at': entry.updatedAt.toIso8601String(),
+  };
+
+  static JourneyEntry _fromRow(Map<String, dynamic> row) {
+    final language = Language(row['language'] as String? ?? 'zh-TW');
+    final styles = ((row['narration_styles'] as List?) ?? const [])
+        .cast<String>()
+        .map(NarrationAspect.fromKey)
+        .whereType<NarrationAspect>()
+        .toSet();
+    final aspects = styles.isEmpty
+        ? {NarrationAspect.historicalBackground}
+        : styles;
+    final createdAt = DateTime.parse(row['created_at'] as String);
+    final updatedAt = row['updated_at'] != null
+        ? DateTime.parse(row['updated_at'] as String)
+        : createdAt;
+
+    return JourneyEntry(
+      id: row['id'] as String,
+      place: SavedPlace(
+        id: row['place_id'] as String,
+        name: row['place_name'] as String,
+        address: row['place_address'] as String,
+        imageUrl: row['place_image_url'] as String?,
+      ),
+      narrationContent: NarrationContent.create(
+        row['narration_text'] as String,
+        language: language,
+      ),
+      narrationAspects: aspects,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      language: language,
+      tripId: row['trip_id'] as String?,
+    );
+  }
+}

--- a/frontend/lib/features/sync/data/supabase_quick_guide_remote_data_source.dart
+++ b/frontend/lib/features/sync/data/supabase_quick_guide_remote_data_source.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/settings/domain/models/language.dart';
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class SupabaseQuickGuideRemoteDataSource
+    implements RemoteSyncDataSource<QuickGuideEntry> {
+  SupabaseQuickGuideRemoteDataSource(this._client);
+
+  static const _table = 'quick_guide_entries';
+  final SupabaseClient _client;
+
+  String get _userId {
+    final id = _client.auth.currentUser?.id;
+    if (id == null) {
+      throw StateError(
+        'SupabaseQuickGuideRemoteDataSource called without auth',
+      );
+    }
+    return id;
+  }
+
+  @override
+  Future<List<QuickGuideEntry>> fetchAll() async {
+    final rows = await _client.from(_table).select().eq('user_id', _userId);
+    return rows.map(_fromRow).toList();
+  }
+
+  @override
+  Future<void> upsert(QuickGuideEntry item) async {
+    await _client.from(_table).upsert(_toRow(item));
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await _client
+        .from(_table)
+        .delete()
+        .eq('user_id', _userId)
+        .eq('id', id);
+  }
+
+  Map<String, dynamic> _toRow(QuickGuideEntry entry) => {
+    'id': entry.id,
+    'user_id': _userId,
+    'image_base64': base64Encode(entry.imageBytes),
+    'ai_description': entry.aiDescription,
+    'language': entry.language.code,
+    'trip_id': entry.tripId,
+    'created_at': entry.createdAt.toIso8601String(),
+    'updated_at': entry.updatedAt.toIso8601String(),
+  };
+
+  static QuickGuideEntry _fromRow(Map<String, dynamic> row) {
+    final createdAt = DateTime.parse(row['created_at'] as String);
+    final updatedAt = row['updated_at'] != null
+        ? DateTime.parse(row['updated_at'] as String)
+        : createdAt;
+
+    return QuickGuideEntry(
+      id: row['id'] as String,
+      imageBytes: base64Decode(row['image_base64'] as String),
+      aiDescription: row['ai_description'] as String,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      language: Language(row['language'] as String? ?? 'zh-TW'),
+      tripId: row['trip_id'] as String?,
+    );
+  }
+}

--- a/frontend/lib/features/sync/data/supabase_saved_locations_remote_data_source.dart
+++ b/frontend/lib/features/sync/data/supabase_saved_locations_remote_data_source.dart
@@ -1,0 +1,78 @@
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class SupabaseSavedLocationsRemoteDataSource
+    implements RemoteSyncDataSource<SavedLocationEntry> {
+  SupabaseSavedLocationsRemoteDataSource(this._client);
+
+  static const _table = 'saved_locations';
+  final SupabaseClient _client;
+
+  String get _userId {
+    final id = _client.auth.currentUser?.id;
+    if (id == null) {
+      throw StateError(
+        'SupabaseSavedLocationsRemoteDataSource called without auth',
+      );
+    }
+    return id;
+  }
+
+  @override
+  Future<List<SavedLocationEntry>> fetchAll() async {
+    final rows = await _client.from(_table).select().eq('user_id', _userId);
+    return rows.map(_fromRow).toList();
+  }
+
+  @override
+  Future<void> upsert(SavedLocationEntry item) async {
+    await _client.from(_table).upsert(_toRow(item));
+  }
+
+  @override
+  Future<void> delete(String placeId) async {
+    await _client
+        .from(_table)
+        .delete()
+        .eq('user_id', _userId)
+        .eq('place_id', placeId);
+  }
+
+  Map<String, dynamic> _toRow(SavedLocationEntry entry) => {
+    'place_id': entry.placeId,
+    'user_id': _userId,
+    'name': entry.name,
+    'formatted_address': entry.address,
+    'latitude': entry.latitude,
+    'longitude': entry.longitude,
+    'types': entry.tags,
+    'photos': entry.photosJson,
+    'category_key': entry.categoryKey,
+    'saved_at': entry.savedAt.toIso8601String(),
+    'updated_at': entry.updatedAt.toIso8601String(),
+  };
+
+  static SavedLocationEntry _fromRow(Map<String, dynamic> row) {
+    final savedAt = DateTime.parse(row['saved_at'] as String);
+    final updatedAt = row['updated_at'] != null
+        ? DateTime.parse(row['updated_at'] as String)
+        : savedAt;
+    final photos = (row['photos'] as List<dynamic>? ?? const [])
+        .map((p) => Map<String, dynamic>.from(p as Map))
+        .toList();
+
+    return SavedLocationEntry(
+      placeId: row['place_id'] as String,
+      name: row['name'] as String,
+      address: row['formatted_address'] as String,
+      latitude: (row['latitude'] as num).toDouble(),
+      longitude: (row['longitude'] as num).toDouble(),
+      tags: (row['types'] as List<dynamic>? ?? const []).cast<String>(),
+      photosJson: photos,
+      categoryKey: row['category_key'] as String,
+      savedAt: savedAt,
+      updatedAt: updatedAt,
+    );
+  }
+}

--- a/frontend/lib/features/sync/data/supabase_trip_remote_data_source.dart
+++ b/frontend/lib/features/sync/data/supabase_trip_remote_data_source.dart
@@ -1,0 +1,70 @@
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class SupabaseTripRemoteDataSource implements RemoteSyncDataSource<Trip> {
+  SupabaseTripRemoteDataSource(this._client);
+
+  static const _table = 'trips';
+  final SupabaseClient _client;
+
+  String get _userId {
+    final id = _client.auth.currentUser?.id;
+    if (id == null) {
+      throw StateError('SupabaseTripRemoteDataSource called without auth');
+    }
+    return id;
+  }
+
+  @override
+  Future<List<Trip>> fetchAll() async {
+    final rows = await _client.from(_table).select().eq('user_id', _userId);
+    return rows.map(_fromRow).toList();
+  }
+
+  @override
+  Future<void> upsert(Trip item) async {
+    await _client.from(_table).upsert(_toRow(item));
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await _client
+        .from(_table)
+        .delete()
+        .eq('user_id', _userId)
+        .eq('id', id);
+  }
+
+  Map<String, dynamic> _toRow(Trip trip) => {
+    'id': trip.id,
+    'user_id': _userId,
+    'name': trip.name,
+    'start_date': trip.startDate?.toIso8601String(),
+    'end_date': trip.endDate?.toIso8601String(),
+    'cover_image_url': trip.coverImageUrl,
+    'description': trip.description,
+    'created_at': trip.createdAt.toIso8601String(),
+    'updated_at': trip.updatedAt.toIso8601String(),
+  };
+
+  static Trip _fromRow(Map<String, dynamic> row) {
+    DateTime? parseTs(Object? v) =>
+        v is String && v.isNotEmpty ? DateTime.parse(v) : null;
+    final createdAt = DateTime.parse(row['created_at'] as String);
+    final updatedAt = row['updated_at'] != null
+        ? DateTime.parse(row['updated_at'] as String)
+        : createdAt;
+
+    return Trip(
+      id: row['id'] as String,
+      name: row['name'] as String,
+      startDate: parseTs(row['start_date']),
+      endDate: parseTs(row['end_date']),
+      coverImageUrl: row['cover_image_url'] as String?,
+      description: row['description'] as String?,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+}

--- a/frontend/lib/features/sync/data/syncing_journey_repository.dart
+++ b/frontend/lib/features/sync/data/syncing_journey_repository.dart
@@ -1,0 +1,37 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+
+/// Decorates a local [JourneyRepository] with optional write-through to
+/// Supabase whenever sync is active.
+class SyncingJourneyRepository implements JourneyRepository {
+  SyncingJourneyRepository({
+    required this.local,
+    required this.engine,
+    required this.session,
+  });
+
+  final JourneyRepository local;
+  final SyncEngine<JourneyEntry> engine;
+  final SyncSession Function() session;
+
+  @override
+  Future<List<JourneyEntry>> getAll() => local.getAll();
+
+  @override
+  Future<void> save(JourneyEntry entry) async {
+    await local.save(entry);
+    if (session().isActive) {
+      await engine.push(entry);
+    }
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await local.delete(id);
+    if (session().isActive) {
+      await engine.deleteRemote(id);
+    }
+  }
+}

--- a/frontend/lib/features/sync/data/syncing_quick_guide_repository.dart
+++ b/frontend/lib/features/sync/data/syncing_quick_guide_repository.dart
@@ -1,0 +1,35 @@
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/quick_guide/domain/repositories/quick_guide_repository.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+
+class SyncingQuickGuideRepository implements QuickGuideRepository {
+  SyncingQuickGuideRepository({
+    required this.local,
+    required this.engine,
+    required this.session,
+  });
+
+  final QuickGuideRepository local;
+  final SyncEngine<QuickGuideEntry> engine;
+  final SyncSession Function() session;
+
+  @override
+  Future<List<QuickGuideEntry>> getAll() => local.getAll();
+
+  @override
+  Future<void> save(QuickGuideEntry entry) async {
+    await local.save(entry);
+    if (session().isActive) {
+      await engine.push(entry);
+    }
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await local.delete(id);
+    if (session().isActive) {
+      await engine.deleteRemote(id);
+    }
+  }
+}

--- a/frontend/lib/features/sync/data/syncing_saved_locations_repository.dart
+++ b/frontend/lib/features/sync/data/syncing_saved_locations_repository.dart
@@ -1,0 +1,38 @@
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+
+class SyncingSavedLocationsRepository implements SavedLocationsRepository {
+  SyncingSavedLocationsRepository({
+    required this.local,
+    required this.engine,
+    required this.session,
+  });
+
+  final SavedLocationsRepository local;
+  final SyncEngine<SavedLocationEntry> engine;
+  final SyncSession Function() session;
+
+  @override
+  Future<List<SavedLocationEntry>> getAll() => local.getAll();
+
+  @override
+  Future<bool> isSaved(String placeId) => local.isSaved(placeId);
+
+  @override
+  Future<void> save(SavedLocationEntry entry) async {
+    await local.save(entry);
+    if (session().isActive) {
+      await engine.push(entry);
+    }
+  }
+
+  @override
+  Future<void> delete(String placeId) async {
+    await local.delete(placeId);
+    if (session().isActive) {
+      await engine.deleteRemote(placeId);
+    }
+  }
+}

--- a/frontend/lib/features/sync/data/syncing_trip_repository.dart
+++ b/frontend/lib/features/sync/data/syncing_trip_repository.dart
@@ -1,0 +1,38 @@
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/domain/repositories/trip_repository.dart';
+
+class SyncingTripRepository implements TripRepository {
+  SyncingTripRepository({
+    required this.local,
+    required this.engine,
+    required this.session,
+  });
+
+  final TripRepository local;
+  final SyncEngine<Trip> engine;
+  final SyncSession Function() session;
+
+  @override
+  Future<List<Trip>> getAll() => local.getAll();
+
+  @override
+  Future<Trip?> getById(String id) => local.getById(id);
+
+  @override
+  Future<void> save(Trip trip) async {
+    await local.save(trip);
+    if (session().isActive) {
+      await engine.push(trip);
+    }
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    await local.delete(id);
+    if (session().isActive) {
+      await engine.deleteRemote(id);
+    }
+  }
+}

--- a/frontend/lib/features/sync/domain/services/remote_sync_data_source.dart
+++ b/frontend/lib/features/sync/domain/services/remote_sync_data_source.dart
@@ -1,0 +1,9 @@
+/// Generic remote source for a single entity type.
+///
+/// Implementations are responsible for scoping queries by the
+/// currently-signed-in user.
+abstract class RemoteSyncDataSource<T> {
+  Future<List<T>> fetchAll();
+  Future<void> upsert(T item);
+  Future<void> delete(String id);
+}

--- a/frontend/lib/features/sync/domain/services/sync_coordinator.dart
+++ b/frontend/lib/features/sync/domain/services/sync_coordinator.dart
@@ -1,0 +1,51 @@
+import 'dart:async';
+
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:logging/logging.dart';
+
+/// Top-level driver that runs a full sync for every entity type.
+class SyncCoordinator {
+  SyncCoordinator({
+    required this.journey,
+    required this.quickGuide,
+    required this.trip,
+    required this.savedLocations,
+  });
+
+  static final _log = Logger('SyncCoordinator');
+
+  final SyncEngine<JourneyEntry> journey;
+  final SyncEngine<QuickGuideEntry> quickGuide;
+  final SyncEngine<Trip> trip;
+  final SyncEngine<SavedLocationEntry> savedLocations;
+
+  bool _running = false;
+
+  /// Runs full sync for all four entity types in parallel.
+  ///
+  /// Re-entry is guarded so toggling on/off rapidly does not pile up
+  /// concurrent passes.
+  Future<void> runFullSync() async {
+    if (_running) {
+      _log.info('Full sync already in progress, skipping');
+      return;
+    }
+    _running = true;
+    try {
+      await Future.wait([
+        journey.fullSync(),
+        quickGuide.fullSync(),
+        trip.fullSync(),
+        savedLocations.fullSync(),
+      ]);
+    } catch (e, stack) {
+      _log.warning('Full sync failed', e, stack);
+    } finally {
+      _running = false;
+    }
+  }
+}

--- a/frontend/lib/features/sync/domain/services/sync_engine.dart
+++ b/frontend/lib/features/sync/domain/services/sync_engine.dart
@@ -1,0 +1,89 @@
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:context_app/features/sync/domain/services/sync_merger.dart';
+import 'package:logging/logging.dart';
+
+/// Per-entity descriptor that explains how to identify and order items.
+class SyncEntityDescriptor<T> {
+  final String name;
+  final String Function(T item) idOf;
+  final DateTime Function(T item) updatedAtOf;
+
+  const SyncEntityDescriptor({
+    required this.name,
+    required this.idOf,
+    required this.updatedAtOf,
+  });
+}
+
+/// Orchestrates push/pull of a single entity type between the local
+/// store (represented by callbacks) and a [RemoteSyncDataSource].
+///
+/// Callbacks keep the engine framework-agnostic so it can wrap any
+/// repository abstraction.
+class SyncEngine<T> {
+  SyncEngine({
+    required this.descriptor,
+    required this.remote,
+    required this.loadLocal,
+    required this.saveLocal,
+  });
+
+  static final _log = Logger('SyncEngine');
+
+  final SyncEntityDescriptor<T> descriptor;
+  final RemoteSyncDataSource<T> remote;
+  final Future<List<T>> Function() loadLocal;
+  final Future<void> Function(T item) saveLocal;
+
+  /// Pull from remote, merge with local by `updatedAt`, then write back
+  /// local-only or newer items to both sides.
+  Future<SyncMergeResult<T>> fullSync() async {
+    final local = await loadLocal();
+    final remoteItems = await remote.fetchAll();
+
+    final result = SyncMerger.merge<T>(
+      local: local,
+      remote: remoteItems,
+      idOf: descriptor.idOf,
+      updatedAtOf: descriptor.updatedAtOf,
+    );
+
+    for (final item in result.toApplyLocally) {
+      try {
+        await saveLocal(item);
+      } catch (e, stack) {
+        _log.warning(
+          'Failed to apply ${descriptor.name} locally',
+          e,
+          stack,
+        );
+      }
+    }
+    for (final item in result.toPush) {
+      try {
+        await remote.upsert(item);
+      } catch (e, stack) {
+        _log.warning('Failed to push ${descriptor.name}', e, stack);
+      }
+    }
+    return result;
+  }
+
+  /// Best-effort single-item push. Errors are logged, not thrown.
+  Future<void> push(T item) async {
+    try {
+      await remote.upsert(item);
+    } catch (e, stack) {
+      _log.warning('Failed to push ${descriptor.name}', e, stack);
+    }
+  }
+
+  /// Best-effort single-item delete. Errors are logged, not thrown.
+  Future<void> deleteRemote(String id) async {
+    try {
+      await remote.delete(id);
+    } catch (e, stack) {
+      _log.warning('Failed to delete ${descriptor.name} remotely', e, stack);
+    }
+  }
+}

--- a/frontend/lib/features/sync/domain/services/sync_merger.dart
+++ b/frontend/lib/features/sync/domain/services/sync_merger.dart
@@ -1,0 +1,77 @@
+/// Outcome of merging local and remote item lists by `updatedAt`.
+///
+/// * [merged] is the unified view (local + remote with the latest version
+///   per id kept).
+/// * [toPush] contains items where the local version is newer than the
+///   remote one (or the remote is missing the item entirely), so they
+///   need to be pushed up.
+/// * [toApplyLocally] contains items where the remote version is newer
+///   than the local one (or the local is missing the item entirely), so
+///   they need to be written locally.
+class SyncMergeResult<T> {
+  final List<T> merged;
+  final List<T> toPush;
+  final List<T> toApplyLocally;
+
+  const SyncMergeResult({
+    required this.merged,
+    required this.toPush,
+    required this.toApplyLocally,
+  });
+}
+
+/// Last-write-wins merge keyed by id, comparing `updatedAt` timestamps.
+///
+/// Soft deletes are out of scope at this milestone — disabling sync
+/// keeps cloud data intact, and a delete is mirrored to both sides
+/// while sync is active.
+class SyncMerger {
+  static SyncMergeResult<T> merge<T>({
+    required List<T> local,
+    required List<T> remote,
+    required String Function(T item) idOf,
+    required DateTime Function(T item) updatedAtOf,
+  }) {
+    final localById = {for (final item in local) idOf(item): item};
+    final remoteById = {for (final item in remote) idOf(item): item};
+    final allIds = {...localById.keys, ...remoteById.keys};
+
+    final merged = <T>[];
+    final toPush = <T>[];
+    final toApplyLocally = <T>[];
+
+    for (final id in allIds) {
+      final localItem = localById[id];
+      final remoteItem = remoteById[id];
+
+      if (localItem == null && remoteItem != null) {
+        merged.add(remoteItem);
+        toApplyLocally.add(remoteItem);
+        continue;
+      }
+      if (remoteItem == null && localItem != null) {
+        merged.add(localItem);
+        toPush.add(localItem);
+        continue;
+      }
+
+      final localTs = updatedAtOf(localItem as T);
+      final remoteTs = updatedAtOf(remoteItem as T);
+      if (localTs.isAfter(remoteTs)) {
+        merged.add(localItem);
+        toPush.add(localItem);
+      } else if (remoteTs.isAfter(localTs)) {
+        merged.add(remoteItem);
+        toApplyLocally.add(remoteItem);
+      } else {
+        merged.add(remoteItem);
+      }
+    }
+
+    return SyncMergeResult<T>(
+      merged: merged,
+      toPush: toPush,
+      toApplyLocally: toApplyLocally,
+    );
+  }
+}

--- a/frontend/lib/features/sync/domain/services/sync_session.dart
+++ b/frontend/lib/features/sync/domain/services/sync_session.dart
@@ -1,0 +1,17 @@
+import 'package:equatable/equatable.dart';
+
+/// Combined snapshot of "is sync currently active?" — both the user
+/// preference and the signed-in user id must be present.
+class SyncSession extends Equatable {
+  final bool enabled;
+  final String? userId;
+
+  const SyncSession({required this.enabled, required this.userId});
+
+  const SyncSession.disabled() : enabled = false, userId = null;
+
+  bool get isActive => enabled && userId != null && userId!.isNotEmpty;
+
+  @override
+  List<Object?> get props => [enabled, userId];
+}

--- a/frontend/lib/features/sync/presentation/controllers/sync_settings_notifier.dart
+++ b/frontend/lib/features/sync/presentation/controllers/sync_settings_notifier.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _kSyncEnabledKey = 'sync_enabled';
+
+/// Manages the user's "sync to cloud" preference and persists it.
+///
+/// State is `true` when sync is on. Initialised eagerly to `false` and
+/// updated asynchronously after loading from [SharedPreferences].
+class SyncSettingsNotifier extends Notifier<bool> {
+  @override
+  bool build() {
+    _loadFromPrefs();
+    return false;
+  }
+
+  Future<void> setEnabled(bool enabled) async {
+    state = enabled;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_kSyncEnabledKey, enabled);
+  }
+
+  Future<void> _loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getBool(_kSyncEnabledKey);
+    if (stored != null && stored != state) {
+      state = stored;
+    }
+  }
+}

--- a/frontend/lib/features/sync/providers.dart
+++ b/frontend/lib/features/sync/providers.dart
@@ -1,0 +1,211 @@
+import 'package:context_app/features/auth/providers.dart';
+import 'package:context_app/features/journey/data/hive_journey_repository.dart';
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/journey/domain/repositories/journey_repository.dart';
+import 'package:context_app/features/quick_guide/data/hive_quick_guide_repository.dart';
+import 'package:context_app/features/quick_guide/domain/models/quick_guide_entry.dart';
+import 'package:context_app/features/quick_guide/domain/repositories/quick_guide_repository.dart';
+import 'package:context_app/features/saved_locations/data/hive_saved_locations_repository.dart';
+import 'package:context_app/features/saved_locations/domain/models/saved_location_entry.dart';
+import 'package:context_app/features/saved_locations/domain/repositories/saved_locations_repository.dart';
+import 'package:context_app/features/sync/data/supabase_journey_remote_data_source.dart';
+import 'package:context_app/features/sync/data/supabase_quick_guide_remote_data_source.dart';
+import 'package:context_app/features/sync/data/supabase_saved_locations_remote_data_source.dart';
+import 'package:context_app/features/sync/data/supabase_trip_remote_data_source.dart';
+import 'package:context_app/features/sync/data/syncing_journey_repository.dart';
+import 'package:context_app/features/sync/data/syncing_quick_guide_repository.dart';
+import 'package:context_app/features/sync/data/syncing_saved_locations_repository.dart';
+import 'package:context_app/features/sync/data/syncing_trip_repository.dart';
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:context_app/features/sync/domain/services/sync_coordinator.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+import 'package:context_app/features/sync/presentation/controllers/sync_settings_notifier.dart';
+import 'package:context_app/features/trip/data/hive_trip_repository.dart';
+import 'package:context_app/features/trip/domain/models/trip.dart';
+import 'package:context_app/features/trip/domain/repositories/trip_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+// ---------------------------------------------------------------------------
+// Sync preference (toggle state) and session.
+// ---------------------------------------------------------------------------
+
+final syncSettingsProvider =
+    NotifierProvider<SyncSettingsNotifier, bool>(SyncSettingsNotifier.new);
+
+/// Combined live snapshot: toggle is on AND user is signed in.
+final syncSessionProvider = Provider<SyncSession>((ref) {
+  final enabled = ref.watch(syncSettingsProvider);
+  final user = ref.watch(currentUserProvider);
+  return SyncSession(enabled: enabled, userId: user?.id);
+});
+
+// ---------------------------------------------------------------------------
+// Local Hive repositories (always used for reads).
+// ---------------------------------------------------------------------------
+
+final localJourneyRepositoryProvider = Provider<JourneyRepository>((ref) {
+  return HiveJourneyRepository();
+});
+
+final localQuickGuideRepositoryProvider = Provider<QuickGuideRepository>((ref) {
+  return HiveQuickGuideRepository();
+});
+
+final localTripRepositoryProvider = Provider<TripRepository>((ref) {
+  return HiveTripRepository();
+});
+
+final localSavedLocationsRepositoryProvider =
+    Provider<SavedLocationsRepository>((ref) {
+      return HiveSavedLocationsRepository();
+    });
+
+// ---------------------------------------------------------------------------
+// Remote data sources (Supabase).
+// ---------------------------------------------------------------------------
+
+final supabaseClientProvider = Provider<SupabaseClient>((ref) {
+  return Supabase.instance.client;
+});
+
+final journeyRemoteDataSourceProvider =
+    Provider<RemoteSyncDataSource<JourneyEntry>>((ref) {
+      return SupabaseJourneyRemoteDataSource(ref.watch(supabaseClientProvider));
+    });
+
+final quickGuideRemoteDataSourceProvider =
+    Provider<RemoteSyncDataSource<QuickGuideEntry>>((ref) {
+      return SupabaseQuickGuideRemoteDataSource(
+        ref.watch(supabaseClientProvider),
+      );
+    });
+
+final tripRemoteDataSourceProvider = Provider<RemoteSyncDataSource<Trip>>((
+  ref,
+) {
+  return SupabaseTripRemoteDataSource(ref.watch(supabaseClientProvider));
+});
+
+final savedLocationsRemoteDataSourceProvider =
+    Provider<RemoteSyncDataSource<SavedLocationEntry>>((ref) {
+      return SupabaseSavedLocationsRemoteDataSource(
+        ref.watch(supabaseClientProvider),
+      );
+    });
+
+// ---------------------------------------------------------------------------
+// Sync engines.
+// ---------------------------------------------------------------------------
+
+final journeySyncEngineProvider = Provider<SyncEngine<JourneyEntry>>((ref) {
+  final local = ref.watch(localJourneyRepositoryProvider);
+  return SyncEngine<JourneyEntry>(
+    descriptor: SyncEntityDescriptor<JourneyEntry>(
+      name: 'journey_entry',
+      idOf: (e) => e.id,
+      updatedAtOf: (e) => e.updatedAt,
+    ),
+    remote: ref.watch(journeyRemoteDataSourceProvider),
+    loadLocal: local.getAll,
+    saveLocal: local.save,
+  );
+});
+
+final quickGuideSyncEngineProvider = Provider<SyncEngine<QuickGuideEntry>>((
+  ref,
+) {
+  final local = ref.watch(localQuickGuideRepositoryProvider);
+  return SyncEngine<QuickGuideEntry>(
+    descriptor: SyncEntityDescriptor<QuickGuideEntry>(
+      name: 'quick_guide_entry',
+      idOf: (e) => e.id,
+      updatedAtOf: (e) => e.updatedAt,
+    ),
+    remote: ref.watch(quickGuideRemoteDataSourceProvider),
+    loadLocal: local.getAll,
+    saveLocal: local.save,
+  );
+});
+
+final tripSyncEngineProvider = Provider<SyncEngine<Trip>>((ref) {
+  final local = ref.watch(localTripRepositoryProvider);
+  return SyncEngine<Trip>(
+    descriptor: SyncEntityDescriptor<Trip>(
+      name: 'trip',
+      idOf: (t) => t.id,
+      updatedAtOf: (t) => t.updatedAt,
+    ),
+    remote: ref.watch(tripRemoteDataSourceProvider),
+    loadLocal: local.getAll,
+    saveLocal: local.save,
+  );
+});
+
+final savedLocationsSyncEngineProvider =
+    Provider<SyncEngine<SavedLocationEntry>>((ref) {
+      final local = ref.watch(localSavedLocationsRepositoryProvider);
+      return SyncEngine<SavedLocationEntry>(
+        descriptor: SyncEntityDescriptor<SavedLocationEntry>(
+          name: 'saved_location',
+          idOf: (s) => s.placeId,
+          updatedAtOf: (s) => s.updatedAt,
+        ),
+        remote: ref.watch(savedLocationsRemoteDataSourceProvider),
+        loadLocal: local.getAll,
+        saveLocal: local.save,
+      );
+    });
+
+// ---------------------------------------------------------------------------
+// Public repositories — wrapped versions used by feature providers.
+// ---------------------------------------------------------------------------
+
+final syncingJourneyRepositoryProvider = Provider<JourneyRepository>((ref) {
+  return SyncingJourneyRepository(
+    local: ref.watch(localJourneyRepositoryProvider),
+    engine: ref.watch(journeySyncEngineProvider),
+    session: () => ref.read(syncSessionProvider),
+  );
+});
+
+final syncingQuickGuideRepositoryProvider = Provider<QuickGuideRepository>((
+  ref,
+) {
+  return SyncingQuickGuideRepository(
+    local: ref.watch(localQuickGuideRepositoryProvider),
+    engine: ref.watch(quickGuideSyncEngineProvider),
+    session: () => ref.read(syncSessionProvider),
+  );
+});
+
+final syncingTripRepositoryProvider = Provider<TripRepository>((ref) {
+  return SyncingTripRepository(
+    local: ref.watch(localTripRepositoryProvider),
+    engine: ref.watch(tripSyncEngineProvider),
+    session: () => ref.read(syncSessionProvider),
+  );
+});
+
+final syncingSavedLocationsRepositoryProvider =
+    Provider<SavedLocationsRepository>((ref) {
+      return SyncingSavedLocationsRepository(
+        local: ref.watch(localSavedLocationsRepositoryProvider),
+        engine: ref.watch(savedLocationsSyncEngineProvider),
+        session: () => ref.read(syncSessionProvider),
+      );
+    });
+
+// ---------------------------------------------------------------------------
+// Coordinator (used to trigger initial full sync).
+// ---------------------------------------------------------------------------
+
+final syncCoordinatorProvider = Provider<SyncCoordinator>((ref) {
+  return SyncCoordinator(
+    journey: ref.watch(journeySyncEngineProvider),
+    quickGuide: ref.watch(quickGuideSyncEngineProvider),
+    trip: ref.watch(tripSyncEngineProvider),
+    savedLocations: ref.watch(savedLocationsSyncEngineProvider),
+  );
+});

--- a/frontend/lib/features/trip/domain/models/trip.dart
+++ b/frontend/lib/features/trip/domain/models/trip.dart
@@ -13,11 +13,13 @@ class Trip extends Equatable {
   final String? coverImageUrl;
   final String? description;
   final DateTime createdAt;
+  final DateTime updatedAt;
 
   const Trip({
     required this.id,
     required this.name,
     required this.createdAt,
+    required this.updatedAt,
     this.startDate,
     this.endDate,
     this.coverImageUrl,
@@ -39,6 +41,7 @@ class Trip extends Equatable {
       coverImageUrl: coverImageUrl ?? this.coverImageUrl,
       description: description ?? this.description,
       createdAt: createdAt,
+      updatedAt: DateTime.now(),
     );
   }
 
@@ -50,11 +53,18 @@ class Trip extends Equatable {
     'cover_image_url': coverImageUrl,
     'description': description,
     'created_at': createdAt.toIso8601String(),
+    'updated_at': updatedAt.toIso8601String(),
   };
 
   factory Trip.fromJson(Map<String, dynamic> json) {
     DateTime? parseDate(Object? v) =>
         v is String && v.isNotEmpty ? DateTime.parse(v) : null;
+
+    final createdAt = DateTime.parse(json['created_at'] as String);
+    final updatedAtRaw = json['updated_at'] as String?;
+    final updatedAt = updatedAtRaw != null
+        ? DateTime.parse(updatedAtRaw)
+        : createdAt;
 
     return Trip(
       id: json['id'] as String,
@@ -63,7 +73,8 @@ class Trip extends Equatable {
       endDate: parseDate(json['end_date']),
       coverImageUrl: json['cover_image_url'] as String?,
       description: json['description'] as String?,
-      createdAt: DateTime.parse(json['created_at'] as String),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
     );
   }
 
@@ -76,5 +87,6 @@ class Trip extends Equatable {
     coverImageUrl,
     description,
     createdAt,
+    updatedAt,
   ];
 }

--- a/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
@@ -65,19 +65,24 @@ class _TripEditScreenState extends ConsumerState<TripEditScreen> {
       final repo = ref.read(tripRepositoryProvider);
       final existing = _isEditMode ? await repo.getById(widget.tripId!) : null;
 
-      final trip = existing != null
-          ? existing.copyWith(
-              name: _nameController.text.trim(),
-              startDate: _startDate,
-              endDate: _endDate,
-            )
-          : Trip(
-              id: const Uuid().v4(),
-              name: _nameController.text.trim(),
-              startDate: _startDate,
-              endDate: _endDate,
-              createdAt: DateTime.now(),
-            );
+      final Trip trip;
+      if (existing != null) {
+        trip = existing.copyWith(
+          name: _nameController.text.trim(),
+          startDate: _startDate,
+          endDate: _endDate,
+        );
+      } else {
+        final now = DateTime.now();
+        trip = Trip(
+          id: const Uuid().v4(),
+          name: _nameController.text.trim(),
+          startDate: _startDate,
+          endDate: _endDate,
+          createdAt: now,
+          updatedAt: now,
+        );
+      }
 
       await repo.save(trip);
 

--- a/frontend/lib/features/trip/providers/trip_providers.dart
+++ b/frontend/lib/features/trip/providers/trip_providers.dart
@@ -1,13 +1,13 @@
 import 'package:context_app/features/journey/domain/models/journey_item.dart';
 import 'package:context_app/features/journey/providers.dart';
-import 'package:context_app/features/trip/data/hive_trip_repository.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/features/trip/domain/models/trip.dart';
 import 'package:context_app/features/trip/domain/repositories/trip_repository.dart';
 import 'package:context_app/features/trip/presentation/controllers/current_trip_notifier.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final tripRepositoryProvider = Provider<TripRepository>((ref) {
-  return HiveTripRepository();
+  return ref.watch(syncingTripRepositoryProvider);
 });
 
 /// All trips, newest first. autoDispose so callers don't keep stale lists.

--- a/frontend/test/fakes/fake_auth_service.dart
+++ b/frontend/test/fakes/fake_auth_service.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:context_app/features/auth/domain/models/auth_user.dart';
+import 'package:context_app/features/auth/domain/services/auth_service.dart';
+
+/// In-memory [AuthService] used by widget tests.
+///
+/// Captures method-call counts so tests can verify which sign-in flow
+/// was triggered without going through Google/Apple SDKs.
+class FakeAuthService implements AuthService {
+  FakeAuthService({AuthUser? initialUser}) : _user = initialUser {
+    _controller.add(_user);
+  }
+
+  final _controller = StreamController<AuthUser?>.broadcast();
+  AuthUser? _user;
+  int googleSignInCount = 0;
+  int appleSignInCount = 0;
+  int signOutCount = 0;
+  bool shouldFailSignIn = false;
+
+  @override
+  AuthUser? get currentUser => _user;
+
+  @override
+  Stream<AuthUser?> authStateChanges() => _controller.stream;
+
+  @override
+  Future<AuthUser> signInWithGoogle() async {
+    googleSignInCount += 1;
+    if (shouldFailSignIn) {
+      throw const AuthFailureException('forced failure');
+    }
+    final user = const AuthUser(
+      id: 'fake-google-user',
+      email: 'fake@example.com',
+      displayName: 'Fake User',
+    );
+    _user = user;
+    _controller.add(user);
+    return user;
+  }
+
+  @override
+  Future<AuthUser> signInWithApple() async {
+    appleSignInCount += 1;
+    if (shouldFailSignIn) {
+      throw const AuthFailureException('forced failure');
+    }
+    final user = const AuthUser(
+      id: 'fake-apple-user',
+      email: 'apple@example.com',
+      displayName: 'Apple User',
+    );
+    _user = user;
+    _controller.add(user);
+    return user;
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCount += 1;
+    _user = null;
+    _controller.add(null);
+  }
+
+  void dispose() {
+    _controller.close();
+  }
+}

--- a/frontend/test/fakes/fake_auth_service.dart
+++ b/frontend/test/fakes/fake_auth_service.dart
@@ -31,7 +31,7 @@ class FakeAuthService implements AuthService {
     if (shouldFailSignIn) {
       throw const AuthFailureException('forced failure');
     }
-    final user = const AuthUser(
+    const user = AuthUser(
       id: 'fake-google-user',
       email: 'fake@example.com',
       displayName: 'Fake User',
@@ -47,7 +47,7 @@ class FakeAuthService implements AuthService {
     if (shouldFailSignIn) {
       throw const AuthFailureException('forced failure');
     }
-    final user = const AuthUser(
+    const user = AuthUser(
       id: 'fake-apple-user',
       email: 'apple@example.com',
       displayName: 'Apple User',

--- a/frontend/test/features/export/domain/services/trip_pdf_export_service_test.dart
+++ b/frontend/test/features/export/domain/services/trip_pdf_export_service_test.dart
@@ -29,11 +29,15 @@ Trip _trip({
   String id = 't1',
   String name = 'Kyoto Getaway',
   DateTime? createdAt,
-}) => Trip(
-  id: id,
-  name: name,
-  createdAt: createdAt ?? DateTime(2026, 4, 10),
-);
+}) {
+  final resolved = createdAt ?? DateTime(2026, 4, 10);
+  return Trip(
+    id: id,
+    name: name,
+    createdAt: resolved,
+    updatedAt: resolved,
+  );
+}
 
 JourneyItem _narrationItem({
   String id = 'j1',
@@ -56,6 +60,7 @@ JourneyItem _narrationItem({
       ),
       narrationAspects: const {NarrationAspect.historicalBackground},
       createdAt: createdAt ?? DateTime(2026, 4, 10, 12),
+      updatedAt: createdAt ?? DateTime(2026, 4, 10, 12),
       language: const Language('zh-TW'),
       tripId: 't1',
     ),

--- a/frontend/test/features/export/presentation/pdf_builder/trip_pdf_document_builder_test.dart
+++ b/frontend/test/features/export/presentation/pdf_builder/trip_pdf_document_builder_test.dart
@@ -17,6 +17,7 @@ Trip _trip() => Trip(
   id: 't1',
   name: 'Kyoto Trip',
   createdAt: DateTime(2026, 4, 10),
+  updatedAt: DateTime(2026, 4, 10),
 );
 
 PdfEntryData _narration(String title) => PdfEntryData(

--- a/frontend/test/features/journey/data/hive_journey_repository_test.dart
+++ b/frontend/test/features/journey/data/hive_journey_repository_test.dart
@@ -22,12 +22,14 @@ JourneyEntry _makeEntry({String id = 'e1', DateTime? createdAt}) {
     language: const Language('zh-TW'),
   );
 
+  final resolvedCreatedAt = createdAt ?? DateTime.now();
   return JourneyEntry(
     id: id,
     place: place,
     narrationContent: content,
     narrationAspects: aspects,
-    createdAt: createdAt ?? DateTime.now(),
+    createdAt: resolvedCreatedAt,
+    updatedAt: resolvedCreatedAt,
     language: const Language('zh-TW'),
   );
 }

--- a/frontend/test/features/journey/providers/filtered_journey_items_test.dart
+++ b/frontend/test/features/journey/providers/filtered_journey_items_test.dart
@@ -32,6 +32,7 @@ JourneyEntry _makeNarration({
     ),
     narrationAspects: const {NarrationAspect.historicalBackground},
     createdAt: createdAt ?? DateTime(2026, 4, 1),
+    updatedAt: createdAt ?? DateTime(2026, 4, 1),
     language: Language.english,
   );
 }
@@ -47,6 +48,7 @@ QuickGuideEntry _makeQuickGuide({
     imageBytes: Uint8List.fromList([0, 1, 2]),
     aiDescription: description,
     createdAt: createdAt ?? DateTime(2026, 4, 2),
+    updatedAt: createdAt ?? DateTime(2026, 4, 2),
     language: Language.english,
   );
 }

--- a/frontend/test/features/main_screen_test.dart
+++ b/frontend/test/features/main_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:context_app/features/auth/providers.dart';
 import 'package:context_app/features/camera/providers.dart';
 import 'package:context_app/features/daily_story/providers.dart';
 import 'package:context_app/features/explore/providers.dart';
@@ -15,6 +16,7 @@ import 'package:context_app/features/usage/providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../fakes/fake_auth_service.dart';
 import '../fakes/fake_image_analysis_service.dart';
 import '../fakes/fake_location_service.dart';
 import '../fakes/fake_places_repository.dart';
@@ -94,6 +96,7 @@ Future<void> _givenMainScreen(
 
 List<Override> _mainScreenOverrides() {
   return [
+    authServiceProvider.overrideWithValue(FakeAuthService()),
     placesRepositoryProvider.overrideWithValue(FakePlacesRepository()),
     locationServiceProvider.overrideWithValue(FakeLocationService()),
     journeyRepositoryProvider.overrideWithValue(InMemoryJourneyRepository()),

--- a/frontend/test/features/quick_guide/data/hive_quick_guide_repository_test.dart
+++ b/frontend/test/features/quick_guide/data/hive_quick_guide_repository_test.dart
@@ -15,11 +15,13 @@ QuickGuideEntry _makeEntry({String id = 'e1', DateTime? createdAt}) {
     language: const Language('zh-TW'),
   );
   // Return a copy with the desired id and createdAt.
+  final resolvedCreatedAt = createdAt ?? entry.createdAt;
   return QuickGuideEntry(
     id: id,
     imageBytes: entry.imageBytes,
     aiDescription: entry.aiDescription,
-    createdAt: createdAt ?? entry.createdAt,
+    createdAt: resolvedCreatedAt,
+    updatedAt: resolvedCreatedAt,
     language: entry.language,
   );
 }

--- a/frontend/test/features/saved_locations/data/hive_saved_locations_repository_test.dart
+++ b/frontend/test/features/saved_locations/data/hive_saved_locations_repository_test.dart
@@ -34,6 +34,7 @@ SavedLocationEntry _makeEntry({
       photosJson: entry.photosJson,
       categoryKey: entry.categoryKey,
       savedAt: savedAt,
+      updatedAt: savedAt,
     );
   }
   return entry;

--- a/frontend/test/features/saved_locations/presentation/widgets/saved_locations_dialog_test.dart
+++ b/frontend/test/features/saved_locations/presentation/widgets/saved_locations_dialog_test.dart
@@ -107,6 +107,7 @@ SavedLocationEntry _entry({
     photosJson: const [],
     categoryKey: category.name,
     savedAt: savedAt ?? DateTime(2024, 1, 1),
+    updatedAt: savedAt ?? DateTime(2024, 1, 1),
   );
 }
 

--- a/frontend/test/features/saved_locations/presentation/widgets/saved_locations_fab_test.dart
+++ b/frontend/test/features/saved_locations/presentation/widgets/saved_locations_fab_test.dart
@@ -91,6 +91,7 @@ SavedLocationEntry _entry({
     photosJson: const [],
     categoryKey: category.name,
     savedAt: DateTime(2024, 1, 1),
+    updatedAt: DateTime(2024, 1, 1),
   );
 }
 

--- a/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -1,12 +1,18 @@
+import 'package:context_app/features/auth/domain/models/auth_user.dart';
+import 'package:context_app/features/auth/providers.dart';
 import 'package:context_app/features/onboarding/providers.dart';
 import 'package:context_app/features/settings/presentation/screens/settings_screen.dart';
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
 import 'package:context_app/features/subscription/providers.dart';
+import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../../fakes/fake_auth_service.dart';
 import '../../../../fakes/in_memory_onboarding_repository.dart';
 import '../../../../fakes/in_memory_usage_repository.dart';
 import '../../../../helpers/pump_app.dart';
@@ -16,6 +22,10 @@ const _fakeVersionLabel = 'Version 9.9.9 (Build 42)';
 void main() {
   setUpAll(() async {
     await initTestEnvironment();
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
   group('SettingsScreen', () {
@@ -56,6 +66,74 @@ void main() {
         _thenVersionLabelIsVisible();
       },
     );
+
+    testWidgets(
+      'given no user is signed in, '
+      'then sign-in buttons are visible and sync toggle is disabled',
+      (tester) async {
+        final auth = FakeAuthService();
+        addTearDown(auth.dispose);
+
+        await _givenSettingsScreen(tester, authService: auth);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(find.byKey(const ValueKey('sign_in_google')), findsOneWidget);
+        expect(find.byKey(const ValueKey('sign_in_apple')), findsOneWidget);
+        final switchFinder = find.byKey(const ValueKey('sync_toggle_switch'));
+        expect(switchFinder, findsOneWidget);
+        final Switch toggle = tester.widget(switchFinder);
+        expect(toggle.onChanged, isNull);
+        expect(toggle.value, isFalse);
+      },
+    );
+
+    testWidgets(
+      'given the user taps the Google sign-in button, '
+      'then signInWithGoogle is invoked and the user appears as signed in',
+      (tester) async {
+        final auth = FakeAuthService();
+        addTearDown(auth.dispose);
+
+        await _givenSettingsScreen(tester, authService: auth);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        await tester.tap(find.byKey(const ValueKey('sign_in_google')));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(auth.googleSignInCount, 1);
+        // After sign-in, the sign-out button replaces the sign-in buttons.
+        expect(find.text('settings.sign_out'), findsOneWidget);
+        expect(find.byKey(const ValueKey('sign_in_google')), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'given a signed-in user, '
+      'when the sync toggle is flipped on, '
+      'then the sync preference is persisted as true',
+      (tester) async {
+        final auth = FakeAuthService(
+          initialUser: const AuthUser(
+            id: 'u1',
+            email: 'a@b.com',
+            displayName: 'A',
+          ),
+        );
+        addTearDown(auth.dispose);
+
+        await _givenSettingsScreen(tester, authService: auth);
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final switchFinder = find.byKey(const ValueKey('sync_toggle_switch'));
+        await tester.tap(switchFinder);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getBool('sync_enabled'), isTrue);
+      },
+    );
   });
 }
 
@@ -63,19 +141,22 @@ Future<void> _givenSettingsScreen(
   WidgetTester tester, {
   InMemoryUsageRepository? usage,
   SubscriptionStatus status = SubscriptionStatus.free,
+  FakeAuthService? authService,
 }) async {
   final usageRepo = usage ?? InMemoryUsageRepository(usedToday: 0);
+  final auth = authService ?? FakeAuthService();
 
   // The settings screen is taller than the default 800x600 test surface
   // after the onboarding section was added. Enlarging the surface lets
   // `find.text` locate tiles below the fold without having to scroll.
-  await tester.binding.setSurfaceSize(const Size(800, 1600));
+  await tester.binding.setSurfaceSize(const Size(800, 2000));
   addTearDown(() => tester.binding.setSurfaceSize(null));
 
   await pumpScreen(
     tester,
     child: const SettingsScreen(),
     overrides: [
+      authServiceProvider.overrideWithValue(auth),
       usageRepositoryProvider.overrideWithValue(usageRepo),
       usageStatusProvider.overrideWith(
         (ref) async => usageRepo.getUsageStatus(),

--- a/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
+++ b/frontend/test/features/settings/presentation/screens/settings_screen_test.dart
@@ -5,10 +5,8 @@ import 'package:context_app/features/settings/presentation/screens/settings_scre
 import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/features/subscription/domain/models/subscription_status.dart';
 import 'package:context_app/features/subscription/providers.dart';
-import 'package:context_app/features/sync/providers.dart';
 import 'package:context_app/features/usage/providers.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 

--- a/frontend/test/features/sync/sync_merger_test.dart
+++ b/frontend/test/features/sync/sync_merger_test.dart
@@ -1,0 +1,76 @@
+import 'package:context_app/features/sync/domain/services/sync_merger.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _Item {
+  _Item(this.id, this.updatedAt);
+  final String id;
+  final DateTime updatedAt;
+}
+
+SyncMergeResult<_Item> _merge({
+  required List<_Item> local,
+  required List<_Item> remote,
+}) {
+  return SyncMerger.merge<_Item>(
+    local: local,
+    remote: remote,
+    idOf: (it) => it.id,
+    updatedAtOf: (it) => it.updatedAt,
+  );
+}
+
+void main() {
+  group('SyncMerger.merge', () {
+    test('given disjoint local and remote items, all show up in merged', () {
+      final local = [_Item('a', DateTime(2026, 1, 1))];
+      final remote = [_Item('b', DateTime(2026, 1, 2))];
+
+      final result = _merge(local: local, remote: remote);
+
+      expect(result.merged.map((i) => i.id).toSet(), {'a', 'b'});
+      expect(result.toPush.map((i) => i.id), ['a']);
+      expect(result.toApplyLocally.map((i) => i.id), ['b']);
+    });
+
+    test('given a local item newer than remote, local wins and is pushed', () {
+      final localItem = _Item('shared', DateTime(2026, 5, 10));
+      final remoteItem = _Item('shared', DateTime(2026, 5, 1));
+
+      final result = _merge(local: [localItem], remote: [remoteItem]);
+
+      expect(result.merged.single, same(localItem));
+      expect(result.toPush, [localItem]);
+      expect(result.toApplyLocally, isEmpty);
+    });
+
+    test('given a remote item newer than local, remote wins locally', () {
+      final localItem = _Item('shared', DateTime(2026, 5, 1));
+      final remoteItem = _Item('shared', DateTime(2026, 5, 10));
+
+      final result = _merge(local: [localItem], remote: [remoteItem]);
+
+      expect(result.merged.single, same(remoteItem));
+      expect(result.toApplyLocally, [remoteItem]);
+      expect(result.toPush, isEmpty);
+    });
+
+    test('given identical timestamps, remote is used as the canonical copy', () {
+      final ts = DateTime(2026, 5, 5);
+      final localItem = _Item('shared', ts);
+      final remoteItem = _Item('shared', ts);
+
+      final result = _merge(local: [localItem], remote: [remoteItem]);
+
+      expect(result.merged.single, same(remoteItem));
+      expect(result.toPush, isEmpty);
+      expect(result.toApplyLocally, isEmpty);
+    });
+
+    test('given empty inputs, returns empty merge result', () {
+      final result = _merge(local: const [], remote: const []);
+      expect(result.merged, isEmpty);
+      expect(result.toPush, isEmpty);
+      expect(result.toApplyLocally, isEmpty);
+    });
+  });
+}

--- a/frontend/test/features/sync/syncing_journey_repository_test.dart
+++ b/frontend/test/features/sync/syncing_journey_repository_test.dart
@@ -1,0 +1,184 @@
+import 'package:context_app/features/journey/domain/models/journey_entry.dart';
+import 'package:context_app/features/sync/data/syncing_journey_repository.dart';
+import 'package:context_app/features/sync/domain/services/remote_sync_data_source.dart';
+import 'package:context_app/features/sync/domain/services/sync_engine.dart';
+import 'package:context_app/features/sync/domain/services/sync_session.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fakes/in_memory_journey_repository.dart';
+import '../../helpers/test_data.dart';
+
+class _FakeRemote implements RemoteSyncDataSource<JourneyEntry> {
+  final List<JourneyEntry> upserts = [];
+  final List<String> deletes = [];
+  List<JourneyEntry> seeded = const [];
+
+  @override
+  Future<List<JourneyEntry>> fetchAll() async => seeded;
+
+  @override
+  Future<void> upsert(JourneyEntry item) async {
+    upserts.add(item);
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    deletes.add(id);
+  }
+}
+
+SyncingJourneyRepository _build({
+  required SyncSession Function() session,
+  required InMemoryJourneyRepository local,
+  required _FakeRemote remote,
+}) {
+  final engine = SyncEngine<JourneyEntry>(
+    descriptor: SyncEntityDescriptor<JourneyEntry>(
+      name: 'journey_entry',
+      idOf: (e) => e.id,
+      updatedAtOf: (e) => e.updatedAt,
+    ),
+    remote: remote,
+    loadLocal: local.getAll,
+    saveLocal: local.save,
+  );
+  return SyncingJourneyRepository(
+    local: local,
+    engine: engine,
+    session: session,
+  );
+}
+
+void main() {
+  group('SyncingJourneyRepository', () {
+    test('given sync inactive, save does not push to remote', () async {
+      final local = InMemoryJourneyRepository();
+      final remote = _FakeRemote();
+      final repo = _build(
+        local: local,
+        remote: remote,
+        session: () => const SyncSession.disabled(),
+      );
+
+      await repo.save(buildJourneyEntry(id: 'e1'));
+
+      expect(await local.getAll(), hasLength(1));
+      expect(remote.upserts, isEmpty);
+    });
+
+    test('given sync active, save also pushes to remote', () async {
+      final local = InMemoryJourneyRepository();
+      final remote = _FakeRemote();
+      final repo = _build(
+        local: local,
+        remote: remote,
+        session: () => const SyncSession(enabled: true, userId: 'u1'),
+      );
+
+      final entry = buildJourneyEntry(id: 'e1');
+      await repo.save(entry);
+
+      expect(remote.upserts, [entry]);
+    });
+
+    test('given sync active, delete cascades to remote', () async {
+      final local = InMemoryJourneyRepository();
+      final remote = _FakeRemote();
+      final repo = _build(
+        local: local,
+        remote: remote,
+        session: () => const SyncSession(enabled: true, userId: 'u1'),
+      );
+
+      await repo.save(buildJourneyEntry(id: 'e1'));
+      await repo.delete('e1');
+
+      expect(remote.deletes, ['e1']);
+    });
+
+    test(
+      'given sync inactive, delete only affects local',
+      () async {
+        final local = InMemoryJourneyRepository();
+        final remote = _FakeRemote();
+        final repo = _build(
+          local: local,
+          remote: remote,
+          session: () => const SyncSession.disabled(),
+        );
+
+        await repo.save(buildJourneyEntry(id: 'e1'));
+        await repo.delete('e1');
+
+        expect(await local.getAll(), isEmpty);
+        expect(remote.deletes, isEmpty);
+      },
+    );
+
+    test(
+      'engine.fullSync writes newer remote items locally and pushes newer locals',
+      () async {
+        final local = InMemoryJourneyRepository();
+        final remote = _FakeRemote();
+        final repo = _build(
+          local: local,
+          remote: remote,
+          session: () => const SyncSession(enabled: true, userId: 'u1'),
+        );
+
+        // Local has an older copy of "shared" and a unique "localOnly".
+        await repo.save(
+          buildJourneyEntry(
+            id: 'shared',
+            createdAt: DateTime(2026, 1, 1),
+            updatedAt: DateTime(2026, 1, 1),
+          ),
+        );
+        await repo.save(
+          buildJourneyEntry(
+            id: 'localOnly',
+            createdAt: DateTime(2026, 2, 1),
+            updatedAt: DateTime(2026, 2, 1),
+          ),
+        );
+
+        // Remote has a newer copy of "shared" and a unique "remoteOnly".
+        remote.seeded = [
+          buildJourneyEntry(
+            id: 'shared',
+            createdAt: DateTime(2026, 6, 1),
+            updatedAt: DateTime(2026, 6, 1),
+          ),
+          buildJourneyEntry(
+            id: 'remoteOnly',
+            createdAt: DateTime(2026, 7, 1),
+            updatedAt: DateTime(2026, 7, 1),
+          ),
+        ];
+
+        // Clear out the upserts captured during the warm-up saves so the
+        // assertions below only see what fullSync pushed.
+        remote.upserts.clear();
+
+        final engine = SyncEngine<JourneyEntry>(
+          descriptor: SyncEntityDescriptor<JourneyEntry>(
+            name: 'journey_entry',
+            idOf: (e) => e.id,
+            updatedAtOf: (e) => e.updatedAt,
+          ),
+          remote: remote,
+          loadLocal: local.getAll,
+          saveLocal: local.save,
+        );
+        await engine.fullSync();
+
+        final localIds = (await local.getAll()).map((e) => e.id).toSet();
+        expect(localIds, {'shared', 'localOnly', 'remoteOnly'});
+
+        final pushedIds = remote.upserts.map((e) => e.id).toList();
+        expect(pushedIds, contains('localOnly'));
+        expect(pushedIds, isNot(contains('shared')));
+      },
+    );
+  });
+}

--- a/frontend/test/features/trip/data/hive_trip_repository_test.dart
+++ b/frontend/test/features/trip/data/hive_trip_repository_test.dart
@@ -6,10 +6,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 
 Trip _makeTrip({String id = 't1', DateTime? createdAt}) {
+  final resolved = createdAt ?? DateTime(2026, 4, 17);
   return Trip(
     id: id,
     name: 'Trip $id',
-    createdAt: createdAt ?? DateTime(2026, 4, 17),
+    createdAt: resolved,
+    updatedAt: resolved,
   );
 }
 
@@ -73,6 +75,7 @@ void main() {
         id: 'dup',
         name: 'Renamed',
         createdAt: DateTime(2026, 4, 17),
+        updatedAt: DateTime(2026, 4, 17),
       ),
     );
 

--- a/frontend/test/features/trip/domain/models/trip_test.dart
+++ b/frontend/test/features/trip/domain/models/trip_test.dart
@@ -9,7 +9,9 @@ Trip _makeTrip({
   String? coverImageUrl,
   String? description,
   DateTime? createdAt,
+  DateTime? updatedAt,
 }) {
+  final resolvedCreatedAt = createdAt ?? DateTime(2026, 4, 17);
   return Trip(
     id: id,
     name: name,
@@ -17,7 +19,8 @@ Trip _makeTrip({
     endDate: endDate,
     coverImageUrl: coverImageUrl,
     description: description,
-    createdAt: createdAt ?? DateTime(2026, 4, 17),
+    createdAt: resolvedCreatedAt,
+    updatedAt: updatedAt ?? resolvedCreatedAt,
   );
 }
 

--- a/frontend/test/helpers/test_data.dart
+++ b/frontend/test/helpers/test_data.dart
@@ -41,13 +41,16 @@ Trip buildTrip({
   DateTime? startDate,
   DateTime? endDate,
   DateTime? createdAt,
+  DateTime? updatedAt,
 }) {
+  final resolvedCreatedAt = createdAt ?? DateTime(2024, 1, 1);
   return Trip(
     id: id,
     name: name,
     startDate: startDate,
     endDate: endDate,
-    createdAt: createdAt ?? DateTime(2024, 1, 1),
+    createdAt: resolvedCreatedAt,
+    updatedAt: updatedAt ?? resolvedCreatedAt,
   );
 }
 
@@ -68,11 +71,13 @@ JourneyEntry buildJourneyEntry({
   NarrationContent? content,
   Set<NarrationAspect> aspects = const {NarrationAspect.historicalBackground},
   DateTime? createdAt,
+  DateTime? updatedAt,
   Language language = Language.english,
   String? tripId,
 }) {
   final resolvedPlace = place ?? buildPlace();
   final resolvedContent = content ?? buildNarrationContent();
+  final resolvedCreatedAt = createdAt ?? DateTime(2024, 1, 2, 10);
   return JourneyEntry(
     id: id,
     place: SavedPlace(
@@ -83,7 +88,8 @@ JourneyEntry buildJourneyEntry({
     ),
     narrationContent: resolvedContent,
     narrationAspects: aspects,
-    createdAt: createdAt ?? DateTime(2024, 1, 2, 10),
+    createdAt: resolvedCreatedAt,
+    updatedAt: updatedAt ?? resolvedCreatedAt,
     language: language,
     tripId: tripId,
   );
@@ -95,14 +101,17 @@ QuickGuideEntry buildQuickGuideEntry({
   Uint8List? imageBytes,
   String aiDescription = 'A short description from fake AI.',
   DateTime? createdAt,
+  DateTime? updatedAt,
   Language language = Language.english,
   String? tripId,
 }) {
+  final resolvedCreatedAt = createdAt ?? DateTime(2024, 1, 1, 12);
   return QuickGuideEntry(
     id: id,
     imageBytes: imageBytes ?? Uint8List.fromList(const [0, 1, 2, 3]),
     aiDescription: aiDescription,
-    createdAt: createdAt ?? DateTime(2024, 1, 1, 12),
+    createdAt: resolvedCreatedAt,
+    updatedAt: updatedAt ?? resolvedCreatedAt,
     language: language,
     tripId: tripId,
   );

--- a/supabase/migrations/20260511000000_create_sync_tables.sql
+++ b/supabase/migrations/20260511000000_create_sync_tables.sql
@@ -1,0 +1,116 @@
+-- Sync tables for opt-in cross-device sync of user data (Journey entries,
+-- Quick Guide entries, Trips, Saved Locations). All tables are owned by
+-- a Supabase auth user and protected by row-level security.
+
+-- ----------------------------------------------------------------------------
+-- journey_entries: narration-based journey entries.
+-- ----------------------------------------------------------------------------
+create table if not exists public.journey_entries (
+  id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  place_id text not null,
+  place_name text not null,
+  place_address text not null,
+  place_image_url text,
+  narration_text text not null,
+  narration_styles text[] not null default array[]::text[],
+  language text not null default 'zh-TW',
+  trip_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, id)
+);
+
+alter table public.journey_entries enable row level security;
+
+create policy "Users can read their own journey entries"
+  on public.journey_entries for select using (auth.uid() = user_id);
+create policy "Users can insert their own journey entries"
+  on public.journey_entries for insert with check (auth.uid() = user_id);
+create policy "Users can update their own journey entries"
+  on public.journey_entries for update using (auth.uid() = user_id);
+create policy "Users can delete their own journey entries"
+  on public.journey_entries for delete using (auth.uid() = user_id);
+
+-- ----------------------------------------------------------------------------
+-- quick_guide_entries: photo-based quick guide entries. Images stored as
+-- base64 text for simplicity in this initial sync milestone.
+-- ----------------------------------------------------------------------------
+create table if not exists public.quick_guide_entries (
+  id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  image_base64 text not null,
+  ai_description text not null,
+  language text not null default 'zh-TW',
+  trip_id text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, id)
+);
+
+alter table public.quick_guide_entries enable row level security;
+
+create policy "Users can read their own quick guide entries"
+  on public.quick_guide_entries for select using (auth.uid() = user_id);
+create policy "Users can insert their own quick guide entries"
+  on public.quick_guide_entries for insert with check (auth.uid() = user_id);
+create policy "Users can update their own quick guide entries"
+  on public.quick_guide_entries for update using (auth.uid() = user_id);
+create policy "Users can delete their own quick guide entries"
+  on public.quick_guide_entries for delete using (auth.uid() = user_id);
+
+-- ----------------------------------------------------------------------------
+-- trips: user-created trips that group journey entries.
+-- ----------------------------------------------------------------------------
+create table if not exists public.trips (
+  id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  start_date timestamptz,
+  end_date timestamptz,
+  cover_image_url text,
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, id)
+);
+
+alter table public.trips enable row level security;
+
+create policy "Users can read their own trips"
+  on public.trips for select using (auth.uid() = user_id);
+create policy "Users can insert their own trips"
+  on public.trips for insert with check (auth.uid() = user_id);
+create policy "Users can update their own trips"
+  on public.trips for update using (auth.uid() = user_id);
+create policy "Users can delete their own trips"
+  on public.trips for delete using (auth.uid() = user_id);
+
+-- ----------------------------------------------------------------------------
+-- saved_locations: locations bookmarked by the user.
+-- ----------------------------------------------------------------------------
+create table if not exists public.saved_locations (
+  place_id text not null,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  formatted_address text not null,
+  latitude double precision not null,
+  longitude double precision not null,
+  types text[] not null default array[]::text[],
+  photos jsonb not null default '[]'::jsonb,
+  category_key text not null,
+  saved_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, place_id)
+);
+
+alter table public.saved_locations enable row level security;
+
+create policy "Users can read their own saved locations"
+  on public.saved_locations for select using (auth.uid() = user_id);
+create policy "Users can insert their own saved locations"
+  on public.saved_locations for insert with check (auth.uid() = user_id);
+create policy "Users can update their own saved locations"
+  on public.saved_locations for update using (auth.uid() = user_id);
+create policy "Users can delete their own saved locations"
+  on public.saved_locations for delete using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
This PR introduces a complete cloud synchronization system that allows users to optionally sync their journey entries, quick guide entries, trips, and saved locations across devices via Supabase. It includes authentication support (Google Sign-In and Apple Sign-In), a sync engine with last-write-wins conflict resolution, and UI controls in the settings screen.

## Key Changes

### Authentication System
- Added `AuthService` domain interface with Supabase implementation supporting Google and Apple Sign-In
- Created `AuthUser` model to wrap authenticated user data
- Added auth providers and state management via Riverpod
- Implemented `SupabaseAuthService` with proper token exchange and error handling

### Sync Infrastructure
- **Sync Engine**: Generic `SyncEngine<T>` that orchestrates push/pull operations with last-write-wins merge strategy based on `updatedAt` timestamps
- **Sync Merger**: Implements conflict resolution logic, determining which items to push to remote and which to apply locally
- **Sync Coordinator**: Top-level driver that runs full sync for all four entity types in parallel
- **Sync Session**: Combines user preference toggle and authentication state to determine if sync is active

### Remote Data Sources
- Implemented Supabase remote data sources for all four entity types:
  - `SupabaseJourneyRemoteDataSource`
  - `SupabaseQuickGuideRemoteDataSource`
  - `SupabaseTripRemoteDataSource`
  - `SupabaseSavedLocationsRemoteDataSource`
- All sources handle user-scoped queries and proper serialization/deserialization

### Repository Decorators
- Created syncing repository wrappers that decorate local repositories with optional write-through to remote:
  - `SyncingJourneyRepository`
  - `SyncingQuickGuideRepository`
  - `SyncingTripRepository`
  - `SyncingSavedLocationsRepository`
- Repositories only push to remote when sync is active and user is authenticated

### Settings UI
- Added Account section showing sign-in status with Google/Apple sign-in buttons
- Added Cloud Sync section with toggle to enable/disable sync
- Integrated sign-out functionality with confirmation dialog
- Added localization strings for English and Traditional Chinese

### Database Schema
- Created Supabase migration with four sync tables (`journey_entries`, `quick_guide_entries`, `trips`, `saved_locations`)
- All tables use composite primary keys (user_id, id) and include row-level security policies
- Added `updated_at` timestamp field to all tables for conflict resolution

### Model Updates
- Added `updatedAt` field to `JourneyEntry`, `QuickGuideEntry`, `Trip`, and `SavedLocationEntry` models
- Updated all test helpers and test data builders to include the new field

### Testing
- Added comprehensive unit tests for `SyncMerger` covering all merge scenarios
- Added integration tests for `SyncingJourneyRepository` verifying sync behavior
- Added `FakeAuthService` for widget testing authentication flows
- Updated settings screen tests to verify account and sync UI behavior

## Notable Implementation Details
- Sync is opt-in and only active when both the user preference is enabled AND the user is authenticated
- The sync engine uses callbacks (`loadLocal`, `saveLocal`) to remain framework-agnostic
- Conflict resolution uses last-write-wins based on `updatedAt` timestamps; soft deletes are out of scope
- Remote data sources throw `StateError` if called without authentication to catch configuration issues early
- Settings screen properly handles sign-in/sign-out flows with error handling and user confirmation

https://claude.ai/code/session_01AgJi83zZCmP5hq8gW2wbro