### PR TITLE
Refactor iOS share extension activation rule configuration

### DIFF
--- a/frontend/ios/ShareExtension/Info.plist
+++ b/frontend/ios/ShareExtension/Info.plist
@@ -12,17 +12,18 @@
         <key>NSExtensionAttributes</key>
         <dict>
             <!-- Share extension temporarily disabled; see lib/app.dart.
-                 Restore to the dict form below to re-enable:
-                 <key>NSExtensionActivationRule</key>
-                 <dict>
-                     <key>NSExtensionActivationSupportsText</key>
-                     <true/>
-                     <key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-                     <integer>1</integer>
-                 </dict>
-            -->
+                 To re-enable, flip the values below:
+                   NSExtensionActivationSupportsText -> <true/>
+                   NSExtensionActivationSupportsWebURLWithMaxCount -> <integer>1</integer>
+                 The dict form (rather than a string predicate) is required by
+                 App Store / TestFlight upload validation. -->
             <key>NSExtensionActivationRule</key>
-            <string>FALSEPREDICATE</string>
+            <dict>
+                <key>NSExtensionActivationSupportsText</key>
+                <false/>
+                <key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+                <integer>0</integer>
+            </dict>
         </dict>
         <key>NSExtensionMainStoryboard</key>
         <string>MainInterface</string>


### PR DESCRIPTION
## Summary
Updated the iOS share extension's `NSExtensionActivationRule` configuration to use the dict form instead of a string predicate, which is required for App Store and TestFlight upload validation. The extension remains disabled with clearer documentation on how to re-enable it.

## Key Changes
- Replaced `FALSEPREDICATE` string with a dict-based activation rule containing:
  - `NSExtensionActivationSupportsText` set to `<false/>`
  - `NSExtensionActivationSupportsWebURLWithMaxCount` set to `<integer>0</integer>`
- Updated inline documentation to clarify:
  - The reason for using dict form (App Store/TestFlight validation requirement)
  - How to re-enable the extension (flip the boolean and integer values)
  - Reference to `lib/app.dart` for context on why it's disabled

## Implementation Details
The dict-based configuration is functionally equivalent to the previous string predicate approach but complies with App Store validation requirements. The extension can be quickly re-enabled by changing `<false/>` to `<true/>` and `<integer>0</integer>` to `<integer>1</integer>` in the respective keys.

https://claude.ai/code/session_017BVmtqbqPYFUYiGLRgHcM9