### PR TITLE
Render IG card PNG for Discord review instead of text embed

### DIFF
--- a/backend/src/lorescape_backend/daily_story/discord_review.py
+++ b/backend/src/lorescape_backend/daily_story/discord_review.py
@@ -1,17 +1,20 @@
 """Discord review-flow client (REST only — no Gateway).
 
-The bot posts a daily-story preview to a private review channel and adds the
-two approval reactions. Later, the publish job reads the reactions to decide
-what to do.
+The bot posts the rendered IG card PNG to a private review channel and
+adds the two approval reactions. Reviewers approve/reject based on the
+image alone — the same image that will be published to Instagram —
+rather than on a text preview. Later, the publish job reads the
+reactions to decide what to do.
 
 Bot permissions required in the review channel:
 - Send Messages
-- Embed Links
+- Attach Files
 - Add Reactions
 - Read Message History
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 import urllib.parse
@@ -28,33 +31,30 @@ REJECT_EMOJI = "❌"
 
 ReviewDecision = Literal["approved", "rejected", "none"]
 
-# Discord embed limits (per their docs).
-_EMBED_DESCRIPTION_LIMIT = 4096
-_REQUEST_TIMEOUT = 10
+_REQUEST_TIMEOUT = 30
 # Cap Retry-After we honor so a misbehaving header can't stall the job.
 _MAX_RETRY_AFTER_SECONDS = 5.0
+_REVIEW_INSTRUCTION = "React ✅ to publish at 21:00 Asia/Taipei · ❌ to skip"
 
 
 @dataclass(frozen=True)
 class ReviewPayload:
-    """The subset of a daily story we surface in the review embed."""
+    """The rendered IG card the reviewer will approve or reject."""
 
-    place_name: str
-    era: str
-    place_location: str
-    story: str
-    threads_summary: str
-    image_url: str | None
-    wikipedia_url: str
+    card_png: bytes
+    publish_date: str  # ISO date, only used in the attachment filename / log
 
 
 def send_for_review(
     *, bot_token: str, channel_id: str, payload: ReviewPayload
 ) -> str:
-    """Post the review message and seed it with ✅/❌. Returns message id."""
-    embed = _build_embed(payload)
-    message_id = _post_message(
-        bot_token=bot_token, channel_id=channel_id, embed=embed
+    """Post the IG card image and seed it with ✅/❌. Returns message id."""
+    message_id = _post_image_message(
+        bot_token=bot_token,
+        channel_id=channel_id,
+        png_bytes=payload.card_png,
+        filename=f"ig-card-{payload.publish_date}.png",
+        content=_REVIEW_INSTRUCTION,
     )
     for emoji in (APPROVE_EMOJI, REJECT_EMOJI):
         _add_self_reaction(
@@ -94,38 +94,32 @@ def check_reaction(
     return "none"
 
 
-def _build_embed(payload: ReviewPayload) -> dict:
-    description_lines = [
-        payload.story,
-        "",
-        "📱 *Threads version:*",
-        payload.threads_summary,
-    ]
-    description = "\n".join(description_lines)
-    if len(description) > _EMBED_DESCRIPTION_LIMIT:
-        description = description[: _EMBED_DESCRIPTION_LIMIT - 1] + "…"
-
-    embed: dict = {
-        "title": f"📜 {payload.place_name} · {payload.era}",
-        "description": description,
-        "url": payload.wikipedia_url,
-        "footer": {
-            "text": "React ✅ to publish at 21:00 Asia/Taipei · ❌ to skip",
-        },
-        "fields": [
-            {"name": "Location", "value": payload.place_location, "inline": True},
-        ],
+def _post_image_message(
+    *,
+    bot_token: str,
+    channel_id: str,
+    png_bytes: bytes,
+    filename: str,
+    content: str,
+) -> str:
+    """POST /channels/{id}/messages as multipart with the PNG attached."""
+    files = {
+        "files[0]": (filename, png_bytes, "image/png"),
+        "payload_json": (
+            None,
+            json.dumps({"content": content}),
+            "application/json",
+        ),
     }
-    if payload.image_url:
-        embed["image"] = {"url": payload.image_url}
-    return embed
-
-
-def _post_message(*, bot_token: str, channel_id: str, embed: dict) -> str:
+    # Don't set Content-Type — requests fills in the multipart boundary.
+    headers = {
+        "Authorization": f"Bot {bot_token}",
+        "User-Agent": "lorescape-daily-story (https://github.com, 0.1.0)",
+    }
     response = requests.post(
         f"{DISCORD_API}/channels/{channel_id}/messages",
-        headers=_bot_headers(bot_token),
-        json={"embeds": [embed]},
+        headers=headers,
+        files=files,
         timeout=_REQUEST_TIMEOUT,
     )
     response.raise_for_status()

--- a/backend/src/lorescape_backend/daily_story/job.py
+++ b/backend/src/lorescape_backend/daily_story/job.py
@@ -19,6 +19,8 @@ from lorescape_backend.daily_story import (
     story_writer,
     wikipedia,
 )
+from lorescape_backend.social.card import mapper
+from lorescape_backend.social.card.renderer import render_card
 
 logger = logging.getLogger(__name__)
 
@@ -118,10 +120,12 @@ def run_with_retry(config: Config, target_date: date) -> None:
 
 
 def send_today_for_review(config: Config, target_date: date) -> None:
-    """Find the EN row for target_date and post it to Discord for review.
+    """Render today's IG card and post the PNG to Discord for review.
 
-    Idempotent: if discord_message_id is already set on the row, the function
-    does nothing (avoids re-posting the same story when the job runs twice).
+    Reviewers approve/reject the actual image that will be posted to
+    Instagram, not a text preview. Idempotent: if discord_message_id is
+    already set on the row, the function does nothing (avoids re-posting
+    the same card when the job runs twice).
     """
     if not config.review_enabled:
         logger.info("Discord review not configured; skipping review step")
