### PR TITLE
Handle Discord reaction rate limiting with retry logic

### DIFF
--- a/backend/src/lorescape_backend/daily_story/discord_review.py
+++ b/backend/src/lorescape_backend/daily_story/discord_review.py
@@ -13,6 +13,7 @@ Bot permissions required in the review channel:
 from __future__ import annotations
 
 import logging
+import time
 import urllib.parse
 from dataclasses import dataclass
 from typing import Literal
@@ -30,6 +31,8 @@ ReviewDecision = Literal["approved", "rejected", "none"]
 # Discord embed limits (per their docs).
 _EMBED_DESCRIPTION_LIMIT = 4096
 _REQUEST_TIMEOUT = 10
+# Cap Retry-After we honor so a misbehaving header can't stall the job.
+_MAX_RETRY_AFTER_SECONDS = 5.0
 
 
 @dataclass(frozen=True)
@@ -137,10 +140,29 @@ def _add_self_reaction(
         f"{DISCORD_API}/channels/{channel_id}/messages/{message_id}"
         f"/reactions/{encoded}/@me"
     )
-    response = requests.put(
-        url, headers=_bot_headers(bot_token), timeout=_REQUEST_TIMEOUT
-    )
+    headers = _bot_headers(bot_token)
+    response = requests.put(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+    # Reactions share a tight per-route bucket (~1 req / 250 ms per channel);
+    # seeding ✅ and ❌ back-to-back can 429. Honor Retry-After once.
+    if response.status_code == 429:
+        delay = _parse_retry_after(response)
+        logger.warning(
+            "discord reaction rate-limited; sleeping %.2fs then retrying once",
+            delay,
+        )
+        time.sleep(delay)
+        response = requests.put(url, headers=headers, timeout=_REQUEST_TIMEOUT)
     response.raise_for_status()
+
+
+def _parse_retry_after(response: requests.Response) -> float:
+    """Discord returns Retry-After in seconds (sometimes fractional)."""
+    raw = response.headers.get("Retry-After", "1")
+    try:
+        delay = float(raw)
+    except ValueError:
+        delay = 1.0
+    return max(0.0, min(delay, _MAX_RETRY_AFTER_SECONDS))
 
 
 def _list_reaction_users(

--- a/backend/tests/test_discord_review.py
+++ b/backend/tests/test_discord_review.py
@@ -88,6 +88,45 @@ def test_send_for_review_omits_image_when_none(requests_mock):
     assert "image" not in embed
 
 
+def test_send_for_review_retries_reaction_once_on_429(requests_mock, mocker):
+    """Per-route bucket 429 on the second seed reaction must retry, not crash."""
+    sleep = mocker.patch(
+        "lorescape_backend.daily_story.discord_review.time.sleep"
+    )
+    requests_mock.post(
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages",
+        json={"id": MESSAGE},
+    )
+    requests_mock.put(
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages/{MESSAGE}"
+        f"/reactions/%E2%9C%85/@me",
+        json={},
+    )
+    reject_url = (
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages/{MESSAGE}"
+        f"/reactions/%E2%9D%8C/@me"
+    )
+    requests_mock.put(
+        reject_url,
+        [
+            {"status_code": 429, "headers": {"Retry-After": "0.25"}, "json": {}},
+            {"status_code": 204, "json": {}},
+        ],
+    )
+
+    msg_id = send_for_review(
+        bot_token="tok", channel_id=CHANNEL, payload=_payload()
+    )
+
+    assert msg_id == MESSAGE
+    reject_calls = [
+        r for r in requests_mock.request_history
+        if r.method == "PUT" and r.url == reject_url
+    ]
+    assert len(reject_calls) == 2
+    sleep.assert_called_once_with(0.25)
+
+
 def _mock_reactions(requests_mock, approve_users, reject_users):
     requests_mock.get(
         f"https://discord.com/api/v10/channels/{CHANNEL}/messages/{MESSAGE}"


### PR DESCRIPTION
## Summary
Add retry logic to handle Discord's per-route rate limiting (HTTP 429) when adding reactions to messages. Discord's reaction endpoint has a tight per-route bucket (~1 request per 250ms per channel), which can cause rate limiting when seeding both approve (✅) and reject (❌) reactions back-to-back.

## Changes
- **Rate limit handling**: Modified `_add_self_reaction()` to detect 429 responses and retry once after honoring the `Retry-After` header
- **Retry-After parsing**: Added `_parse_retry_after()` helper to safely parse the `Retry-After` header with:
  - Fallback to 1 second if header is missing or invalid
  - Cap at `_MAX_RETRY_AFTER_SECONDS` (5.0s) to prevent misbehaving headers from stalling the job
- **Logging**: Added warning log when rate limiting occurs to aid in monitoring
- **Test coverage**: Added `test_send_for_review_retries_reaction_once_on_429()` to verify:
  - First reaction request succeeds
  - Second reaction request receives 429 with `Retry-After: 0.25`
  - System sleeps for the specified duration and retries
  - Final message ID is returned successfully

## Implementation Details
- Imported `time` module for `sleep()` functionality
- Retry is attempted exactly once per reaction to avoid excessive retries
- The solution gracefully handles both numeric and non-numeric `Retry-After` values
- Mocked `time.sleep` in tests to avoid actual delays during test execution

https://claude.ai/code/session_01VAYzxcSoEyKrvx4fgrBmHa