### PR TITLE
fix(narration): stop TTS when leaving the player screen

### DIFF
--- a/frontend/lib/features/narration/presentation/controllers/player_controller.dart
+++ b/frontend/lib/features/narration/presentation/controllers/player_controller.dart
@@ -158,6 +158,23 @@ class PlayerController extends AutoDisposeNotifier<NarrationState> {
     state = state.paused();
   }
 
+  /// 停止播放並重置為就緒狀態。
+  ///
+  /// 供離開播放頁面時呼叫。不能只依賴 provider 的 autoDispose 來停止
+  /// 播放：全 app 存活的 `NarrationAnalyticsObserver` 會持續 listen
+  /// [playerControllerProvider]，使其永不 autoDispose（[_cleanup] 因此
+  /// 不會執行），所以離開頁面時必須明確停止 TTS。
+  Future<void> stop() async {
+    _isSkipping = false;
+    _charPositionOffset = 0;
+    await _ttsService.stop();
+    final place = state.place;
+    final content = state.content;
+    if (place != null && content != null) {
+      state = state.ready(place, content);
+    }
+  }
+
   /// 跳到指定段落並開始播放
   ///
   /// [segmentIndex] 目標段落索引

--- a/frontend/lib/features/narration/presentation/screens/narration_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/narration_screen.dart
@@ -5,6 +5,7 @@ import 'package:context_app/features/narration/domain/models/narration_content.d
 import 'package:context_app/features/narration/presentation/widgets/grounding_info_sheet.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_control_panel.dart';
 import 'package:context_app/features/narration/presentation/widgets/narration_transcript_area.dart';
+import 'package:context_app/features/narration/presentation/controllers/player_controller.dart';
 import 'package:context_app/features/narration/presentation/widgets/reading_palette.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
@@ -60,23 +61,33 @@ class _NarrationScreenState extends ConsumerState<NarrationScreen> {
   final AutoScrollController _scrollController = AutoScrollController();
   int? _lastSegmentIndex;
 
+  /// Cached in [initState] so [dispose] can stop playback without `ref`,
+  /// which is no longer usable once the widget has been disposed.
+  late final PlayerController _playerController;
+
   @override
   void initState() {
     super.initState();
+    _playerController = ref.read(playerControllerProvider.notifier);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref
-          .read(playerControllerProvider.notifier)
+      _playerController
           .initializeWithContent(widget.place, widget.narrationContent)
           .then((_) {
             if (!mounted || !widget.autoPlay) return;
-            ref.read(playerControllerProvider.notifier).play();
+            _playerController.play();
           });
     });
   }
 
   @override
   void dispose() {
+    // Explicitly stop TTS when leaving the player. playerControllerProvider
+    // is autoDispose and originally relied on autoDispose firing _cleanup()
+    // (which stops TTS). But the app-wide NarrationAnalyticsObserver keeps a
+    // permanent ref.listen on this provider, so it never auto-disposes; we
+    // must stop playback here instead.
+    _playerController.stop();
     _scrollController.dispose();
     super.dispose();
   }

--- a/frontend/test/features/narration/presentation/screens/narration_screen_stop_on_leave_test.dart
+++ b/frontend/test/features/narration/presentation/screens/narration_screen_stop_on_leave_test.dart
@@ -1,0 +1,89 @@
+import 'package:context_app/features/explore/domain/models/place.dart';
+import 'package:context_app/features/narration/domain/models/narration_content.dart';
+import 'package:context_app/features/narration/presentation/screens/narration_screen.dart';
+import 'package:context_app/features/narration/providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../fakes/fake_tts_service.dart';
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/test_data.dart';
+
+/// Keeps [playerControllerProvider] alive for the whole test, mirroring the
+/// app-wide `NarrationAnalyticsObserver` which `ref.listen`s the player for
+/// its entire lifetime. With a permanent listener present the provider never
+/// auto-disposes, so leaving the screen must stop TTS explicitly.
+class _KeepPlayerAlive extends ConsumerWidget {
+  const _KeepPlayerAlive();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(playerControllerProvider);
+    return const SizedBox.shrink();
+  }
+}
+
+class _Host extends StatefulWidget {
+  const _Host({required this.place, required this.content});
+  final Place place;
+  final NarrationContent content;
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  bool _showScreen = true;
+
+  void leaveScreen() => setState(() => _showScreen = false);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const _KeepPlayerAlive(),
+        if (_showScreen)
+          Expanded(
+            child: NarrationScreen(
+              place: widget.place,
+              narrationContent: widget.content,
+              autoPlay: true,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+void main() {
+  setUpAll(() async {
+    await initTestEnvironment();
+  });
+
+  testWidgets(
+    'given playback started and the player provider is kept alive, '
+    'when the narration screen is left (disposed), '
+    'then TTS is stopped',
+    (tester) async {
+      final tts = FakeTtsService();
+      await pumpScreen(
+        tester,
+        child: _Host(place: buildPlace(), content: buildNarrationContent()),
+        overrides: [ttsServiceProvider.overrideWithValue(tts)],
+      );
+      // Let initializeWithContent() + autoPlay reach speak().
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.pump(const Duration(milliseconds: 20));
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(tts.speakCount, greaterThanOrEqualTo(1));
+
+      // Leave the screen.
+      tester.state<_HostState>(find.byType(_Host)).leaveScreen();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(tts.stopCount, greaterThanOrEqualTo(1));
+    },
+  );
+}


### PR DESCRIPTION
## Problem

The narration audio kept playing after the user left the player screen.

## Root cause

`PlayerController` is an `AutoDisposeNotifier` and stops TTS in its
`ref.onDispose` cleanup — it relied on the provider auto-disposing to stop
playback. But `app.dart` keeps the app-wide `NarrationAnalyticsObserver` alive
for the whole app lifecycle via `ref.watch`, and that observer holds a
permanent `ref.listen(playerControllerProvider)`. With a permanent listener the
provider never auto-disposes, so `_cleanup()` (which calls `tts.stop()`) never
runs and audio continues after leaving the screen.

## Fix

Stop playback explicitly on screen teardown instead of relying on the
autoDispose side effect:

- Add `PlayerController.stop()` — stops TTS and resets to the ready state.
- `NarrationScreen` caches the controller in `initState` and calls
  `stop()` from `dispose()` (`ref` is unusable once the widget is disposed).

## Tests

- New widget test reproduces the bug: with the player provider kept alive by a
  permanent listener (mirroring the observer), leaving the screen must stop TTS.
  Fails before the fix, passes after.
- `analyze --fatal-infos`: 0 issues. All 55 narration tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
