### PR TITLE
feat(daily-story): use only commercially-licensed images, with attribution

### DIFF
--- a/backend/src/lorescape_backend/daily_story/job.py
+++ b/backend/src/lorescape_backend/daily_story/job.py
@@ -47,6 +47,24 @@ def run_once(config: Config, target_date: date) -> None:
         or summary.extract
     )
 
+    # Resolve the lead image together with its Wikimedia licence and only use
+    # it when it is commercially reusable (public domain / CC0 / CC BY /
+    # CC BY-SA). Fair-use and NC/ND images are dropped so we never post art we
+    # are not licensed to use commercially; usable images carry an attribution
+    # credit that we store and display.
+    lead_image = wikipedia.fetch_lead_image(place.wikipedia_title_en)
+    if lead_image and lead_image.is_commercial_ok and summary.image_url:
+        image_url = summary.image_url
+        image_attribution = lead_image.attribution
+    else:
+        image_url = None
+        image_attribution = None
+        if summary.image_url:
+            logger.info(
+                "Lead image for %s is not commercially usable; dropping it",
+                place.wikipedia_title_en,
+            )
+
     for language in LANGUAGES:
         target_lang = language.split("-")[0]  # 'zh-TW' → 'zh', 'en' → 'en'
         wiki_url = (
@@ -77,7 +95,8 @@ def run_once(config: Config, target_date: date) -> None:
                 place_location=story.place_location,
                 era=story.era,
                 story=story_text,
-                image_url=summary.image_url,
+                image_url=image_url,
+                image_attribution=image_attribution,
                 wikipedia_url=wiki_url,
                 hashtags=story.hashtags,
                 paragraphs=story.paragraphs,

--- a/backend/src/lorescape_backend/daily_story/story_writer.py
+++ b/backend/src/lorescape_backend/daily_story/story_writer.py
@@ -16,6 +16,9 @@ class StoryRow:
     story: str
     image_url: str | None
     wikipedia_url: str
+    # Credit string for the lead image (author / licence / source). None when
+    # there is no commercially usable image.
+    image_attribution: str | None = None
     hashtags: tuple[str, ...] = field(default_factory=tuple)
     # Long-form 3-paragraph narration used by App story view & TTS.
     paragraphs: tuple[str, ...] = field(default_factory=tuple)

--- a/backend/src/lorescape_backend/daily_story/wikipedia.py
+++ b/backend/src/lorescape_backend/daily_story/wikipedia.py
@@ -6,6 +6,7 @@ Two endpoints used:
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from urllib.parse import quote
 
@@ -46,6 +47,164 @@ def fetch_summary(title: str) -> WikipediaSummary:
         image_url=(data.get("thumbnail") or {}).get("source"),
         en_url=data["content_urls"]["desktop"]["page"],
     )
+
+
+@dataclass(frozen=True)
+class LeadImage:
+    """A page's lead image with its Wikimedia licence metadata.
+
+    `is_commercial_ok` is True only for licences that allow commercial reuse
+    (public domain, CC0, CC BY, CC BY-SA). `attribution` is the credit string
+    to display alongside the image (None when the image is not commercially
+    usable, since we won't post it).
+    """
+
+    url: str
+    license_short: str | None
+    license_code: str | None
+    artist: str | None
+    attribution: str | None
+    is_commercial_ok: bool
+
+
+def fetch_lead_image(title: str) -> LeadImage | None:
+    """Fetch the page's lead image together with its licence metadata.
+
+    Unlike the REST summary thumbnail (which carries no licence info), this
+    resolves the lead image file and queries Wikimedia `imageinfo`
+    `extmetadata` so the caller can filter to commercially reusable images
+    and record the required attribution.
+
+    Returns None when the page has no lead image or the file has no usable
+    image info.
+    """
+    file_name = _fetch_lead_image_filename(title)
+    if not file_name:
+        return None
+    info = _fetch_file_imageinfo(file_name)
+    if not info:
+        return None
+    url = info.get("url")
+    if not url:
+        return None
+    meta = info.get("extmetadata", {}) or {}
+    license_short = _meta_value(meta, "LicenseShortName")
+    license_code = _meta_value(meta, "License")
+    non_free = _meta_value(meta, "NonFree")
+    artist = _clean_html(_meta_value(meta, "Artist"))
+    ok = _is_commercial_ok(license_code, license_short, non_free)
+    attribution = _build_attribution(artist, license_short) if ok else None
+    return LeadImage(
+        url=url,
+        license_short=license_short,
+        license_code=license_code,
+        artist=artist,
+        attribution=attribution,
+        is_commercial_ok=ok,
+    )
+
+
+def _fetch_lead_image_filename(title: str) -> str | None:
+    response = requests.get(
+        _API_URL,
+        params={
+            "action": "query",
+            "format": "json",
+            "titles": title,
+            "prop": "pageimages",
+            "piprop": "name",
+            "redirects": 1,
+        },
+        headers={"User-Agent": USER_AGENT},
+        timeout=30,
+    )
+    response.raise_for_status()
+    pages = response.json().get("query", {}).get("pages", {})
+    for page in pages.values():
+        name = page.get("pageimage")
+        if name:
+            return name
+    return None
+
+
+def _fetch_file_imageinfo(file_name: str) -> dict | None:
+    response = requests.get(
+        _API_URL,
+        params={
+            "action": "query",
+            "format": "json",
+            "titles": f"File:{file_name}",
+            "prop": "imageinfo",
+            "iiprop": "url|extmetadata",
+            "redirects": 1,
+        },
+        headers={"User-Agent": USER_AGENT},
+        timeout=30,
+    )
+    response.raise_for_status()
+    pages = response.json().get("query", {}).get("pages", {})
+    for page in pages.values():
+        infos = page.get("imageinfo")
+        if infos:
+            return infos[0]
+    return None
+
+
+def _meta_value(meta: dict, key: str) -> str | None:
+    entry = meta.get(key)
+    if not entry:
+        return None
+    value = entry.get("value")
+    return value if value else None
+
+
+def _is_commercial_ok(
+    license_code: str | None,
+    license_short: str | None,
+    non_free: str | None,
+) -> bool:
+    """Allow only licences that permit commercial reuse.
+
+    Whitelist: public domain, CC0, CC BY, CC BY-SA. Anything carrying a
+    NonCommercial (NC) or NoDerivatives (ND) term, marked non-free
+    (fair use), or with an unknown licence is rejected.
+    """
+    if non_free and str(non_free).strip().lower() not in ("0", "false", ""):
+        return False
+
+    code = (license_code or "").strip().lower()
+    short = (license_short or "").strip().lower()
+    if not code and not short:
+        return False
+
+    # Reject non-commercial / no-derivatives variants outright.
+    if "nc" in re.split(r"[-\s]", code) or "nc" in re.split(r"[-\s]", short):
+        return False
+    if "nd" in re.split(r"[-\s]", code) or "nd" in re.split(r"[-\s]", short):
+        return False
+    if "noncommercial" in short or "non-commercial" in short:
+        return False
+
+    if code.startswith(("cc0", "pd", "cc-by")):
+        return True
+    if "public domain" in short or short.startswith(("cc0", "cc by")):
+        return True
+    return False
+
+
+def _build_attribution(artist: str | None, license_short: str | None) -> str | None:
+    parts = [p for p in (artist, license_short) if p]
+    if not parts:
+        return None
+    return " / ".join(parts) + " (via Wikimedia Commons)"
+
+
+def _clean_html(value: str | None) -> str | None:
+    if not value:
+        return None
+    text = re.sub(r"<[^>]+>", "", value)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text or None
 
 
 def fetch_intro_extract(title: str) -> str:

--- a/backend/src/lorescape_backend/social/caption.py
+++ b/backend/src/lorescape_backend/social/caption.py
@@ -29,25 +29,37 @@ class StoryCopy:
     era: str
     story: str
     hashtags: tuple[str, ...]
+    # Lead-image credit (author / licence / source). None when there is no
+    # commercially usable image; omitted from the caption when absent.
+    image_attribution: str | None = None
 
 
 def build_full_caption(
     *, story: StoryCopy, brand_handle: str, cta_text: str
 ) -> str:
-    """Build the full IG caption (header + body + hashtags + CTA).
+    """Build the full IG caption (header + body + hashtags + CTA + credit).
 
     Truncates only the body to keep the result under IG's 2200-char limit.
+    A photo credit line is appended when the story has an image attribution.
     """
     header = _header(story)
     tags = _format_tags(BRAND_TAGS + story.hashtags)
     footer = _footer(cta_text=cta_text, brand_handle=brand_handle)
+    credit = _photo_credit(story.image_attribution)
 
-    fixed = "\n\n".join(p for p in (header, "", tags, footer) if p)
+    fixed = "\n\n".join(p for p in (header, "", tags, footer, credit) if p)
     body_budget = _IG_HARD_LIMIT - len(fixed) - 2  # account for separators
     body = story.story if len(story.story) <= body_budget else _truncate(
         story.story, body_budget
     )
-    return "\n\n".join(p for p in (header, body, tags, footer) if p)
+    return "\n\n".join(p for p in (header, body, tags, footer, credit) if p)
+
+
+def _photo_credit(attribution: str | None) -> str:
+    """Render the image credit line, or empty string when absent."""
+    if not attribution:
+        return ""
+    return f"📷 {attribution}"
 
 
 def _header(story: StoryCopy) -> str:

--- a/backend/src/lorescape_backend/social/publisher.py
+++ b/backend/src/lorescape_backend/social/publisher.py
@@ -115,6 +115,7 @@ def _try_publish(supabase, config: Config, row: dict[str, Any]) -> None:
         era=row["era"],
         story=row["story"],
         hashtags=tuple(row.get("hashtags") or ()),
+        image_attribution=row.get("image_attribution"),
     )
 
     place_row = _load_place_row(supabase, row["place_id"])

--- a/backend/tests/test_caption.py
+++ b/backend/tests/test_caption.py
@@ -53,3 +53,24 @@ def test_full_caption_under_ig_limit_when_story_is_huge():
         cta_text="Explore more.",
     )
     assert len(out) <= 2200
+
+
+def test_full_caption_includes_photo_credit_when_present():
+    story = _story(
+        image_attribution="Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)"
+    )
+    out = build_full_caption(
+        story=story,
+        brand_handle="@instant_explore",
+        cta_text="Explore more.",
+    )
+    assert "📷 Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)" in out
+
+
+def test_full_caption_omits_photo_credit_when_absent():
+    out = build_full_caption(
+        story=_story(image_attribution=None),
+        brand_handle="@instant_explore",
+        cta_text="Explore more.",
+    )
+    assert "📷" not in out

--- a/backend/tests/test_job.py
+++ b/backend/tests/test_job.py
@@ -6,7 +6,7 @@ import pytest
 from lorescape_backend.daily_story.job import LANGUAGES, run_once, run_with_retry
 from lorescape_backend.daily_story.gemini_client import GeneratedStory
 from lorescape_backend.daily_story.place_picker import PickedPlace
-from lorescape_backend.daily_story.wikipedia import WikipediaSummary
+from lorescape_backend.daily_story.wikipedia import LeadImage, WikipediaSummary
 
 
 def _make_story(
@@ -42,6 +42,7 @@ def _make_story(
 @patch("lorescape_backend.daily_story.job.create_client")
 @patch("lorescape_backend.daily_story.job.place_picker.pick_next_place")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_summary")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_lead_image")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_intro_extract")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_langlink_url")
 @patch("lorescape_backend.daily_story.job.gemini_client.generate_story")
@@ -53,6 +54,7 @@ def test_run_once_happy_path_calls_each_step(
     generate_story,
     fetch_langlink,
     fetch_intro_extract,
+    fetch_lead_image,
     fetch_summary,
     pick_next,
     create_client,
@@ -65,6 +67,14 @@ def test_run_once_happy_path_calls_each_step(
         extract="Built 70-80 CE.",
         image_url="https://upload.wikimedia.org/x.jpg",
         en_url="https://en.wikipedia.org/wiki/Colosseum",
+    )
+    fetch_lead_image.return_value = LeadImage(
+        url="https://upload.wikimedia.org/x.jpg",
+        license_short="CC BY-SA 4.0",
+        license_code="cc-by-sa-4.0",
+        artist="Jane Doe",
+        attribution="Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)",
+        is_commercial_ok=True,
     )
     fetch_langlink.side_effect = lambda title, lang: (
         f"https://{lang}.wikipedia.org/wiki/{title}"
@@ -96,6 +106,14 @@ def test_run_once_happy_path_calls_each_step(
     mark_used.assert_called_once()
     args, _ = mark_used.call_args
     assert args[1] == "p1"
+    # Each row carries the commercially-licensed image and its attribution.
+    for c in insert_story.call_args_list:
+        row = c.args[1]
+        assert row.image_url == "https://upload.wikimedia.org/x.jpg"
+        assert (
+            row.image_attribution
+            == "Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)"
+        )
 
 
 @patch("lorescape_backend.daily_story.job.create_client")
@@ -109,6 +127,7 @@ def test_run_once_raises_when_no_place(pick_next, create_client, fake_config):
 @patch("lorescape_backend.daily_story.job.create_client")
 @patch("lorescape_backend.daily_story.job.place_picker.pick_next_place")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_summary")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_lead_image")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_intro_extract")
 @patch("lorescape_backend.daily_story.job.wikipedia.fetch_langlink_url")
 @patch("lorescape_backend.daily_story.job.gemini_client.generate_story")
@@ -120,6 +139,7 @@ def test_run_once_falls_back_to_en_url_when_no_langlink(
     generate_story,
     fetch_langlink,
     fetch_intro_extract,
+    fetch_lead_image,
     fetch_summary,
     pick_next,
     create_client,
@@ -133,6 +153,7 @@ def test_run_once_falls_back_to_en_url_when_no_langlink(
         image_url=None,
         en_url="https://en.wikipedia.org/wiki/Colosseum",
     )
+    fetch_lead_image.return_value = None
     # Simulate: zh has no langlink, en is just the same article
     fetch_langlink.return_value = None
     generate_story.return_value = _make_story()
@@ -143,6 +164,55 @@ def test_run_once_falls_back_to_en_url_when_no_langlink(
     for c in insert_story.call_args_list:
         row = c.args[1]
         assert row.wikipedia_url == "https://en.wikipedia.org/wiki/Colosseum"
+
+
+@patch("lorescape_backend.daily_story.job.create_client")
+@patch("lorescape_backend.daily_story.job.place_picker.pick_next_place")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_summary")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_lead_image")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_intro_extract")
+@patch("lorescape_backend.daily_story.job.wikipedia.fetch_langlink_url")
+@patch("lorescape_backend.daily_story.job.gemini_client.generate_story")
+@patch("lorescape_backend.daily_story.job.story_writer.insert_story")
+@patch("lorescape_backend.daily_story.job.place_picker.mark_place_used")
+def test_run_once_drops_image_when_not_commercially_licensed(
+    mark_used,
+    insert_story,
+    generate_story,
+    fetch_langlink,
+    fetch_intro_extract,
+    fetch_lead_image,
+    fetch_summary,
+    pick_next,
+    create_client,
+    fake_config,
+):
+    pick_next.return_value = PickedPlace(id="p1", wikipedia_title_en="Colosseum")
+    fetch_intro_extract.return_value = "Long intro extract text for tests."
+    fetch_summary.return_value = WikipediaSummary(
+        title="Colosseum",
+        extract="Built 70-80 CE.",
+        image_url="https://upload.wikimedia.org/x.jpg",
+        en_url="https://en.wikipedia.org/wiki/Colosseum",
+    )
+    # A fair-use / non-commercial lead image must NOT be used.
+    fetch_lead_image.return_value = LeadImage(
+        url="https://upload.wikimedia.org/x.jpg",
+        license_short="Fair use",
+        license_code="fair use",
+        artist=None,
+        attribution=None,
+        is_commercial_ok=False,
+    )
+    fetch_langlink.return_value = None
+    generate_story.return_value = _make_story()
+
+    run_once(fake_config, date(2026, 5, 11))
+
+    for c in insert_story.call_args_list:
+        row = c.args[1]
+        assert row.image_url is None
+        assert row.image_attribution is None
 
 
 @patch("lorescape_backend.daily_story.job.time.sleep")  # speed up retry

--- a/backend/tests/test_story_writer.py
+++ b/backend/tests/test_story_writer.py
@@ -39,6 +39,7 @@ def test_insert_story_upserts_with_publish_date_language_conflict_key():
         "story": "...",
         "image_url": "https://upload.wikimedia.org/x.jpg",
         "wikipedia_url": "https://zh.wikipedia.org/wiki/...",
+        "image_attribution": None,
         "hashtags": ["rome", "colosseum"],
         "paragraphs": [],
         "card_title": "",

--- a/backend/tests/test_wikipedia.py
+++ b/backend/tests/test_wikipedia.py
@@ -1,9 +1,13 @@
+import copy
+
 import pytest
 import requests_mock
 
 from lorescape_backend.daily_story.wikipedia import (
+    LeadImage,
     WikipediaSummary,
     fetch_intro_extract,
+    fetch_lead_image,
     fetch_summary,
     fetch_langlink_url,
 )
@@ -143,3 +147,125 @@ def test_fetch_langlink_url_returns_none_when_no_langlink():
     with requests_mock.Mocker() as m:
         m.get("https://en.wikipedia.org/w/api.php", json=response)
         assert fetch_langlink_url("X", "zh") is None
+
+
+# ---- fetch_lead_image (licence-aware) ----------------------------------
+
+PAGEIMAGE_RESP = {
+    "query": {
+        "pages": {
+            "123": {
+                "pageid": 123,
+                "title": "Colosseum",
+                "pageimage": "Colosseum_2020.jpg",
+            }
+        }
+    }
+}
+
+
+def _imageinfo_resp(*, license_code, license_short, artist="<a href='#'>Jane Doe</a>", non_free=None):
+    extmeta = {
+        "License": {"value": license_code},
+        "LicenseShortName": {"value": license_short},
+    }
+    if artist is not None:
+        extmeta["Artist"] = {"value": artist}
+    if non_free is not None:
+        extmeta["NonFree"] = {"value": non_free}
+    return {
+        "query": {
+            "pages": {
+                "-1": {
+                    "title": "File:Colosseum_2020.jpg",
+                    "imageinfo": [
+                        {
+                            "url": "https://upload.wikimedia.org/Colosseum_2020.jpg",
+                            "extmetadata": extmeta,
+                        }
+                    ],
+                }
+            }
+        }
+    }
+
+
+def _mock_lead_image(m, imageinfo):
+    """Register the two sequential api.php calls fetch_lead_image makes."""
+    m.get(
+        "https://en.wikipedia.org/w/api.php",
+        [{"json": PAGEIMAGE_RESP}, {"json": imageinfo}],
+    )
+
+
+def test_fetch_lead_image_accepts_cc_by_sa_with_attribution():
+    with requests_mock.Mocker() as m:
+        _mock_lead_image(
+            m,
+            _imageinfo_resp(license_code="cc-by-sa-4.0", license_short="CC BY-SA 4.0"),
+        )
+        img = fetch_lead_image("Colosseum")
+    assert isinstance(img, LeadImage)
+    assert img.is_commercial_ok is True
+    assert img.url == "https://upload.wikimedia.org/Colosseum_2020.jpg"
+    assert img.attribution is not None
+    assert "Jane Doe" in img.attribution
+    assert "CC BY-SA 4.0" in img.attribution
+
+
+def test_fetch_lead_image_accepts_public_domain_without_artist():
+    with requests_mock.Mocker() as m:
+        _mock_lead_image(
+            m,
+            _imageinfo_resp(
+                license_code="pd", license_short="Public domain", artist=None
+            ),
+        )
+        img = fetch_lead_image("Colosseum")
+    assert img.is_commercial_ok is True
+    assert img.attribution is not None
+    assert "Public domain" in img.attribution
+
+
+def test_fetch_lead_image_rejects_non_commercial():
+    with requests_mock.Mocker() as m:
+        _mock_lead_image(
+            m,
+            _imageinfo_resp(license_code="cc-by-nc-4.0", license_short="CC BY-NC 4.0"),
+        )
+        img = fetch_lead_image("Colosseum")
+    assert img is not None
+    assert img.is_commercial_ok is False
+    assert img.attribution is None
+
+
+def test_fetch_lead_image_rejects_no_derivatives():
+    with requests_mock.Mocker() as m:
+        _mock_lead_image(
+            m,
+            _imageinfo_resp(license_code="cc-by-nd-4.0", license_short="CC BY-ND 4.0"),
+        )
+        img = fetch_lead_image("Colosseum")
+    assert img.is_commercial_ok is False
+
+
+def test_fetch_lead_image_rejects_non_free_fair_use():
+    with requests_mock.Mocker() as m:
+        _mock_lead_image(
+            m,
+            _imageinfo_resp(
+                license_code="Fair use",
+                license_short="Fair use",
+                non_free="1",
+            ),
+        )
+        img = fetch_lead_image("Colosseum")
+    assert img.is_commercial_ok is False
+
+
+def test_fetch_lead_image_returns_none_when_no_pageimage():
+    no_image = copy.deepcopy(PAGEIMAGE_RESP)
+    del no_image["query"]["pages"]["123"]["pageimage"]
+    with requests_mock.Mocker() as m:
+        m.get("https://en.wikipedia.org/w/api.php", json=no_image)
+        assert fetch_lead_image("Colosseum") is None

--- a/frontend/lib/features/daily_story/data/supabase_daily_story_repository.dart
+++ b/frontend/lib/features/daily_story/data/supabase_daily_story_repository.dart
@@ -56,6 +56,7 @@ class SupabaseDailyStoryRepository implements DailyStoryRepository {
       era: row['era'] as String,
       story: row['story'] as String,
       imageUrl: row['image_url'] as String?,
+      imageAttribution: row['image_attribution'] as String?,
       wikipediaUrl: row['wikipedia_url'] as String,
       cardTitle: row['card_title'] as String?,
       cardTitleSub: row['card_title_sub'] as String?,

--- a/frontend/lib/features/daily_story/domain/models/daily_story.dart
+++ b/frontend/lib/features/daily_story/domain/models/daily_story.dart
@@ -29,6 +29,10 @@ class DailyStory extends Equatable {
   /// Optional image URL (Wikipedia thumbnail). May be null.
   final String? imageUrl;
 
+  /// Credit for [imageUrl] (author / licence / source). Null when there is no
+  /// commercially usable image. Shown as a small caption in the reader.
+  final String? imageAttribution;
+
   /// Wikipedia article URL in the matching language; falls back to en.
   final String wikipediaUrl;
 
@@ -61,6 +65,7 @@ class DailyStory extends Equatable {
     required this.era,
     required this.story,
     required this.imageUrl,
+    this.imageAttribution,
     required this.wikipediaUrl,
     this.cardTitle,
     this.cardTitleSub,
@@ -83,6 +88,7 @@ class DailyStory extends Equatable {
     era,
     story,
     imageUrl,
+    imageAttribution,
     wikipediaUrl,
     cardTitle,
     cardTitleSub,

--- a/frontend/lib/features/daily_story/presentation/widgets/card_layout_body.dart
+++ b/frontend/lib/features/daily_story/presentation/widgets/card_layout_body.dart
@@ -190,6 +190,10 @@ class _TextPlate extends StatelessWidget {
           ],
           const SizedBox(height: 34),
           _Footer(story: story),
+          if (story.imageAttribution != null) ...[
+            const SizedBox(height: 10),
+            _PhotoCredit(text: story.imageAttribution!),
+          ],
           if (onExploreMore != null) ...[
             const SizedBox(height: 28),
             MoreStoriesCta(
@@ -326,6 +330,25 @@ class _Footer extends StatelessWidget {
           fontSize: 13,
           letterSpacing: 0.8,
         ),
+      ),
+    );
+  }
+}
+
+/// Small image credit line (author / licence / source) shown under the
+/// article so commercially-licensed photos are attributed.
+class _PhotoCredit extends StatelessWidget {
+  final String text;
+  const _PhotoCredit({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      '📷 $text',
+      style: GoogleFonts.notoSerifTc(
+        color: CardReaderTheme.readDim,
+        fontSize: 12,
+        height: 1.4,
       ),
     );
   }

--- a/frontend/test/features/daily_story/data/supabase_daily_story_repository_test.dart
+++ b/frontend/test/features/daily_story/data/supabase_daily_story_repository_test.dart
@@ -8,134 +8,157 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('SupabaseDailyStoryRepository.rowToStory', () {
-    test(
-      'given a row with all card fields and joined place fields, '
-      'when parsed, '
-      'then DailyStory carries every value',
-      () {
-        final row = <String, dynamic>{
-          'publish_date': '2026-05-25',
-          'language': 'zh-TW',
-          'place_name': '羅馬競技場',
-          'place_location': '義大利羅馬',
-          'era': '公元 70-80 年',
-          'story': 'p1\n\np2\n\np3',
-          'image_url': null,
-          'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
-          'card_title': '血腥的盛宴',
-          'card_title_sub': '從石灰岩堆砌的命運舞台',
-          'card_paragraphs': ['p1', 'p2', 'p3'],
-          'card_pull_quote': '「他們將死之人向您致敬」',
-          'card_pull_quote_attrib': '── 蘇埃托尼烏斯，西元 121 年',
-          'card_anno_roman': 'LXXX',
-          'daily_story_places': {
-            'card_location_en': 'COLOSSEUM',
-            'card_city_ch': '羅馬',
-            'card_city_en': 'Rome',
-          },
-        };
-        final story = SupabaseDailyStoryRepository.rowToStory(row);
-        expect(story.cardTitle, '血腥的盛宴');
-        expect(story.cardParagraphs, ['p1', 'p2', 'p3']);
-        expect(story.cardLocationEn, 'COLOSSEUM');
-        expect(story.cardCityCh, '羅馬');
-        expect(story.cardCityEn, 'Rome');
-      },
-    );
+    test('given a row with all card fields and joined place fields, '
+        'when parsed, '
+        'then DailyStory carries every value', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'zh-TW',
+        'place_name': '羅馬競技場',
+        'place_location': '義大利羅馬',
+        'era': '公元 70-80 年',
+        'story': 'p1\n\np2\n\np3',
+        'image_url': null,
+        'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
+        'card_title': '血腥的盛宴',
+        'card_title_sub': '從石灰岩堆砌的命運舞台',
+        'card_paragraphs': ['p1', 'p2', 'p3'],
+        'card_pull_quote': '「他們將死之人向您致敬」',
+        'card_pull_quote_attrib': '── 蘇埃托尼烏斯，西元 121 年',
+        'card_anno_roman': 'LXXX',
+        'daily_story_places': {
+          'card_location_en': 'COLOSSEUM',
+          'card_city_ch': '羅馬',
+          'card_city_en': 'Rome',
+        },
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.cardTitle, '血腥的盛宴');
+      expect(story.cardParagraphs, ['p1', 'p2', 'p3']);
+      expect(story.cardLocationEn, 'COLOSSEUM');
+      expect(story.cardCityCh, '羅馬');
+      expect(story.cardCityEn, 'Rome');
+    });
 
-    test(
-      'given a row missing card fields and place join, '
-      'when parsed, '
-      'then card_* fields are null',
-      () {
-        final row = <String, dynamic>{
-          'publish_date': '2026-05-25',
-          'language': 'en',
-          'place_name': 'Colosseum',
-          'place_location': 'Rome, Italy',
-          'era': '70-80 CE',
-          'story': 'A plain text story.',
-          'image_url': 'https://example.com/img.jpg',
-          'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
-        };
-        final story = SupabaseDailyStoryRepository.rowToStory(row);
-        expect(story.cardTitle, isNull);
-        expect(story.cardParagraphs, isNull);
-        expect(story.cardLocationEn, isNull);
-      },
-    );
+    test('given a row missing card fields and place join, '
+        'when parsed, '
+        'then card_* fields are null', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'en',
+        'place_name': 'Colosseum',
+        'place_location': 'Rome, Italy',
+        'era': '70-80 CE',
+        'story': 'A plain text story.',
+        'image_url': 'https://example.com/img.jpg',
+        'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.cardTitle, isNull);
+      expect(story.cardParagraphs, isNull);
+      expect(story.cardLocationEn, isNull);
+    });
 
-    test(
-      'given a place join with some null city fields, '
-      'when parsed, '
-      'then nulls propagate without crashing',
-      () {
-        final row = <String, dynamic>{
-          'publish_date': '2026-05-25',
-          'language': 'zh-TW',
-          'place_name': '羅馬競技場',
-          'place_location': '義大利羅馬',
-          'era': '公元 70-80 年',
-          'story': 'x',
-          'image_url': null,
-          'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
-          'daily_story_places': {
-            'card_location_en': null,
-            'card_city_ch': '羅馬',
-            'card_city_en': null,
-          },
-        };
-        final story = SupabaseDailyStoryRepository.rowToStory(row);
-        expect(story.cardLocationEn, isNull);
-        expect(story.cardCityCh, '羅馬');
-        expect(story.cardCityEn, isNull);
-      },
-    );
+    test('given a place join with some null city fields, '
+        'when parsed, '
+        'then nulls propagate without crashing', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'zh-TW',
+        'place_name': '羅馬競技場',
+        'place_location': '義大利羅馬',
+        'era': '公元 70-80 年',
+        'story': 'x',
+        'image_url': null,
+        'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
+        'daily_story_places': {
+          'card_location_en': null,
+          'card_city_ch': '羅馬',
+          'card_city_en': null,
+        },
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.cardLocationEn, isNull);
+      expect(story.cardCityCh, '羅馬');
+      expect(story.cardCityEn, isNull);
+    });
 
-    test(
-      'given a place join with wikidata_id, '
-      'when parsed, '
-      'then DailyStory.wikidataId carries it',
-      () {
-        final row = <String, dynamic>{
-          'publish_date': '2026-05-25',
-          'language': 'zh-TW',
-          'place_name': '羅馬競技場',
-          'place_location': '義大利羅馬',
-          'era': '公元 70-80 年',
-          'story': 'x',
-          'image_url': null,
-          'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
-          'daily_story_places': {
-            'card_location_en': 'COLOSSEUM',
-            'card_city_ch': '羅馬',
-            'card_city_en': 'Rome',
-            'wikidata_id': 'Q10285',
-          },
-        };
-        final story = SupabaseDailyStoryRepository.rowToStory(row);
-        expect(story.wikidataId, 'Q10285');
-      },
-    );
+    test('given a place join with wikidata_id, '
+        'when parsed, '
+        'then DailyStory.wikidataId carries it', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'zh-TW',
+        'place_name': '羅馬競技場',
+        'place_location': '義大利羅馬',
+        'era': '公元 70-80 年',
+        'story': 'x',
+        'image_url': null,
+        'wikipedia_url': 'https://zh.wikipedia.org/wiki/Colosseum',
+        'daily_story_places': {
+          'card_location_en': 'COLOSSEUM',
+          'card_city_ch': '羅馬',
+          'card_city_en': 'Rome',
+          'wikidata_id': 'Q10285',
+        },
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.wikidataId, 'Q10285');
+    });
 
-    test(
-      'given a row without place join, '
-      'when parsed, '
-      'then DailyStory.wikidataId is null',
-      () {
-        final row = <String, dynamic>{
-          'publish_date': '2026-05-25',
-          'language': 'en',
-          'place_name': 'Colosseum',
-          'place_location': 'Rome, Italy',
-          'era': '70-80 CE',
-          'story': 'x',
-          'image_url': null,
-          'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
-        };
-        final story = SupabaseDailyStoryRepository.rowToStory(row);
-        expect(story.wikidataId, isNull);
-      },
-    );
+    test('given a row with image_attribution, '
+        'when parsed, '
+        'then DailyStory.imageAttribution carries it', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'en',
+        'place_name': 'Colosseum',
+        'place_location': 'Rome, Italy',
+        'era': '70-80 CE',
+        'story': 'x',
+        'image_url': 'https://example.com/img.jpg',
+        'image_attribution': 'Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)',
+        'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(
+        story.imageAttribution,
+        'Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)',
+      );
+    });
+
+    test('given a row without image_attribution, '
+        'when parsed, '
+        'then DailyStory.imageAttribution is null', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'en',
+        'place_name': 'Colosseum',
+        'place_location': 'Rome, Italy',
+        'era': '70-80 CE',
+        'story': 'x',
+        'image_url': null,
+        'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.imageAttribution, isNull);
+    });
+
+    test('given a row without place join, '
+        'when parsed, '
+        'then DailyStory.wikidataId is null', () {
+      final row = <String, dynamic>{
+        'publish_date': '2026-05-25',
+        'language': 'en',
+        'place_name': 'Colosseum',
+        'place_location': 'Rome, Italy',
+        'era': '70-80 CE',
+        'story': 'x',
+        'image_url': null,
+        'wikipedia_url': 'https://en.wikipedia.org/wiki/Colosseum',
+      };
+      final story = SupabaseDailyStoryRepository.rowToStory(row);
+      expect(story.wikidataId, isNull);
+    });
   });
 }

--- a/frontend/test/features/daily_story/presentation/widgets/card_layout_body_test.dart
+++ b/frontend/test/features/daily_story/presentation/widgets/card_layout_body_test.dart
@@ -11,6 +11,7 @@ DailyStory _fullCardStory({
   String? cardCityEn = 'Rome',
   String? cardPullQuote = '「他們將死之人向您致敬」',
   String? cardAnnoRoman = 'LXXX',
+  String? imageAttribution,
 }) {
   return DailyStory(
     publishDate: DateTime(2026, 5, 25),
@@ -20,14 +21,11 @@ DailyStory _fullCardStory({
     era: '公元 70-80 年',
     story: 'p1\n\np2\n\np3',
     imageUrl: null,
+    imageAttribution: imageAttribution,
     wikipediaUrl: 'https://zh.wikipedia.org/wiki/Colosseum',
     cardTitle: '血腥的盛宴',
     cardTitleSub: '從石灰岩堆砌的命運舞台',
-    cardParagraphs: const [
-      '維斯帕先在西元七十年下令...',
-      '工匠們夜以繼日地堆砌...',
-      '今日的競技場斷垣殘壁...',
-    ],
+    cardParagraphs: const ['維斯帕先在西元七十年下令...', '工匠們夜以繼日地堆砌...', '今日的競技場斷垣殘壁...'],
     cardPullQuote: cardPullQuote,
     cardPullQuoteAttrib: '── 蘇埃托尼烏斯，西元 121 年',
     cardAnnoRoman: cardAnnoRoman,
@@ -67,9 +65,7 @@ void main() {
         expect(find.text('維'), findsOneWidget);
         expect(
           find.byWidgetPredicate(
-            (w) =>
-                w is RichText &&
-                w.text.toPlainText().contains('斯帕先在西元七十年'),
+            (w) => w is RichText && w.text.toPlainText().contains('斯帕先在西元七十年'),
           ),
           findsOneWidget,
         );
@@ -82,69 +78,69 @@ void main() {
       },
     );
 
-    testWidgets(
-      'given pull quote is null, '
-      'when rendered, '
-      'then no quote block appears',
-      (tester) async {
-        await _pump(tester, _fullCardStory(cardPullQuote: null));
-        expect(find.textContaining('將死之人'), findsNothing);
-        expect(find.textContaining('蘇埃托尼烏斯'), findsNothing);
-      },
-    );
+    testWidgets('given pull quote is null, '
+        'when rendered, '
+        'then no quote block appears', (tester) async {
+      await _pump(tester, _fullCardStory(cardPullQuote: null));
+      expect(find.textContaining('將死之人'), findsNothing);
+      expect(find.textContaining('蘇埃托尼烏斯'), findsNothing);
+    });
 
-    testWidgets(
-      'given cardLocationEn is null, '
-      'when rendered, '
-      'then the spine is omitted',
-      (tester) async {
-        await _pump(tester, _fullCardStory(cardLocationEn: null));
-        expect(find.text('COLOSSEUM'), findsNothing);
-      },
-    );
+    testWidgets('given cardLocationEn is null, '
+        'when rendered, '
+        'then the spine is omitted', (tester) async {
+      await _pump(tester, _fullCardStory(cardLocationEn: null));
+      expect(find.text('COLOSSEUM'), findsNothing);
+    });
 
-    testWidgets(
-      'given cardAnnoRoman is null, '
-      'when rendered, '
-      'then the Anno block is omitted',
-      (tester) async {
-        await _pump(tester, _fullCardStory(cardAnnoRoman: null));
-        expect(find.textContaining('Anno'), findsNothing);
-      },
-    );
+    testWidgets('given cardAnnoRoman is null, '
+        'when rendered, '
+        'then the Anno block is omitted', (tester) async {
+      await _pump(tester, _fullCardStory(cardAnnoRoman: null));
+      expect(find.textContaining('Anno'), findsNothing);
+    });
 
-    testWidgets(
-      'given both city fields are null, '
-      'when rendered, '
-      'then footer shows only the place location',
-      (tester) async {
-        await _pump(
-          tester,
-          _fullCardStory(cardCityCh: null, cardCityEn: null),
-        );
-        expect(find.text('義大利羅馬'), findsOneWidget);
-        expect(find.textContaining('羅馬 Rome'), findsNothing);
-      },
-    );
+    testWidgets('given both city fields are null, '
+        'when rendered, '
+        'then footer shows only the place location', (tester) async {
+      await _pump(tester, _fullCardStory(cardCityCh: null, cardCityEn: null));
+      expect(find.text('義大利羅馬'), findsOneWidget);
+      expect(find.textContaining('羅馬 Rome'), findsNothing);
+    });
 
-    testWidgets(
-      'given both city fields are present, '
-      'when rendered, '
-      'then footer shows place location + cardCityCh + cardCityEn',
-      (tester) async {
-        await _pump(tester, _fullCardStory());
-        expect(find.text('義大利羅馬 · 羅馬 Rome'), findsOneWidget);
-      },
-    );
+    testWidgets('given both city fields are present, '
+        'when rendered, '
+        'then footer shows place location + cardCityCh + cardCityEn', (
+      tester,
+    ) async {
+      await _pump(tester, _fullCardStory());
+      expect(find.text('義大利羅馬 · 羅馬 Rome'), findsOneWidget);
+    });
 
-    testWidgets(
-      'given only cardCityEn is null, '
-      'when rendered, '
-      'then footer shows place location + cardCityCh',
-      (tester) async {
-        await _pump(tester, _fullCardStory(cardCityEn: null));
-        expect(find.text('義大利羅馬 · 羅馬'), findsOneWidget);
-      },
-    );
+    testWidgets('given only cardCityEn is null, '
+        'when rendered, '
+        'then footer shows place location + cardCityCh', (tester) async {
+      await _pump(tester, _fullCardStory(cardCityEn: null));
+      expect(find.text('義大利羅馬 · 羅馬'), findsOneWidget);
+    });
+
+    testWidgets('given an image attribution, '
+        'when rendered, '
+        'then a photo credit line is shown', (tester) async {
+      await _pump(
+        tester,
+        _fullCardStory(
+          imageAttribution: 'Jane Doe / CC BY-SA 4.0 (via Wikimedia Commons)',
+        ),
+      );
+      expect(find.textContaining('Jane Doe / CC BY-SA 4.0'), findsOneWidget);
+    });
+
+    testWidgets('given no image attribution, '
+        'when rendered, '
+        'then no photo credit line is shown', (tester) async {
+      await _pump(tester, _fullCardStory(imageAttribution: null));
+      expect(find.textContaining('📷'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Problem

Daily story cover images were taken straight from the Wikipedia REST
`/page/summary` thumbnail with **no licence check at all**. Wikipedia images
are a mix of public domain, CC BY/BY-SA (attribution required) and **fair-use
non-free** files, so the app could post images commercially that are either
unattributed or not licensed for commercial reuse.

## What changed

**Backend**
- `wikipedia.fetch_lead_image()` resolves the page's lead-image file and queries
  Wikimedia `imageinfo` / `extmetadata` for licence code, short name and author.
- Commercial-safe whitelist: **public domain / CC0 / CC BY / CC BY-SA**.
  Rejected: NonCommercial (NC), NoDerivatives (ND), non-free/fair-use, and
  unknown licences.
- `job.py` drops images that fail the check (image becomes NULL → existing
  no-image flow) and stores the credit in `daily_stories.image_attribution`.
- IG caption appends `📷 author / licence (via Wikimedia Commons)`.

**Frontend**
- `DailyStory.imageAttribution` is read from the row and shown as a small photo
  credit under the article in the reader.

No new migration: `image_attribution` already existed (was unused) and
`daily_stories` has table-level SELECT.

## Tests

- Licence filter: CC BY-SA / PD accepted; NC / ND / fair-use rejected.
- Job keeps a licensed image (+attribution) and drops a non-commercial one.
- Caption includes / omits the credit line.
- Repository row parsing + reader credit line.

Backend: 222 passed. Frontend daily_story: 39 passed. `analyze`: 0 issues.

> Note: this enforces commercial-safe images going forward; it does not
> back-fill attribution for stories already published. Final licensing call
> should still be confirmed with legal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