@@ -149,14 +153,29 @@ def send_today_for_review(config: Config, target_date: date) -> None:
         )
         return
 
+    place_row = _load_place_row(supabase, row["place_id"])
+    card_content = (
+        mapper.build_card_content(row, place_row) if place_row else None
+    )
+    if card_content is None:
+        error_message = (
+            f"Row {row['id']} missing IG card content — "
+            f"Discord review not posted for {target_date.isoformat()}"
+        )
+        logger.warning(error_message)
+        if config.discord_webhook_url:
+            discord_notify.notify_failure(
+                webhook_url=config.discord_webhook_url,
+                date_str=target_date.isoformat(),
+                error_message=error_message,
+                traceback_str="",
+            )
+        return
+
+    png = render_card(card_content)
     payload = discord_review.ReviewPayload(
-        place_name=row["place_name"],
-        era=row["era"],
-        place_location=row["place_location"],
-        story=row["story"],
-        threads_summary=row.get("threads_summary") or "",
-        image_url=row.get("image_url"),
-        wikipedia_url=row["wikipedia_url"],
+        card_png=png,
+        publish_date=target_date.isoformat(),
     )
     message_id = discord_review.send_for_review(
         bot_token=config.discord_bot_token,  # type: ignore[arg-type]
@@ -199,6 +218,18 @@ def _load_review_row(supabase, target_date: date) -> dict[str, Any] | None:
         .select("*")
         .eq("publish_date", target_date.isoformat())
         .eq("language", REVIEW_LANGUAGE)
+        .limit(1)
+        .execute()
+    )
+    rows = response.data or []
+    return rows[0] if rows else None
+
+
+def _load_place_row(supabase, place_id: str) -> dict[str, Any] | None:
+    response = (
+        supabase.table("daily_story_places")
+        .select("*")
+        .eq("id", place_id)
         .limit(1)
         .execute()
     )

