### PR TITLE
Grant App clients SELECT access to daily_story_places card fields

### DIFF
--- a/frontend/test/features/daily_story/data/daily_story_places_grant_contract_test.dart
+++ b/frontend/test/features/daily_story/data/daily_story_places_grant_contract_test.dart
@@ -1,0 +1,121 @@
+// Contract test: every column the App embeds via
+// `daily_story_places!left(...)` in SupabaseDailyStoryRepository MUST also
+// be granted SELECT to anon/authenticated by a Supabase migration.
+//
+// This is the test that would have caught the PostgrestException 42501
+// regression on the history-story screen, where the repository embed
+// referenced columns on a table that had no client-side SELECT grant.
+//
+// The test reads the repository source and the migration SQL files
+// directly, so it has no Flutter, no Supabase, and no network dependency.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const _repoSourcePath =
+    'lib/features/daily_story/data/supabase_daily_story_repository.dart';
+const _migrationsDir = '../supabase/migrations';
+
+void main() {
+  group('daily_story_places client access contract', () {
+    test(
+      'given the repository embeds daily_story_places columns, '
+      'when checking Supabase grants, '
+      'then every embedded column is granted SELECT to anon/authenticated',
+      () {
+        final embeddedColumns = _extractEmbeddedColumns(
+          File(_repoSourcePath).readAsStringSync(),
+        );
+        expect(
+          embeddedColumns,
+          isNotEmpty,
+          reason:
+              'Failed to parse `daily_story_places!left(...)` in '
+              '$_repoSourcePath — has the embed syntax changed?',
+        );
+
+        final grantedColumns = _extractGrantedColumns(_collectMigrationSql());
+        expect(
+          grantedColumns,
+          isNotEmpty,
+          reason:
+              'No `grant select (...) on table public.daily_story_places '
+              'to anon, authenticated` found in supabase/migrations/.',
+        );
+
+        final ungranted = embeddedColumns.difference(grantedColumns);
+        expect(
+          ungranted,
+          isEmpty,
+          reason:
+              'Columns embedded by the repository but NOT granted to '
+              'anon/authenticated: $ungranted. PostgREST will reject the '
+              'join with 42501. Either add the columns to the GRANT or '
+              'remove them from the embed.',
+        );
+      },
+    );
+  });
+}
+
+/// Extracts the comma-separated column list from an embed like
+/// `daily_story_places!left(col1, col2, col3)` in the given Dart source.
+Set<String> _extractEmbeddedColumns(String source) {
+  final match = RegExp(
+    r'daily_story_places!left\(([^)]*)\)',
+  ).firstMatch(source);
+  if (match == null) return <String>{};
+  return match
+      .group(1)!
+      .split(',')
+      .map((c) => c.trim())
+      .where((c) => c.isNotEmpty)
+      .toSet();
+}
+
+/// Walks `supabase/migrations/` and collects every `grant select (...)
+/// on table public.daily_story_places to ... anon ... authenticated ...`
+/// column list. Tolerates either order of anon/authenticated and
+/// either single- or multi-line GRANT statements.
+Set<String> _extractGrantedColumns(String allMigrationSql) {
+  final grants = RegExp(
+    r'grant\s+select\s*\(([^)]+)\)\s+on\s+table\s+public\.daily_story_places'
+    r'\s+to\s+([^;]+);',
+    caseSensitive: false,
+  ).allMatches(allMigrationSql);
+
+  final granted = <String>{};
+  for (final match in grants) {
+    final roles = match
+        .group(2)!
+        .split(',')
+        .map((r) => r.trim().toLowerCase())
+        .toSet();
+    final coversAnon = roles.contains('anon');
+    final coversAuth = roles.contains('authenticated');
+    if (!coversAnon || !coversAuth) continue;
+    granted.addAll(
+      match
+          .group(1)!
+          .split(',')
+          .map((c) => c.trim())
+          .where((c) => c.isNotEmpty),
+    );
+  }
+  return granted;
+}
+
+String _collectMigrationSql() {
+  final dir = Directory(_migrationsDir);
+  if (!dir.existsSync()) {
+    fail('Migrations directory not found at $_migrationsDir');
+  }
+  final buffer = StringBuffer();
+  for (final entity in dir.listSync()) {
+    if (entity is File && entity.path.endsWith('.sql')) {
+      buffer.writeln(entity.readAsStringSync());
+    }
+  }
+  return buffer.toString();
+}

--- a/supabase/migrations/20260527000000_grant_daily_story_places_card_select.sql
+++ b/supabase/migrations/20260527000000_grant_daily_story_places_card_select.sql
@@ -1,0 +1,25 @@
+-- Allow App clients to read the card display fields from daily_story_places.
+--
+-- Background: 20260510000001 deliberately withheld SELECT on this table from
+-- anon/authenticated, treating it as an admin-only master list. Later,
+-- 20260521120000 added card_location_en / card_city_ch / card_city_en to
+-- power the IG-style card layout in the App. The repository
+-- (SupabaseDailyStoryRepository._select) embeds these via PostgREST join
+--   daily_story_places!left(card_location_en, card_city_ch, card_city_en)
+-- which fails with `42501 permission denied for table daily_story_places`
+-- because (a) no table-level SELECT grant and (b) no RLS SELECT policy
+-- exist for anon/authenticated.
+--
+-- Fix: column-level SELECT on the join key + 3 card display columns, plus
+-- a permissive RLS SELECT policy. Operational columns
+-- (name, country, wikipedia_title_en, is_active, used_at, latitude,
+-- longitude, created_at) remain admin-only — neither granted to anon/
+-- authenticated nor exposed by the policy alone, since column-level grants
+-- gate them.
+
+grant select (id, card_location_en, card_city_ch, card_city_en)
+  on table public.daily_story_places to anon, authenticated;
+
+create policy "anon can read card display fields"
+  on public.daily_story_places for select to anon, authenticated
+  using (true);


### PR DESCRIPTION
## Summary
Fixes permission errors when the App repository attempts to join card display fields from `daily_story_places` via PostgREST. Previously, the table was admin-only; this change grants column-level SELECT access to the join key and card display columns, plus a permissive RLS policy.

## Changes
- **Column-level SELECT grant**: Allows `anon` and `authenticated` roles to read `id`, `card_location_en`, `card_city_ch`, and `card_city_en` from `daily_story_places`
- **RLS SELECT policy**: Adds a permissive policy (`anon can read card display fields`) to enable the PostgREST join operation
- **Operational columns remain admin-only**: Columns like `name`, `country`, `wikipedia_title_en`, `is_active`, `used_at`, `latitude`, `longitude`, and `created_at` are not granted and remain inaccessible to app clients

## Implementation Details
The fix uses column-level grants to expose only the necessary fields for the IG-style card layout in the App, while maintaining admin-only access to operational and sensitive columns. The RLS policy is permissive (`using (true)`) because the column-level grants already enforce the security boundary.

This resolves the `42501 permission denied for table daily_story_places` error that occurred when `SupabaseDailyStoryRepository._select` attempted to embed these fields via a PostgREST left join.

https://claude.ai/code/session_01Cdrm1h4yN2NkD62McndTtU