### PR TITLE
fix(auth): make anonymous sign-in upgrade reachable + add marionette dev driving

### DIFF
--- a/.claude/skills/marionette-cli/SKILL.md
+++ b/.claude/skills/marionette-cli/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: marionette-cli
+description: Use when driving, automating, or inspecting a running Flutter app in debug mode via the `marionette` CLI — tapping buttons, entering text, pressing keys, swiping/scrolling, taking screenshots, recording video, reading logs, listing interactive widgets, or triggering hot reload/restart against a live VM service URI. Trigger whenever the user wants to interact with or test a Flutter app that's already running (e.g. "tap the submit button", "screenshot the app", "what's on screen", "scroll to X", "record a demo video"), even if they don't say "marionette" by name.
+---
+
+# Marionette CLI (this project)
+
+Drive a Flutter app running in debug mode from the command line. Use this to
+inspect the widget tree, simulate user input, capture screenshots/video, read
+logs, and hot reload — useful for manual verification, demos, and reproducing
+UI flows without touching the app code.
+
+> **回覆語言:除技術名詞外,一律用繁體中文回覆使用者。**
+
+The binary is at `marionette` (installed via `~/.pub-cache/bin/marionette`).
+
+## Connecting to an app
+
+Every interaction command needs a target. Two modes:
+
+- **Direct URI (`--uri`)** — stateless, no setup. Best for one-off
+  interactions. Each command opens a fresh WebSocket, runs, disconnects.
+  ```
+  marionette --uri ws://127.0.0.1:8181/ws <command> [args]
+  ```
+- **Named instance (`-i`)** — register once, then use a short name for
+  repeated interactions with the same app.
+  ```
+  marionette register my-app ws://127.0.0.1:8181/ws
+  marionette -i my-app <command> [args]
+  marionette unregister my-app   # clean up when done
+  ```
+
+Get the VM service URI from the `flutter run` console output (looks like
+`ws://127.0.0.1:XXXXX/ws`). Prefer `--uri` unless you'll run many commands.
+
+Global options: `--timeout <seconds>` (default 5), plus `-i`/`--uri`
+(mutually exclusive).
+
+## Recommended flow
+
+1. **Discover before acting.** Run `get-interactive-elements` first to see what
+   widgets exist and grab their keys/text — don't guess matchers.
+2. **Prefer `--key` over `--text`.** Keys (`ValueKey<String>`) are stable; visible
+   text changes with i18n and state.
+3. **Act**, then re-check with `get-interactive-elements` or `take-screenshots`
+   to confirm the result.
+
+## Command index
+
+Read `references/commands.md` for full options, output formats, and examples
+of any command below before constructing a non-trivial invocation.
+
+| Command | Purpose |
+|---|---|
+| `get-interactive-elements` | List tappable/typable widgets (type, key, text). Start here. |
+| `tap` | Tap an element by `--key`/`--text`/`--type` or `--x --y`. |
+| `secondary-tap` | Right-click / `onSecondaryTap` (desktop only). |
+| `enter-text` | Set a text field's value (`--key`/`--text` + `--input`). |
+| `press-key` | Send a real key event to the focused element (enter, tab, arrows, char) with optional `--modifiers`. |
+| `press-back-button` | System back (Android back / iOS swipe-back); respects PopScope. |
+| `swipe` | Swipe/drag by element+`--direction` or start/end coordinates. |
+| `scroll-to` | Scroll until an element (`--key`/`--text`) is visible. |
+| `take-screenshots` | Save PNG(s) to `--output`; multi-view apps get numbered files. |
+| `record-video` | Record a `.webm` (`--output`, optional `--duration`); needs ffmpeg. |
+| `get-logs` | Dump collected app logs. |
+| `hot-reload` | Hot reload the app. |
+| `hot-restart` | Full restart from `main()` (resets state); needs `flutter run`. |
+| `register` / `unregister` / `list` | Manage named instances. |
+| `doctor` | Check connectivity of all registered instances. |
+| `mcp` | Run the Marionette MCP server. |
+
+## Exit codes
+
+- `0` success
+- `1` runtime error (connection failed, command failed, app unreachable)
+- `64` usage error (missing args, invalid options)
+
+## When a command fails to connect
+
+The app likely stopped or the URI changed.
+
+- **`-i` mode:** run `marionette doctor`, then `marionette unregister <name>`
+  for stale entries.
+- **`--uri` mode:** confirm the app is still running and the URI is current;
+  re-run `flutter run` and use the new URI if needed.

