### PR TITLE
feat(backend): route manual daily stories into IG auto-publish flow

### DIFF
--- a/.claude/skills/lorescape-manual-daily-story/SKILL.md
+++ b/.claude/skills/lorescape-manual-daily-story/SKILL.md
@@ -18,9 +18,17 @@ Claude-driven workflow below to produce the draft JSON manually, then
 use `publish` to write it to Supabase.
 
 **Core principle: the App has NO review gate.** It shows whatever row
-has the newest `publish_date` for the language — `review_state` is only
-used by the (paused) Instagram flow. The moment `publish` runs, users
-can see the story. Review must finish BEFORE publish, never after.
+has the newest `publish_date` for the language. The moment `publish`
+runs, users can see the story in the App. Content review must finish
+BEFORE publish, never after.
+
+**`publish` also hands the story off to the Instagram flow.** After
+writing the rows it renders the IG card and posts it to Discord for
+review (same step the cron does), setting `discord_message_id`. With
+`DAILY_STORY_PUBLISH_ENABLED` on, the 21:00 cron then auto-posts to
+Instagram once an approver reacts ✅ in Discord. So `review_state` /
+Discord review now gates **Instagram**, not the App. If Discord isn't
+configured the hand-off is skipped (story still goes live in the App).
 
 ## The Tool
 
@@ -32,8 +40,10 @@ uv run python -m scripts.manual_daily_story publish --date 2026-06-12
 ```
 
 `publish` reads `/tmp/lorescape_daily_story_draft.json`, upserts both
-language rows (idempotent on publish_date+language), and marks the
-place used.
+language rows (idempotent on publish_date+language), marks the place
+used, and posts the IG card to Discord for review (best-effort — a
+Discord failure leaves the story live in the App and can be retried by
+re-running `publish`).
 
 ## Workflow
 
@@ -126,7 +136,10 @@ Only run `publish` after the user says 可以 / 通過 / 發布 / yes / ok:
 uv run python -m scripts.manual_daily_story publish
 ```
 
-Relay the verification output (row count + place_name per language).
+Relay the verification output (row count + place_name per language) and
+the IG review hand-off result (the printed `message_id=…` line, or the
+"skipping IG review hand-off" / "posted nothing" note). If it posted to
+Discord, tell the user to approve with ✅ for the 21:00 IG publish.
 
 ## Quick Reference
 
@@ -137,7 +150,9 @@ Relay the verification output (row count + place_name per language).
 | `story` column | Joined `card_paragraphs` (short), NOT the long `paragraphs` — matches the cron job |
 | Cover image | Only commercially licensed Wikipedia lead images (CC0/CC BY/CC BY-SA); otherwise NULL — see lorescape-fix-missing-card-image skill |
 | Overwriting a date | `publish --date X` upserts, so re-publishing the same date replaces it |
-| `review_state` | Left at default `pending`; harmless while the IG publish job is paused |
+| `review_state` | Starts `pending`; the 21:00 cron flips it to `published`/`skipped`/etc. based on the Discord ✅/❌ reaction |
+| IG review hand-off | `publish` posts the card to Discord (sets `discord_message_id`); needs DISCORD_BOT_TOKEN + DISCORD_REVIEW_CHANNEL_ID + DISCORD_APPROVER_IDS, else skipped |
+| Env flags | `DAILY_STORY_GENERATE_ENABLED` (09:00 Gemini, keep OFF) and `DAILY_STORY_PUBLISH_ENABLED` (21:00 IG, ON) — both fall back to legacy `DAILY_STORY_ENABLED` |
 | Languages | Always both `zh-TW` and `en` (App queries per language) |
 
 ## Gotchas
@@ -158,5 +173,7 @@ Relay the verification output (row count + place_name per language).
   lorescape-debug skill (read-only) first.
 - A published story missing only its cover image → use
   lorescape-fix-missing-card-image.
-- Re-enabling the automatic pipeline → set `DAILY_STORY_ENABLED=1` on
-  the VPS and restart the container instead.
+- Re-enabling the automatic Gemini generation → set
+  `DAILY_STORY_GENERATE_ENABLED=1` on the VPS and restart (keep this OFF
+  while Claude writes the content). To let manual stories auto-post to
+  Instagram, set `DAILY_STORY_PUBLISH_ENABLED=1` instead.