--- a/backend/tests/test_discord_review.py
+++ b/backend/tests/test_discord_review.py
@@ -1,6 +1,8 @@
 """Discord review-flow REST client tests."""
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from lorescape_backend.daily_story.discord_review import (
@@ -15,23 +17,16 @@ CHANNEL = "777"
 MESSAGE = "9999"
 APPROVER_A = "111"
 APPROVER_B = "222"
+FAKE_PNG = b"\x89PNG\r\n\x1a\nfake-card-bytes"
 
 
 def _payload(**overrides) -> ReviewPayload:
-    base = dict(
-        place_name="Colosseum",
-        era="70-80 CE",
-        place_location="Rome, Italy",
-        story="A vivid story",
-        threads_summary="Short summary",
-        image_url="https://upload.wikimedia.org/x.jpg",
-        wikipedia_url="https://en.wikipedia.org/wiki/Colosseum",
-    )
+    base = dict(card_png=FAKE_PNG, publish_date="2026-05-12")
     base.update(overrides)
     return ReviewPayload(**base)
 
 
-def test_send_for_review_posts_message_then_adds_two_reactions(requests_mock):
+def test_send_for_review_uploads_png_then_adds_two_reactions(requests_mock):
     requests_mock.post(
         f"https://discord.com/api/v10/channels/{CHANNEL}/messages",
         json={"id": MESSAGE},
@@ -53,17 +48,29 @@ def test_send_for_review_posts_message_then_adds_two_reactions(requests_mock):
 
     assert msg_id == MESSAGE
     history = requests_mock.request_history
-    assert history[0].method == "POST"
-    body = history[0].json()
-    embed = body["embeds"][0]
-    assert "Colosseum" in embed["title"]
-    assert "70-80 CE" in embed["title"]
-    assert embed["image"]["url"] == "https://upload.wikimedia.org/x.jpg"
+    post = history[0]
+    assert post.method == "POST"
+
+    # Multipart body must carry the PNG and a JSON payload, not a text embed.
+    content_type = post.headers["Content-Type"]
+    assert content_type.startswith("multipart/form-data")
+    body = post.body
+    if isinstance(body, str):
+        body = body.encode("latin-1")
+    assert FAKE_PNG in body
+    assert b"image/png" in body
+    assert b'name="files[0]"' in body
+    assert b'name="payload_json"' in body
+    # The instruction lives in the message content, not as a story preview.
+    assert b"React" in body and b"21:00" in body
+    # No leftover story / threads fields from the old text-based flow.
+    assert b"embeds" not in body
+
     # Reaction calls authenticated as the bot.
     assert any("Bot tok" in r.headers.get("Authorization", "") for r in history)
 
 
-def test_send_for_review_omits_image_when_none(requests_mock):
+def test_send_for_review_filename_includes_publish_date(requests_mock):
     requests_mock.post(
         f"https://discord.com/api/v10/channels/{CHANNEL}/messages",
         json={"id": MESSAGE},
@@ -82,10 +89,13 @@ def test_send_for_review_omits_image_when_none(requests_mock):
     send_for_review(
         bot_token="tok",
         channel_id=CHANNEL,
-        payload=_payload(image_url=None),
+        payload=_payload(publish_date="2026-05-12"),
     )
-    embed = requests_mock.request_history[0].json()["embeds"][0]
-    assert "image" not in embed
+
+    body = requests_mock.request_history[0].body
+    if isinstance(body, str):
+        body = body.encode("latin-1")
+    assert b"ig-card-2026-05-12.png" in body
 
 
 def test_send_for_review_retries_reaction_once_on_429(requests_mock, mocker):

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -220,6 +220,7 @@ def test_languages_list_matches_spec():
 def _zh_row():
     return {
         "id": "row-zh",
+        "place_id": "place-1",
         "place_name": "羅馬競技場",
         "place_location": "義大利羅馬",
         "era": "公元 70-80 年",
@@ -229,50 +230,126 @@ def _zh_row():
         "image_url": "https://upload.wikimedia.org/x.jpg",
         "wikipedia_url": "https://zh.wikipedia.org/wiki/羅馬競技場",
         "discord_message_id": None,
+        "card_title": "石頭裡的吶喊",
+        "card_title_sub": "鬥獸場百年",
+        "card_paragraphs": ["第一段", "第二段", "第三段"],
+        "card_pull_quote": "「我們將娛樂血腥化為藝術。」",
+        "card_pull_quote_attrib": "—— 塔西陀",
+        "card_anno_roman": "LXXX",
     }
 
 
-def _supabase_with_select_and_update(row):
-    select = MagicMock()
-    select.eq.return_value = select
-    select.limit.return_value = select
-    select.execute.return_value = MagicMock(data=[row] if row else [])
+def _place_row():
+    return {
+        "id": "place-1",
+        "name": "Colosseum",
+        "wikipedia_title_en": "Colosseum",
+        "country": "Italy",
+        "card_location_en": "COLOSSEUM · ROME",
+        "card_city_ch": "羅",
+        "card_city_en": "ROME",
+        "latitude": 41.8902,
+        "longitude": 12.4922,
+    }
+
+
+def _supabase_with_select_and_update(row, place_row=None):
+    """Mock supabase client supporting daily_stories + daily_story_places.
+
+    `row` is the zh-TW review row (None to simulate missing). `place_row`
+    is the joined daily_story_places row (None to simulate missing). The
+    `daily_stories` table responds with `row` for the first .select() call
+    (review-row lookup); the `daily_story_places` table responds with
+    `place_row` for its lookup. .update() on daily_stories always passes.
+    """
+    def _select_chain(data):
+        chain = MagicMock()
+        chain.eq.return_value = chain
+        chain.limit.return_value = chain
+        chain.execute.return_value = MagicMock(data=data)
+        return chain
 
     update_chain = MagicMock()
     update_chain.eq.return_value = update_chain
     update_chain.execute.return_value = MagicMock(data=None)
 
-    table = MagicMock()
-    table.select.return_value = select
-    table.update.return_value = update_chain
+    daily_stories_table = MagicMock()
+    daily_stories_table.select.return_value = _select_chain([row] if row else [])
+    daily_stories_table.update.return_value = update_chain
+
+    places_table = MagicMock()
+    places_table.select.return_value = _select_chain(
+        [place_row] if place_row else []
+    )
+
+    def _table(name):
+        if name == "daily_stories":
+            return daily_stories_table
+        if name == "daily_story_places":
+            return places_table
+        raise AssertionError(f"unexpected table: {name}")
 
     client = MagicMock()
-    client.table.return_value = table
-    return client, table, update_chain
+    client.table.side_effect = _table
+    return client, daily_stories_table, update_chain
 
 
 @patch("lorescape_backend.daily_story.job.create_client")
+@patch("lorescape_backend.daily_story.job.render_card")
 @patch("lorescape_backend.daily_story.job.discord_review.send_for_review")
-def test_send_today_for_review_posts_and_writes_message_id(
-    send, create, fake_config
+def test_send_today_for_review_renders_card_and_posts_image(
+    send, render, create, fake_config
 ):
     from datetime import date as _date
     from lorescape_backend.daily_story.job import send_today_for_review
 
     row = _zh_row()
-    client, table, update_chain = _supabase_with_select_and_update(row)
+    place = _place_row()
+    client, table, _ = _supabase_with_select_and_update(row, place_row=place)
     create.return_value = client
+    render.return_value = b"\x89PNGfake-card"
     send.return_value = "msg-abc"
 
     send_today_for_review(fake_config, _date(2026, 5, 12))
 
+    # Card rendered from the joined zh-TW + place rows, not stubbed in test.
+    render.assert_called_once()
+    rendered_card = render.call_args[0][0]
+    assert rendered_card.title_ch == "石頭裡的吶喊"
+
+    # Discord receives the PNG bytes — no story / threads text fields.
     send.assert_called_once()
     payload = send.call_args.kwargs["payload"]
-    assert payload.place_name == "羅馬競技場"
-    assert payload.threads_summary == "中文短摘。"
+    assert payload.card_png == b"\x89PNGfake-card"
+    assert payload.publish_date == "2026-05-12"
+
     # message id written back to the row
     update_payload = table.update.call_args[0][0]
     assert update_payload == {"discord_message_id": "msg-abc"}
+
+
+@patch("lorescape_backend.daily_story.job.create_client")
+@patch("lorescape_backend.daily_story.job.render_card")
+@patch("lorescape_backend.daily_story.job.discord_review.send_for_review")
+@patch("lorescape_backend.daily_story.job.discord_notify.notify_failure")
+def test_send_today_for_review_notifies_when_card_content_missing(
+    notify, send, render, create, fake_config
+):
+    """If card fields are missing, don't render or post — alert via webhook."""
+    from datetime import date as _date
+    from lorescape_backend.daily_story.job import send_today_for_review
+
+    row = _zh_row()
+    row["card_title"] = None  # mapper rejects when any required field is empty
+    client, _, _ = _supabase_with_select_and_update(row, place_row=_place_row())
+    create.return_value = client
+
+    send_today_for_review(fake_config, _date(2026, 5, 12))
+
+    render.assert_not_called()
+    send.assert_not_called()
+    notify.assert_called_once()
+    assert "card content" in notify.call_args.kwargs["error_message"]
 
 
 @patch("lorescape_backend.daily_story.job.create_client")


### PR DESCRIPTION
## Summary

Refactored the Discord review flow to post the actual rendered Instagram card image (PNG) for reviewer approval, rather than a text-based embed preview. Reviewers now approve/reject the exact image that will be published to Instagram.

## Key Changes

- **Discord Review Payload**: Simplified `ReviewPayload` to contain only `card_png` (bytes) and `publish_date` (ISO string), removing all story/place text fields
- **Message Format**: Changed from JSON embed to multipart form-data with PNG attachment and instruction text in message content
- **Card Rendering**: Integrated card mapper and renderer into the job flow:
  - Load place row from `daily_story_places` table using `place_id` foreign key
  - Build card content from joined story + place rows via `mapper.build_card_content()`
  - Render card to PNG bytes via `render_card()`
- **Error Handling**: Added validation to skip posting and notify via webhook if card content is missing (e.g., required fields like `card_title` are null)
- **Test Data**: Extended `_zh_row()` fixture with card-specific fields (`card_title`, `card_title_sub`, `card_paragraphs`, `card_pull_quote`, `card_pull_quote_attrib`, `card_anno_roman`, `place_id`) and added `_place_row()` fixture
- **Mock Infrastructure**: Updated `_supabase_with_select_and_update()` to support dual-table mocking (`daily_stories` and `daily_story_places`) with separate select chains

## Notable Implementation Details

- The multipart upload uses `requests` library with `files` parameter; Content-Type header is omitted to let `requests` auto-fill the boundary
- Card rendering happens before Discord posting, so validation errors are caught early and logged with webhook notification
- Filename includes publish date for clarity in Discord: `ig-card-{publish_date}.png`
- Review instruction text ("React ✅ to publish...") moved from embed footer to message content

https://claude.ai/code/session_01E4JvrAus8rBbZSdV4rsKsd