--- a/.claude/skills/marionette-cli/references/commands.md
+++ b/.claude/skills/marionette-cli/references/commands.md
@@ -1,0 +1,367 @@
+# Marionette CLI — full command reference
+
+Detailed options, output, and examples for every command. The SKILL.md has the
+quick index and connection workflow; read this when you need exact flags or
+output shapes.
+
+## Table of contents
+
+- [Instance management](#instance-management): `register`, `unregister`, `list`, `doctor`
+- [Inspection](#inspection): `get-interactive-elements`, `get-logs`
+- [Input](#input): `tap`, `secondary-tap`, `enter-text`, `press-key`, `press-back-button`, `swipe`, `scroll-to`
+- [Capture](#capture): `take-screenshots`, `record-video`
+- [Lifecycle](#lifecycle): `hot-reload`, `hot-restart`
+- [MCP server](#mcp-server): `mcp`
+
+All interaction commands require `-i <instance>` or `--uri <ws-uri>`.
+
+---
+
+## Instance management
+
+### register \<name\> \<uri\>
+
+Register a Flutter app instance.
+
+- `name` — alphanumeric identifier `[a-zA-Z0-9_-]+`
+- `uri` — VM service WebSocket URI (e.g. `ws://127.0.0.1:8181/ws`)
+
+```
+marionette register my-app ws://127.0.0.1:8181/ws
+```
+
+Output (stdout): `Registered instance "my-app" → ws://127.0.0.1:8181/ws`
+Overwriting (stderr): `Updated existing instance "my-app" → ws://127.0.0.1:8181/ws`
+Exit codes: `0` success, `64` invalid name/usage.
+
+### unregister \<name\>
+
+Remove a registered instance.
+
+```
+marionette unregister my-app
+```
+
+Output: `Unregistered instance "my-app".`
+Not found (stderr, exit 1): `Instance "my-app" not found.`
+
+### list
+
+List all registered instances.
+
+```
+marionette list
+```
+
+Output:
+```
+Registered instances:
+
+  my-app
+    URI: ws://127.0.0.1:8181/ws
+    Registered: 2026-02-12 15:30:00.000
+```
+Empty: `No instances registered.`
+
+### doctor
+
+Check connectivity of all registered instances.
+
+```
+marionette doctor
+```
+
+Output:
+```
+Checking 2 instance(s)...
+
+  my-app (ws://127.0.0.1:8181/ws) ... OK
+  other-app (ws://127.0.0.1:9090/ws) ... FAILED
+
+Some instances are unreachable. Use "marionette unregister <name>" to remove stale entries.
+```
+Exit codes: `0` all reachable, `1` any unreachable.
+
+---
+
+## Inspection
+
+### get-interactive-elements
+
+List interactive UI elements in the app's widget tree. Run this first to
+discover matchers.
+
+```
+marionette -i my-app get-interactive-elements
+marionette --uri ws://127.0.0.1:8181/ws get-interactive-elements
+```
+
+Output, one line per element:
+```
+Found 3 interactive element(s):
+
+Type: ElevatedButton, Key: "submit_button", Text: "Submit"
+Type: TextField, Key: "email_field"
+Type: IconButton, Text: ""
+```
+
+Each element may have type, key, text, and additional properties. Use the key
+or text as matchers for `tap`, `enter-text`, `scroll-to`.
+
+### get-logs
+
+Retrieve collected application logs.
+
+```
+marionette -i my-app get-logs
+```
+
+Output:
+```
+Collected 5 log entries:
+
+[INFO] App started
+[DEBUG] Loading data...
+...
+```
+Empty: `No logs collected.`
+
+---
+
+## Input
+
+### tap
+
+Tap an element. Provide exactly one matching strategy.
+
+- `--key <string>` — match by `ValueKey<String>` (most reliable)
+- `--text <string>` — match by visible text
+- `--type <string>` — match by widget type name (e.g. `ElevatedButton`)
+- `--x <number>` / `--y <number>` — screen coordinates (use together)
+
+```
+marionette -i my-app tap --key submit_button
+marionette -i my-app tap --text "Submit"
+marionette -i my-app tap --x 100 --y 200
+```
+
+Output: `Tapped element matching {key: submit_button}`
+
+### secondary-tap
+
+Secondary (right mouse button) tap. **Desktop only** — triggers Flutter's
+`onSecondaryTap` (e.g. context menus). Same matching options as `tap`.
+
+```
+marionette -i my-app secondary-tap --key file_item
+marionette -i my-app secondary-tap --x 100 --y 200
+```
+
+Output: `Secondary tapped element matching {key: file_item}`
+
+### enter-text
+
+Enter text into a text field. Rewrites the field's value directly.
+
+- `--key <string>` or `--text <string>` — match the field
+- `--input <string>` — text to enter (mandatory)
+
+```
+marionette -i my-app enter-text --key email_field --input "user@example.com"
+```
+
+Output: `Entered text into element matching {key: email_field}`
+
+### press-key
+
+Press a keyboard key on the currently focused element. Unlike `enter-text`
+(which rewrites a field's value), this sends a real key event through the focus
+system, so `onSubmitted`, Shortcuts/Actions, and focus traversal all respond.
+Focus a target first (e.g. with `tap`).
+
+- `--key <string>` (mandatory) — named keys: `enter, tab, escape, backspace,
+  delete, space, arrowUp, arrowDown, arrowLeft, arrowRight, home, end, pageUp,
+  pageDown`. Also a single character `a-z` or `0-9`.
+- `--modifiers <list>` — comma-separated: `control, shift, alt, meta`. On macOS
+  use `meta` for the Command key.
+
+```
+marionette -i my-app press-key --key enter
+marionette -i my-app press-key --key a --modifiers control
+marionette --uri ws://127.0.0.1:8181/ws press-key --key arrowDown
+```
+
+Output: `Pressed key: enter` / `Pressed key: control+a`
+
+Notes:
+- A character is only typed for an unmodified (or shift-only) printable key;
+  `control+a` activates select-all rather than typing "a".
+- Modifier combos match Flutter Shortcuts / `SingleActivator`.
+
+### press-back-button
+
+Simulate a system back button press (Android back / iOS swipe-back).
+
+```
+marionette -i my-app press-back-button
+```
+
+Output: `Back button pressed, route was popped`
+On root route: `Back button pressed, no route to pop (app may exit)`
+
+Notes:
+- Works with Navigator, GoRouter, and other routing solutions.
+- On the root route the system may minimize or close the app.
+- Respects `PopScope` / `WillPopScope`.
+
+### swipe
+
+Swipe/drag on the app. Useful for PageView, Dismissible, Drawer, Slider. Use
+either element-based mode (matcher + direction) or coordinate-based mode.
+
+Element-based:
+- `--key` / `--text` / `--type` — matcher
+- `--direction <dir>` — `left, right, up, down` (required for this mode)
+- `--distance <number>` — pixels (default 200)
+
+Coordinate-based (all required together):
+- `--start-x`, `--start-y`, `--end-x`, `--end-y`
+
+```
+marionette -i my-app swipe --type PageView --direction left
+marionette -i my-app swipe --key carousel --direction right --distance 300
+marionette -i my-app swipe --start-x 300 --start-y 400 --end-x 50 --end-y 400
+```
+
+Output:
+```
+Swiped left on element matching: {type: PageView}
+Swiped from (300.0, 400.0) to (50.0, 400.0)
+```
+
+### scroll-to
+
+Scroll until an element becomes visible.
+
+- `--key <string>` or `--text <string>`
+
+```
+marionette -i my-app scroll-to --text "Bottom Item"
+```
+
+Output: `Scrolled to element matching {text: Bottom Item}`
+
+---
+
+## Capture
+
+### take-screenshots
+
+Capture screenshots and save to PNG files.
+
+- `-o, --output <path>` — output file path (mandatory)
+- `--open` — open the file after saving
+
+```
+marionette -i my-app take-screenshots --output ./screenshot.png
+```
+
+Output: `Saved screenshot: ./screenshot.png`
+Multi-view apps produce numbered files:
+```
+Saved screenshot: ./screenshot.png
+Saved screenshot: ./screenshot_1.png
+```
+
+### record-video
+
+Record a video of the running app to a WebM file. **Requires ffmpeg.**
+
+- `-o, --output <path>` — mandatory, must end with `.webm`
+- `-d, --duration <seconds>` — records until Ctrl+C if not set
+- `--width <pixels>` / `--height <pixels>`
+- `--open` — open the video after recording
+- `--ffmpeg-path <path>` — ffmpeg binary (default `ffmpeg`)
+- `-v, --verbose` — diagnostic details (probe response, frame counts)
+- `--transport <mode>` — frame transport: `auto` (default; try TCP, fall back
+  to reverse-WS via adb), `tcp` (force TCP), `ws` (force reverse-WS, needs adb)
+- `--frame-port <port>` — specific TCP port instead of auto-negotiation
+  (mutually exclusive with `--transport ws`)
+
+```
+marionette -i my-app record-video --output ./recording.webm
+marionette -i my-app record-video -o ./demo.webm -d 10
+marionette --uri ws://127.0.0.1:8181/ws record-video -o ./recording.webm --width 1280 --height 720
+marionette -i my-app record-video -o ./demo.webm --transport ws
+```
+
+Output:
+```
+Starting screencast...
+Recording 640x480 video to ./recording.webm...
+Press Ctrl+C to stop recording.
+Recording complete: ./recording.webm (10s, 250 frames)
+```
+
+Prerequisites — ffmpeg on PATH (or `--ffmpeg-path`):
+- macOS: `brew install ffmpeg`
+- Ubuntu: `sudo apt install ffmpeg`
+- Windows: `winget install ffmpeg`
+
+Exit codes: `0` success, `1` ffmpeg not found or recording failed, `64` invalid options.
+
+---
+
+## Lifecycle
+
+### hot-reload
+
+Perform a hot reload of the Flutter app.
+
+```
+marionette -i my-app hot-reload
+```
+
+Output (exit 0): `Hot reload completed successfully.`
+Failure (stderr, exit 1): `Hot reload failed. The app may need a full restart.`
+
+### hot-restart
+
+Full restart from `main()`, resetting all state. Use it for changes a hot
+reload can't pick up (e.g. `main()`/bootstrap edits, global singletons, state
+shape). Requires the app running via `flutter run`.
+
+```
+marionette -i my-app hot-restart
+```
+
+Output (exit 0): `Hot restart completed successfully.`
+Failure (stderr, exit 1): `Hot restart failed or is unavailable. Make sure the app is running via 'flutter run'.`
+
+---
+
+## MCP server
+
+### mcp
+
+Run the Marionette MCP server (preserves original `marionette_mcp` behavior).
+
+- `-l, --log-level <level>` — `FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE` (default `INFO`)
+- `--log-file <path>` — log file path (default stderr)
+- `--sse-port <port>` — use SSE transport on this port (default stdio)
+
+```
+marionette mcp
+marionette mcp --sse-port 3000
+```
+
+---
+
+## Tips
+
+- Prefer `--uri` for one-off interactions (no setup/cleanup overhead).
+- Prefer `-i` for repeated interactions with the same app (shorter commands).
+- Prefer `--key` over `--text` (keys are stable, text changes).
+- Run `get-interactive-elements` first to discover what's on screen.
+- Instance names: `[a-zA-Z0-9_-]+`.
+- Commands are stateless — each opens a fresh connection, no session management.

--- a/frontend/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/screens/settings_screen.dart
@@ -239,7 +239,10 @@ class _AccountGroup extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final user = ref.watch(currentUserProvider);
 
-    if (user != null) {
+    // Anonymous users have a session but no real identity yet, so treat them
+    // as signed out here — they must see the Google/Apple buttons to upgrade
+    // (which links the identity in place via linkIdentity).
+    if (user != null && !user.isAnonymous) {
       return _SettingsGroup(
         label: 'settings.account_section'.tr(),
         child: _SettingsCard(

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:marionette_flutter/marionette_flutter.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -27,7 +28,11 @@ void main() async {
 }
 
 Future<Widget> init() async {
-  WidgetsFlutterBinding.ensureInitialized();
+  if (kDebugMode) {
+    MarionetteBinding.ensureInitialized();
+  } else {
+    WidgetsFlutterBinding.ensureInitialized();
+  }
 
   // Load API configuration
   apiConfig = ApiConfig.fromEnvironment();

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -981,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  marionette_flutter:
+    dependency: "direct main"
+    description:
+      name: marionette_flutter
+      sha256: "9bf6aa531157edeb3d94f7c4972367240a1d704bbe9f4ac558ef1a125c4d1a6d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   markdown:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -107,6 +107,7 @@ dependencies:
   # requires firebase_core ^4.11.0 (Firebase SDK 12.15.0 / iOS 16). Same
   # class-based provider API (providerAndroid/providerApple) used in main.dart.
   firebase_app_check: 0.4.4+1
+  marionette_flutter: ^0.6.0
 
 dev_dependencies:
   flutter_test:

--- a/frontend/scripts/run_dev.sh
+++ b/frontend/scripts/run_dev.sh
@@ -60,6 +60,8 @@ fvm flutter run \
     --dart-define=SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY}" \
     --dart-define=GOOGLE_WEB_CLIENT_ID=$GOOGLE_WEB_CLIENT_ID \
     --dart-define=GOOGLE_IOS_CLIENT_ID=$GOOGLE_IOS_CLIENT_ID \
+    --dart-define=REVENUECAT_API_KEY_IOS="${REVENUECAT_API_KEY_IOS}" \
+    --dart-define=REVENUECAT_API_KEY_ANDROID="${REVENUECAT_API_KEY_ANDROID}" \
     --dart-define=BACKEND_BASE_URL="${BACKEND_BASE_URL:-https://api.lorescape.app}"
 
 FLUTTER_PID=$!


### PR DESCRIPTION
## 背景

PR #83 啟用了「匿名 → linkIdentity 原地升級」，但實機驗證時發現：**設定頁的帳號區塊只在 `currentUser == null` 時顯示 Google/Apple 登入鈕**。一旦匿名登入啟用，每個使用者開 App 就有匿名 session（`currentUser != null`），登入鈕被藏起來、被當成「已登入」——匿名使用者根本碰不到登入鈕，linkIdentity 在 UI 上不可達。

## 改了什麼

**修正**
- `settings_screen.dart` `_AccountGroup`：匿名使用者視為「尚未登入」（`user != null && !user.isAnonymous`），顯示 Google/Apple 升級鈕——與 `_SyncGroup` 既有的 `isAnonymous` gate 一致。
- `scripts/run_dev.sh`：補上 `REVENUECAT_API_KEY_IOS/ANDROID` 兩個 dart-define。先前漏傳導致 RevenueCat SDK 未設定，一進設定頁/訂閱 UI 就 native fatal error。

**dev 工具**
- 加入 `marionette_flutter`，讓 debug build 的 App 可被 CLI 驅動（檢視 widget、tap、截圖）做手動/E2E 驗證。`MarionetteBinding.ensureInitialized()` 由 `kDebugMode` 包住，release build 走一般 `WidgetsFlutterBinding`，不會暴露驅動能力。
- 附 `.claude/skills/marionette-cli/` 專案 skill。

## 驗證（實機 marionette + iOS 模擬器）

- 修正後熱重載：匿名使用者帳號區塊顯示「尚未登入」+ Google/Apple 鈕。
- fallback 路徑實機通過：用既有 Google 帳號登入 → 正確登入既有帳號、**Supabase Users 總數不變**（無重複帳號）。
- linkIdentity 分支邏輯由 PR #83 單元測試涵蓋。

🤖 Generated with [Claude Code](https://claude.com/claude-code)