--- a/backend/scripts/manual_daily_story.py
+++ b/backend/scripts/manual_daily_story.py
@@ -15,7 +15,10 @@ Claude Code session (see .claude/skills/lorescape-manual-daily-story):
        daily_stories (idempotent on publish_date+language) and marks the
        place used. The App shows the newest publish_date immediately —
        there is no review_state gate on the App side — which is why
-       review MUST happen before this step.
+       content review MUST happen before this step. publish then renders
+       the IG card and posts it to Discord for review (same hand-off as the
+       cron), so the 21:00 publish job auto-posts it to Instagram once an
+       approver reacts ✅. Requires DAILY_STORY_PUBLISH_ENABLED on the VPS.
 
 Run from backend/:
 
@@ -35,17 +38,12 @@ import sys
 from datetime import date
 
 from dotenv import load_dotenv
-
-load_dotenv()
-# The google-genai SDK prefers GOOGLE_API_KEY over GEMINI_API_KEY when both
-# are set; on this machine GOOGLE_API_KEY is a non-Gemini key, so drop it.
-os.environ.pop("GOOGLE_API_KEY", None)
-
 from supabase import create_client
 
 from lorescape_backend.config import Config
 from lorescape_backend.daily_story import (
     gemini_client,
+    job,
     place_picker,
     prompts,
     story_writer,
@@ -210,6 +208,8 @@ def cmd_publish(args: argparse.Namespace) -> int:
     place_picker.mark_place_used(supabase, draft["place_id"])
     print(f"Marked place used: {draft['wikipedia_title_en']}")
 
+    _send_for_ig_review(config, supabase, publish_date)
+
     rows = (
         supabase.table("daily_stories")
         .select("language, place_name, review_state")
@@ -220,7 +220,67 @@ def cmd_publish(args: argparse.Namespace) -> int:
     return 0
 
 
+def _send_for_ig_review(config: Config, supabase, publish_date: date) -> None:
+    """Hand the published story off to the Instagram review flow.
+
+    Reuses the cron's review step (``job.send_today_for_review``): it renders
+    the IG card, posts it to Discord, and stores ``discord_message_id`` on the
+    zh-TW row. That id is what the 21:00 publish cron requires before it will
+    post a row to Instagram, so without this step a manually-written story
+    would never reach the auto-publish flow.
+
+    Idempotent (skips if the card was already posted) and best-effort: a
+    failure leaves the story live in the App but not queued for Instagram.
+    """
+    if not config.review_enabled:
+        print(
+            "Discord review not configured (DISCORD_BOT_TOKEN / "
+            "DISCORD_REVIEW_CHANNEL_ID / DISCORD_APPROVER_IDS) — skipping IG "
+            "review hand-off. Story is live in the App but won't auto-post to "
+            "Instagram."
+        )
+        return
+
+    try:
+        job.send_today_for_review(config, publish_date)
+    except Exception as exc:  # noqa: BLE001 — review send is best-effort
+        print(
+            f"WARNING: IG review hand-off failed: {exc}\n"
+            "Story is live in the App. Re-run publish to retry the Discord "
+            "post, or use the manual IG publish skill."
+        )
+        return
+
+    row = (
+        supabase.table("daily_stories")
+        .select("discord_message_id")
+        .eq("publish_date", publish_date.isoformat())
+        .eq("language", job.REVIEW_LANGUAGE)
+        .limit(1)
+        .execute()
+    ).data
+    message_id = row[0]["discord_message_id"] if row else None
+    if message_id:
+        print(
+            f"Sent IG card to Discord for review (message_id={message_id}). "
+            "Approve with ✅ and the 21:00 publish job posts it to Instagram."
+        )
+    else:
+        print(
+            "IG review hand-off posted nothing — likely a missing card "
+            "image/content (see lorescape-fix-missing-card-image). Story is "
+            "live in the App but not queued for Instagram."
+        )
+
+
 def main(argv: list[str]) -> int:
+    load_dotenv()
+    # The google-genai SDK prefers GOOGLE_API_KEY over GEMINI_API_KEY when
+    # both are set; on this machine GOOGLE_API_KEY is a non-Gemini key, so
+    # drop it. Done here (not at import) to keep importing this module for
+    # tests free of environment side effects.
+    os.environ.pop("GOOGLE_API_KEY", None)
+
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
 

--- a/backend/src/lorescape_backend/api.py
+++ b/backend/src/lorescape_backend/api.py
@@ -50,13 +50,19 @@ def _register_jobs(scheduler: BackgroundScheduler, config: Config) -> None:
     def _reconcile() -> None:
         run_reconcile_job(config)
 
-    if config.daily_story_enabled:
+    if config.daily_story_generate_enabled:
         scheduler.add_job(
             _generate,
             trigger=CronTrigger(hour=GENERATE_HOUR, minute=0),
             id=GENERATE_JOB_ID,
             replace_existing=True,
         )
+    else:
+        logger.warning(
+            "daily_story.generate paused — 09:00 generate job not scheduled "
+            "(DAILY_STORY_GENERATE_ENABLED is off)"
+        )
+    if config.daily_story_publish_enabled:
         scheduler.add_job(
             _publish,
             trigger=CronTrigger(hour=PUBLISH_HOUR, minute=0),
@@ -65,8 +71,8 @@ def _register_jobs(scheduler: BackgroundScheduler, config: Config) -> None:
         )
     else:
         logger.warning(
-            "daily_story.paused — generate/publish jobs not scheduled "
-            "(DAILY_STORY_ENABLED is off)"
+            "daily_story.publish paused — 21:00 publish job not scheduled "
+            "(DAILY_STORY_PUBLISH_ENABLED is off)"
         )
     if config.revenuecat_reconcile_enabled:
         scheduler.add_job(

--- a/backend/src/lorescape_backend/config.py
+++ b/backend/src/lorescape_backend/config.py
@@ -43,10 +43,17 @@ class Config:
     # emergencies). Env: NARRATION_WEB_SEARCH=0/false to disable.
     narration_web_search_enabled: bool = True
 
-    # Daily story pipeline (08:00 generate + 21:00 publish cron jobs).
-    # Env: DAILY_STORY_ENABLED=0/false to pause both jobs; the 03:00
+    # Daily story pipeline (09:00 generate + 21:00 publish cron jobs).
+    # DAILY_STORY_ENABLED is the legacy master switch; the two per-job flags
+    # below default to it but can be overridden independently. This lets the
+    # 21:00 IG-publish job keep running for manually-written (Claude) stories
+    # while the 09:00 Gemini generate job stays paused.
+    # Env: DAILY_STORY_ENABLED / DAILY_STORY_GENERATE_ENABLED /
+    # DAILY_STORY_PUBLISH_ENABLED = 0/false/off to pause. The 03:00
     # subscription reconcile and all HTTP APIs are unaffected.
     daily_story_enabled: bool = True
+    daily_story_generate_enabled: bool = True
+    daily_story_publish_enabled: bool = True
 
     @classmethod
     def from_env(cls) -> "Config":
@@ -59,10 +66,22 @@ class Config:
         def optional(name: str) -> str | None:
             return os.environ.get(name) or None
 
+        def is_on(name: str, default: str) -> bool:
+            return (
+                (os.environ.get(name) or default).strip().lower()
+                not in ("0", "false", "off")
+            )
+
         approver_raw = os.environ.get("DISCORD_APPROVER_IDS", "")
         approver_ids = tuple(
             part.strip() for part in approver_raw.split(",") if part.strip()
         )
+
+        # The per-job flags fall back to the master switch when unset, so an
+        # operator who only sets DAILY_STORY_ENABLED keeps the old all-or-
+        # nothing behaviour; setting a per-job flag overrides just that job.
+        daily_story_enabled = is_on("DAILY_STORY_ENABLED", "1")
+        master_default = "1" if daily_story_enabled else "0"
 
         return cls(
             supabase_url=required("SUPABASE_URL"),
@@ -80,17 +99,13 @@ class Config:
                 "REVENUECAT_WEBHOOK_AUTH_TOKEN"
             ),
             revenuecat_api_key=optional("REVENUECAT_API_KEY"),
-            narration_web_search_enabled=(
-                (os.environ.get("NARRATION_WEB_SEARCH") or "1")
-                .strip()
-                .lower()
-                not in ("0", "false", "off")
+            narration_web_search_enabled=is_on("NARRATION_WEB_SEARCH", "1"),
+            daily_story_enabled=daily_story_enabled,
+            daily_story_generate_enabled=is_on(
+                "DAILY_STORY_GENERATE_ENABLED", master_default
             ),
-            daily_story_enabled=(
-                (os.environ.get("DAILY_STORY_ENABLED") or "1")
-                .strip()
-                .lower()
-                not in ("0", "false", "off")
+            daily_story_publish_enabled=is_on(
+                "DAILY_STORY_PUBLISH_ENABLED", master_default
             ),
         )
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -106,8 +106,14 @@ def test_publish_job_runs_for_today(mock_run, fake_config):
     assert args[1] == date.today()
 
 
-def test_register_jobs_skips_story_jobs_when_daily_story_disabled(fake_config):
-    config = dataclasses.replace(fake_config, daily_story_enabled=False)
+def test_register_jobs_skips_story_jobs_when_both_per_job_flags_disabled(
+    fake_config,
+):
+    config = dataclasses.replace(
+        fake_config,
+        daily_story_generate_enabled=False,
+        daily_story_publish_enabled=False,
+    )
     scheduler = MagicMock()
     _register_jobs(scheduler, config)
 
@@ -115,3 +121,18 @@ def test_register_jobs_skips_story_jobs_when_daily_story_disabled(fake_config):
     assert GENERATE_JOB_ID not in ids
     assert PUBLISH_JOB_ID not in ids
     assert ids == {RECONCILE_JOB_ID}  # reconcile unaffected
+
+
+def test_register_jobs_publish_only_when_generate_disabled(fake_config):
+    """Manual-story mode: 21:00 publish runs, 09:00 Gemini generate does not."""
+    config = dataclasses.replace(
+        fake_config,
+        daily_story_generate_enabled=False,
+        daily_story_publish_enabled=True,
+    )
+    scheduler = MagicMock()
+    _register_jobs(scheduler, config)
+
+    ids = {call.kwargs["id"] for call in scheduler.add_job.call_args_list}
+    assert GENERATE_JOB_ID not in ids
+    assert PUBLISH_JOB_ID in ids

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -123,3 +123,31 @@ def test_daily_story_defaults_on_and_kill_switch(monkeypatch):
 
     monkeypatch.setenv("DAILY_STORY_ENABLED", "1")
     assert Config.from_env().daily_story_enabled is True
+
+
+def test_per_job_flags_fall_back_to_master_switch(monkeypatch):
+    _baseline_env(monkeypatch)
+    monkeypatch.delenv("DAILY_STORY_GENERATE_ENABLED", raising=False)
+    monkeypatch.delenv("DAILY_STORY_PUBLISH_ENABLED", raising=False)
+
+    monkeypatch.delenv("DAILY_STORY_ENABLED", raising=False)
+    config = Config.from_env()
+    assert config.daily_story_generate_enabled is True
+    assert config.daily_story_publish_enabled is True
+
+    monkeypatch.setenv("DAILY_STORY_ENABLED", "0")
+    config = Config.from_env()
+    assert config.daily_story_generate_enabled is False
+    assert config.daily_story_publish_enabled is False
+
+
+def test_per_job_flags_override_master_switch(monkeypatch):
+    """Generate stays off (Claude writes), publish runs for manual stories."""
+    _baseline_env(monkeypatch)
+    monkeypatch.setenv("DAILY_STORY_ENABLED", "0")
+    monkeypatch.setenv("DAILY_STORY_PUBLISH_ENABLED", "1")
+
+    config = Config.from_env()
+    assert config.daily_story_enabled is False
+    assert config.daily_story_generate_enabled is False
+    assert config.daily_story_publish_enabled is True

--- a/backend/tests/test_manual_daily_story.py
+++ b/backend/tests/test_manual_daily_story.py
@@ -1,0 +1,65 @@
+"""Tests for the manual daily-story publish → IG review hand-off."""
+from __future__ import annotations
+
+import dataclasses
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from scripts.manual_daily_story import _send_for_ig_review
+
+_DATE = date(2026, 6, 18)
+
+
+def _supabase_returning(message_id):
+    """A supabase double whose zh-TW row carries this discord_message_id."""
+    supabase = MagicMock()
+    execute = supabase.table.return_value.select.return_value.eq.return_value
+    execute = execute.eq.return_value.limit.return_value.execute
+    execute.return_value.data = [{"discord_message_id": message_id}]
+    return supabase
+
+
+def test_skips_hand_off_when_review_not_configured(fake_config, capsys):
+    config = dataclasses.replace(fake_config, discord_bot_token=None)
+    supabase = MagicMock()
+
+    with patch("scripts.manual_daily_story.job.send_today_for_review") as send:
+        _send_for_ig_review(config, supabase, _DATE)
+
+    send.assert_not_called()
+    assert "won't auto-post to Instagram" in capsys.readouterr().out
+
+
+def test_posts_card_and_reports_message_id(fake_config, capsys):
+    supabase = _supabase_returning("msg-123")
+
+    with patch("scripts.manual_daily_story.job.send_today_for_review") as send:
+        _send_for_ig_review(fake_config, supabase, _DATE)
+
+    send.assert_called_once_with(fake_config, _DATE)
+    out = capsys.readouterr().out
+    assert "message_id=msg-123" in out
+    assert "21:00 publish job" in out
+
+
+def test_warns_when_no_card_posted(fake_config, capsys):
+    supabase = _supabase_returning(None)
+
+    with patch("scripts.manual_daily_story.job.send_today_for_review"):
+        _send_for_ig_review(fake_config, supabase, _DATE)
+
+    assert "posted nothing" in capsys.readouterr().out
+
+
+def test_best_effort_on_send_failure(fake_config, capsys):
+    supabase = MagicMock()
+
+    with patch(
+        "scripts.manual_daily_story.job.send_today_for_review",
+        side_effect=RuntimeError("discord down"),
+    ):
+        _send_for_ig_review(fake_config, supabase, _DATE)
+
+    out = capsys.readouterr().out
+    assert "IG review hand-off failed" in out
+    assert "discord down" in out


### PR DESCRIPTION
## 摘要

讓**手動產生的 daily story** 也能走 IG 自動發布流程。先前 21:00 的 IG 發布 cron 只會處理有 `discord_message_id` 的列，而手動 publish 從不貼 Discord，所以 Claude 手寫的故事永遠進不了 Instagram。

## 改動

- **手動 publish 貼 Discord 審核**：`manual_daily_story publish` 寫完列後，重用 cron 的 `job.send_today_for_review()` 渲染 IG 卡片、貼到 Discord、設 `discord_message_id`（冪等、best-effort）。21:00 cron 之後就會在 ✅ 後自動發到 IG，與自動生成的故事走同一條路。順手把 `load_dotenv()` 移到 `main()`，消除 import 期副作用造成的測試污染。
- **拆分排程旗標**：`DAILY_STORY_ENABLED` 拆成 `DAILY_STORY_GENERATE_ENABLED`（09:00 Gemini 生成）與 `DAILY_STORY_PUBLISH_ENABLED`（21:00 IG 發布），兩者未設定時回退到舊的 master 旗標。如此可維持 Gemini 生成關閉（內容由 Claude 手寫）、同時重新開啟 IG 發布。
- 更新 `lorescape-manual-daily-story` skill 文件。

## VPS 設定（部署後）

```
DAILY_STORY_ENABLED=0
DAILY_STORY_PUBLISH_ENABLED=1
```

流程：手動 publish → 卡片貼 Discord → 審核者 ✅ → 21:00 cron 自動發到 Instagram。

## 測試

- 後端全套 298 passed（含 8 個新增測試：config 旗標回退/覆寫、api 分別 gating、手動 publish 的 4 個 review 分支）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)