### PR TITLE
feat(publisher): independent Discord review for IG Reels

### DIFF
--- a/.claude/skills/lorescape-debug/SKILL.md
+++ b/.claude/skills/lorescape-debug/SKILL.md
@@ -106,14 +106,18 @@ curl -s \
   "https://ymndmrefqprhtjxhgsei.supabase.co/rest/v1/daily_stories?publish_date=eq.${TODAY}&select=id,language,place_name,review_state,discord_message_id,hashtags,card_title_ch,card_paragraphs_ch,reviewed_at,created_at"
 ```
 
-The IG publish outcome (post id / error) lives in `social_posts`, one row
-per (publish_date, media_type ∈ carousel|reel):
+The IG publish state lives in `social_posts`, one row per (publish_date,
+media_type ∈ carousel|reel). Carousel rows only record the outcome
+(review state stays on `daily_stories.review_state`); reel rows carry the
+full review state machine — `pending` (awaiting ✅ on the reel's own
+Discord video message, `discord_message_id`) → `published` / `failed` /
+`rejected` / `skipped` (no reaction by the 23:10 final pass):
 
 ```bash
 curl -s \
   -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
   -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
-  "https://ymndmrefqprhtjxhgsei.supabase.co/rest/v1/social_posts?publish_date=eq.${TODAY}&select=media_type,status,ig_post_id,error,published_at"
+  "https://ymndmrefqprhtjxhgsei.supabase.co/rest/v1/social_posts?publish_date=eq.${TODAY}&select=media_type,status,discord_message_id,ig_post_id,error,published_at"
 ```
 
 Check:

--- a/.claude/skills/lorescape-manual-daily-story/SKILL.md
+++ b/.claude/skills/lorescape-manual-daily-story/SKILL.md
@@ -211,20 +211,24 @@ step turns it into the IG Reels cut by adding a short zh-TW voiceover and
 full burned-in captions. See
 [IG Reels post-production](#ig-reels-post-production-subtitles--voiceover).
 
-### Step 11 — Upload to VPS for auto-publish
+### Step 11 — Upload to VPS + send for review
 
-Once `final.mp4` is confirmed, rsync it (plus `narration.txt`) to the VPS:
+Once `final.mp4` is confirmed, one command uploads AND submits for review:
 
 ```bash
 scripts/upload_reel_to_vps.sh {date}     # date 預設今天
 ```
 
-The `publisher` container on the VPS publishes it to IG Reels at **21:10**
-Asia/Taipei (retry at 23:10 for late uploads), but only after the day's
-story got the Discord ✅ (the 21:00 carousel job flips
-`review_state=published`, which gates the reel). Publish state is recorded
-in the `social_posts` table, so re-runs never double-post. If the upload
-misses 23:10 too, publish manually with the publish-reel skill.
+It rsyncs `final.mp4` + `narration.txt` to the VPS, then posts the video
+to the Discord review channel (✅/❌ seeded; >9.5MB videos are compressed
+to a 720p preview for review only). **The reel has its own review,
+independent of the carousel's** — remind the user to react ✅ on the
+*video* message. The `publisher` container publishes at **21:10**
+Asia/Taipei; an unreacted review gets one more chance at **23:10**, then
+is marked `skipped` (manual publish only after that). State lives in
+`social_posts` (media_type='reel'), so re-runs never double-post. A
+re-edited video can be re-submitted by re-running the same command — the
+review resets to pending with a fresh message.
 
 ## Image resolution
 
@@ -546,7 +550,8 @@ build supports them (`ffmpeg -filters | grep subtitles`).
 
 Then present `final.mp4` in chat — this is the IG Reels deliverable. After
 the user confirms it, run Step 11 (`scripts/upload_reel_to_vps.sh {date}`)
-so the VPS publishes it automatically at 21:10.
+to upload it and send it into its own Discord review; the VPS publishes
+automatically at 21:10 once the video message gets a ✅.
 
 ## Quick Reference
 
@@ -564,7 +569,7 @@ so the VPS publishes it automatically at 21:10.
 | Flow reel | ONLY after publish; ai-media-generator + Omni Flash; guide (`docs/ig/reels/actor/`) + place photo as Ingredients; 9:16 (vertical for Reels) · 10s; paid (~15 cr), confirm before send |
 | Reel prompt output | `marketing/outputs/daily_image/{date}/video_prompt.md` (repo root, next to the photos) |
 | IG Reels post-prod | After Flow + user downloads master to `marketing/outputs/daily_video/{date}/source.mp4` (use `scripts/import_source_video.sh [date]` to move it from `~/Downloads` and rename); `uv run python -m daily_video_post --date X` adds zh-TW voiceover + burned-in captions from `narration.txt` → `final.mp4`. Gemini TTS (voice Despina) is the default; free tier = 10 TTS req/day; `say`/Meijia is the offline fallback (ElevenLabs removed — Western accent on zh) |
-| Reel auto-publish | `scripts/upload_reel_to_vps.sh {date}` rsyncs `final.mp4` + `narration.txt` to the VPS; the publisher container posts to IG Reels at 21:10 (retry 23:10) once the story's Discord ✅ landed. State in `social_posts`; manual fallback = publish-reel skill |
+| Reel auto-publish | `scripts/upload_reel_to_vps.sh {date}` rsyncs `final.mp4` + `narration.txt` to the VPS **and** posts the video to Discord for its own ✅/❌ review (independent of the carousel's). Publisher container publishes at 21:10; still-unreacted at 23:10 → `skipped`. State in `social_posts`; manual fallback = publish-reel skill |
 | Overwriting a date | `publish --date X` upserts, so re-publishing the same date replaces it |
 | `review_state` | Starts `pending`; the 21:00 cron flips it to `published`/`skipped`/etc. based on the Discord ✅/❌ reaction |
 | IG review hand-off | `publish` posts the card to Discord (sets `discord_message_id`); needs DISCORD_BOT_TOKEN + DISCORD_REVIEW_CHANNEL_ID + DISCORD_APPROVER_IDS, else skipped |

--- a/.claude/skills/publish-reel/SKILL.md
+++ b/.claude/skills/publish-reel/SKILL.md
@@ -9,11 +9,13 @@ description: Use when the user wants to manually publish a specific day's finish
 完全在本機執行，不寫回 Supabase 的發布狀態。
 
 **這是手動 fallback / 補發工具。** 正常流程是
-`scripts/upload_reel_to_vps.sh <date>` 把影片 rsync 上 VPS，publisher
-容器在 21:10（Asia/Taipei，23:10 補跑）自動發布（gate = 當天 story 的
-Discord ✅）。只有自動發布錯過或失敗時才走這裡。注意：本 skill 發布成功
-**不會**寫 `social_posts`，若當天影片之後才被傳上 VPS，publisher 可能重
-複發——手動補發後就不要再上傳同一天的影片。
+`scripts/upload_reel_to_vps.sh <date>` 把影片 rsync 上 VPS 並送進
+Discord 審核（影片訊息，與 carousel 審核**各自獨立**）；✅ 後 publisher
+容器在 21:10（Asia/Taipei）自動發布，23:10 再檢查一次，仍無反應標
+`skipped`。只有自動發布錯過（skipped）、被誤 ❌、或發布失敗排查後才走
+這裡。注意：本 skill 發布成功**不會**寫 `social_posts`，若該日 reel 列
+還在 pending 且之後被按 ✅，publisher 可能重複發——手動補發前先確認該列
+已是 skipped/rejected，或補發後不要再對審核訊息按 ✅。
 
 ## 前置條件
 
@@ -66,10 +68,13 @@ service-role curl）：
 
 1. **VPS 上有沒有影片**：`ssh lorescape-vps ls /opt/lorescape-media/daily_video/<date>/`
    —— 沒有就是本機忘了跑 `scripts/upload_reel_to_vps.sh`。
-2. **story 是否已核准**：`daily_stories` 該日 zh-TW 列的
-   `review_state` 必須是 `published`（Discord ✅ + 21:00 carousel 成功）。
-3. **social_posts 狀態**：查該日 `media_type=reel` 列——`failed` 的
-   `error` 欄有 Graph API 錯誤訊息；`published` 表示其實已發出。
+2. **social_posts 狀態**：查該日 `media_type=reel` 列——
+   - 沒有列 = 沒送審（upload script 的送審步驟失敗或沒跑）
+   - `pending` = 還沒人對影片訊息按 ✅（21:10/23:10 前補按即可）
+   - `skipped` = 23:10 前都沒反應，已停止自動發布 → 用本 skill 補發
+   - `rejected` = 被按了 ❌
+   - `failed` 的 `error` 欄有 Graph API 錯誤訊息；`published` 表示其實已發出
+3. **Discord 審核訊息**：確認 ✅ 是核准者本人按的（bot 種的 ✅ 不算）。
 4. **publisher log**：`ssh lorescape-vps "cd /opt/lorescape/backend && docker compose logs --since 24h publisher"`。
 
 手動發布問題：

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,11 +16,14 @@ Gemini and serves them to the app, plus runs the daily-story / social pipeline.
     - `03:00` — reconcile subscriptions against RevenueCat
   - `publisher` container (`lorescape_backend.social.publisher_daemon`,
     same image):
-    - `21:00` — read the Discord ✅/❌ reactions and publish the carousel to IG
-    - `21:10` / `23:10` — publish the day's reel video from
-      `/opt/lorescape-media/daily_video/<date>/` (rsynced from the
-      operator's machine via `scripts/upload_reel_to_vps.sh`; idempotent
-      via the `social_posts` table)
+    - `21:00` — read the story review's ✅/❌ and publish the carousel to IG
+    - `21:10` / `23:10` — read the reel review's ✅/❌ (its own Discord
+      message, independent of the carousel's) and publish the day's reel
+      video from `/opt/lorescape-media/daily_video/<date>/`. The video +
+      review are submitted by `scripts/upload_reel_to_vps.sh` on the
+      operator's machine; state machine lives in the `social_posts` table
+      (pending → published/failed/rejected/skipped; still-unreacted at
+      23:10 → skipped)
 
 See `docs/superpowers/specs/2026-05-10-daily-place-story-design.md` for the full spec.
 

--- a/backend/src/lorescape_backend/daily_story/discord_review.py
+++ b/backend/src/lorescape_backend/daily_story/discord_review.py
@@ -35,6 +35,9 @@ _REQUEST_TIMEOUT = 30
 # Cap Retry-After we honor so a misbehaving header can't stall the job.
 _MAX_RETRY_AFTER_SECONDS = 5.0
 _REVIEW_INSTRUCTION = "React ✅ to publish at 21:00 Asia/Taipei · ❌ to skip"
+_REEL_REVIEW_INSTRUCTION = (
+    "React ✅ to publish the reel at 21:10 Asia/Taipei · ❌ to skip"
+)
 
 
 @dataclass(frozen=True)
@@ -49,12 +52,43 @@ def send_for_review(
     *, bot_token: str, channel_id: str, payload: ReviewPayload
 ) -> str:
     """Post the IG card image and seed it with ✅/❌. Returns message id."""
-    message_id = _post_image_message(
+    message_id = _post_attachment_message(
         bot_token=bot_token,
         channel_id=channel_id,
-        png_bytes=payload.card_png,
+        file_bytes=payload.card_png,
         filename=f"ig-card-{payload.publish_date}.png",
+        content_type="image/png",
         content=_REVIEW_INSTRUCTION,
+    )
+    for emoji in (APPROVE_EMOJI, REJECT_EMOJI):
+        _add_self_reaction(
+            bot_token=bot_token,
+            channel_id=channel_id,
+            message_id=message_id,
+            emoji=emoji,
+        )
+    return message_id
+
+
+def send_video_for_review(
+    *,
+    bot_token: str,
+    channel_id: str,
+    video_bytes: bytes,
+    publish_date: str,
+) -> str:
+    """Post the reel video and seed it with ✅/❌. Returns message id.
+
+    The video must fit the channel's attachment limit (10 MB on a
+    non-boosted server) — callers compress a preview when needed.
+    """
+    message_id = _post_attachment_message(
+        bot_token=bot_token,
+        channel_id=channel_id,
+        file_bytes=video_bytes,
+        filename=f"ig-reel-{publish_date}.mp4",
+        content_type="video/mp4",
+        content=_REEL_REVIEW_INSTRUCTION,
     )
     for emoji in (APPROVE_EMOJI, REJECT_EMOJI):
         _add_self_reaction(
@@ -94,17 +128,18 @@ def check_reaction(
     return "none"
 
 
-def _post_image_message(
+def _post_attachment_message(
     *,
     bot_token: str,
     channel_id: str,
-    png_bytes: bytes,
+    file_bytes: bytes,
     filename: str,
+    content_type: str,
     content: str,
 ) -> str:
-    """POST /channels/{id}/messages as multipart with the PNG attached."""
+    """POST /channels/{id}/messages as multipart with the file attached."""
     files = {
-        "files[0]": (filename, png_bytes, "image/png"),
+        "files[0]": (filename, file_bytes, content_type),
         "payload_json": (
             None,
             json.dumps({"content": content}),

--- a/backend/src/lorescape_backend/social/post_log.py
+++ b/backend/src/lorescape_backend/social/post_log.py
@@ -1,9 +1,12 @@
-"""Record per-day Instagram publish outcomes in the `social_posts` table.
+"""Track per-day Instagram publish state in the `social_posts` table.
 
-One row per (publish_date, media_type). A publish attempt upserts its row:
-`status='published'` on success (with `ig_post_id`), `status='failed'` on
-error (with the error text). Retries overwrite the same row, which is what
-makes re-running a publish job for the same day idempotent.
+One row per (publish_date, media_type). For reels the row is created as
+`pending` by the local send-for-review step (carrying the Discord message
+id of the video review post); the publish job then moves it to
+published / failed / rejected / skipped. For carousels only the outcome
+is recorded (review state lives on daily_stories.review_state). Upserts
+overwrite the same row, which is what makes re-running a publish job for
+the same day idempotent.
 """
 from __future__ import annotations
 
@@ -11,6 +14,47 @@ from datetime import datetime, timezone
 from typing import Any
 
 TABLE_NAME = "social_posts"
+
+
+def record_review_pending(
+    supabase,
+    *,
+    publish_date: str,
+    media_type: str,
+    discord_message_id: str,
+) -> None:
+    """Upsert a 'pending' row pointing at the Discord review message.
+
+    Re-sending for review (e.g. after a re-edited video) resets any prior
+    state so the publish job re-reads the new message's reactions.
+    """
+    payload: dict[str, Any] = {
+        "publish_date": publish_date,
+        "media_type": media_type,
+        "status": "pending",
+        "discord_message_id": discord_message_id,
+        "ig_post_id": None,
+        "error": None,
+        "published_at": None,
+    }
+    (
+        supabase.table(TABLE_NAME)
+        .upsert(payload, on_conflict="publish_date,media_type")
+        .execute()
+    )
+
+
+def mark_status(
+    supabase, *, publish_date: str, media_type: str, status: str
+) -> None:
+    """Set the review verdict (e.g. 'rejected' / 'skipped') on the row."""
+    (
+        supabase.table(TABLE_NAME)
+        .update({"status": status})
+        .eq("publish_date", publish_date)
+        .eq("media_type", media_type)
+        .execute()
+    )
 
 
 def record_post(

--- a/backend/src/lorescape_backend/social/publisher_daemon.py
+++ b/backend/src/lorescape_backend/social/publisher_daemon.py
@@ -6,10 +6,12 @@ process, while the api container keeps only the generate and reconcile
 jobs. Daily jobs (Asia/Taipei):
 
     21:00 — carousel: read Discord reactions, publish the approved story
-    21:10 — reel: publish the day's video from DAILY_VIDEO_DIR
-    23:10 — reel retry: picks up a video uploaded after 21:10 (the reel
-            job is idempotent via the social_posts table, so re-running
-            after a successful publish is a no-op)
+    21:10 — reel: read the reel review message's reactions (independent
+            of the carousel review) and publish the day's video from
+            DAILY_VIDEO_DIR; an unreacted review stays pending
+    23:10 — reel final pass: publishes a late ✅ (or a late upload) and
+            marks a still-unreacted review as skipped; idempotent via
+            the social_posts table
 
 `DAILY_STORY_PUBLISH_ENABLED=0` pauses all three jobs (the process stays
 up so the container doesn't restart-loop).
@@ -59,6 +61,9 @@ def _register_jobs(scheduler, config: Config) -> None:
     def _reel() -> None:
         run_reel_publish_job(config, date.today())
 
+    def _reel_final() -> None:
+        run_reel_publish_job(config, date.today(), final_pass=True)
+
     scheduler.add_job(
         _carousel,
         trigger=CronTrigger(hour=CAROUSEL_HOUR, minute=CAROUSEL_MINUTE),
@@ -72,7 +77,7 @@ def _register_jobs(scheduler, config: Config) -> None:
         replace_existing=True,
     )
     scheduler.add_job(
-        _reel,
+        _reel_final,
         trigger=CronTrigger(hour=REEL_RETRY_HOUR, minute=REEL_RETRY_MINUTE),
         id=REEL_RETRY_JOB_ID,
         replace_existing=True,

--- a/backend/src/lorescape_backend/social/reel_publisher.py
+++ b/backend/src/lorescape_backend/social/reel_publisher.py
@@ -1,19 +1,24 @@
 """21:10 Asia/Taipei reel publish job: post the day's video to IG Reels.
 
-Runs after the 21:00 carousel job. Gate and idempotency:
+The reel has its own Discord review, fully independent of the carousel's:
+the local send-for-review step (scripts/send_reel_for_review.py) posts the
+video to the review channel and creates a 'pending' social_posts row with
+the message id. This job reads that message's ✅/❌ reactions and drives
+the row's state machine:
 
-- The zh-TW daily_stories row must be in review_state='published' — i.e.
-  the Discord ✅ approved the story and the carousel went out. The reel
-  reuses that same review; it never publishes an unapproved story.
-- A social_posts row (publish_date, 'reel') with status='published' means
-  the reel already went out — the job exits, so the 21:10 / 23:10
-  double-schedule and manual re-runs are safe.
+    pending → published  (approver ✅ → IG publish succeeded)
+    pending → failed     (publish call raised; retried on the next run)
+    pending → rejected   (approver ❌)
+    pending → skipped    (no reaction by the final 23:10 pass)
+
+The 21:10 run leaves an unreacted row in 'pending' so a late ✅ still
+publishes at 23:10; the 23:10 run (`final_pass=True`) marks it 'skipped',
+matching the carousel's semantics. Re-runs are idempotent: published /
+rejected / skipped rows are never touched again.
 
 The video is expected at `<DAILY_VIDEO_DIR>/<date>/final.mp4`, rsynced from
 the operator's machine (see scripts/upload_reel_to_vps.sh). A sibling
-narration.txt supplies the caption's hook line. When the video is missing
-the job notifies the Discord webhook and leaves no state behind, so a late
-upload is picked up by the next scheduled run (or a manual one).
+narration.txt supplies the caption's hook line.
 
 Manual CLI (back-fill / debugging):
     python -m lorescape_backend.social.reel_publisher [YYYY-MM-DD] [--dry-run]
@@ -27,7 +32,7 @@ from pathlib import Path
 from supabase import create_client
 
 from lorescape_backend.config import Config
-from lorescape_backend.daily_story import discord_notify
+from lorescape_backend.daily_story import discord_notify, discord_review
 from lorescape_backend.social import caption, instagram, post_log, reel_cover
 
 logger = logging.getLogger(__name__)
@@ -37,9 +42,13 @@ NARRATION_FILENAME = "narration.txt"
 
 
 def run_reel_publish_job(
-    config: Config, target_date: date | None = None, *, dry_run: bool = False
+    config: Config,
+    target_date: date | None = None,
+    *,
+    dry_run: bool = False,
+    final_pass: bool = False,
 ) -> None:
-    """Publish the day's reel if approved, present, and not yet published."""
+    """Publish the day's reel once its own Discord review is approved."""
     if target_date is None:
         target_date = date.today()
     date_str = target_date.isoformat()
@@ -54,46 +63,92 @@ def run_reel_publish_job(
         config.supabase_url, config.supabase_service_role_key
     )
 
-    existing = post_log.get_post(supabase, date_str, "reel")
-    if existing and existing.get("status") == "published":
-        logger.info("Reel for %s already published; nothing to do", date_str)
-        return
-
-    row = reel_cover.load_story_row(supabase, date_str)
+    row = post_log.get_post(supabase, date_str, "reel")
     if row is None:
-        logger.info("No zh-TW daily_stories row for %s; skipping", date_str)
+        logger.info("No reel review row for %s; nothing to publish", date_str)
+        if not final_pass:
+            _notify(
+                config,
+                date_str,
+                "Reel publish: no reel was sent for review today — run "
+                "scripts/upload_reel_to_vps.sh, or publish manually via "
+                "/publish-reel.",
+            )
         return
-    if row.get("review_state") != "published":
+    status = row.get("status")
+    if status in ("published", "rejected", "skipped"):
         logger.info(
-            "Story for %s is in review_state=%s (not 'published'); "
-            "skipping reel", date_str, row.get("review_state"),
+            "Reel for %s already in terminal state '%s'; nothing to do",
+            date_str, status,
         )
         return
 
+    # status is 'pending' or 'failed' (failed = approved but the publish
+    # attempt raised; re-check the reaction and retry).
+    message_id = row.get("discord_message_id")
+    if not message_id or not config.review_enabled:
+        logger.warning(
+            "Reel row for %s has no reviewable message (message_id=%s, "
+            "review_enabled=%s); leaving as-is",
+            date_str, message_id, config.review_enabled,
+        )
+        return
+
+    decision = discord_review.check_reaction(
+        bot_token=config.discord_bot_token,  # type: ignore[arg-type]
+        channel_id=config.discord_review_channel_id,  # type: ignore[arg-type]
+        message_id=message_id,
+        approver_ids=config.discord_approver_ids,
+    )
+    if decision == "rejected":
+        logger.info("Reel for %s rejected by reviewer", date_str)
+        if not dry_run:
+            post_log.mark_status(
+                supabase, publish_date=date_str, media_type="reel",
+                status="rejected",
+            )
+        return
+    if decision == "none":
+        if final_pass:
+            logger.info(
+                "Reel for %s got no reaction by the final pass; marking "
+                "skipped", date_str,
+            )
+            if not dry_run:
+                post_log.mark_status(
+                    supabase, publish_date=date_str, media_type="reel",
+                    status="skipped",
+                )
+        else:
+            logger.info(
+                "Reel for %s has no reaction yet; leaving pending for the "
+                "23:10 pass", date_str,
+            )
+        return
+
+    # decision == "approved"
     video_path = Path(config.daily_video_dir) / date_str / VIDEO_FILENAME
     if not video_path.is_file():
-        logger.warning("No reel video at %s; skipping", video_path)
+        logger.warning("No reel video at %s; cannot publish", video_path)
         _notify(
             config,
             date_str,
-            f"Reel publish: no video at {video_path} — upload with "
-            f"scripts/upload_reel_to_vps.sh or publish manually via "
-            f"/publish-reel.",
+            f"Reel publish: approved but no video at {video_path} — "
+            f"re-run scripts/upload_reel_to_vps.sh.",
         )
         return
 
-    ig_caption = _build_caption(config, row, video_path.parent)
+    ig_caption = _build_caption(config, supabase, date_str, video_path.parent)
 
     cover_url: str | None = None
     try:
-        cover_url = reel_cover.build_cover_url(
-            supabase, date_str, story_row=row
-        )
+        cover_url = reel_cover.build_cover_url(supabase, date_str)
     except Exception as exc:  # noqa: BLE001 — cover is best-effort
         logger.warning("Could not build reel cover (%s); using video frame",
                        exc)
 
     if dry_run:
+        print("[dry-run] decision: approved")
         print(f"[dry-run] video:   {video_path}")
         print(f"[dry-run] cover:   {cover_url or '(none — video frame)'}")
         print(f"[dry-run] caption:\n{ig_caption}")
@@ -133,13 +188,19 @@ def run_reel_publish_job(
     logger.info("Published reel for %s: %s", date_str, ig_post_id)
 
 
-def _build_caption(config: Config, row: dict, day_dir: Path) -> str:
+def _build_caption(
+    config: Config, supabase, date_str: str, day_dir: Path
+) -> str:
+    """Caption from the day's story row, falling back to narration.txt."""
     narration_path = day_dir / NARRATION_FILENAME
     narration_text = (
-        narration_path.read_text(encoding="utf-8")
+        narration_path.read_text(encoding="utf-8").strip()
         if narration_path.is_file()
         else None
     )
+    row = reel_cover.load_story_row(supabase, date_str)
+    if row is None:
+        return narration_text or ""
     story_copy = caption.StoryCopy(
         place_name=row["place_name"],
         era=row["era"],
@@ -182,13 +243,20 @@ def main() -> None:
     )
     parser.add_argument(
         "--dry-run", action="store_true",
-        help="Print the video, cover and caption without publishing",
+        help="Print the decision, video, cover and caption without "
+             "publishing",
+    )
+    parser.add_argument(
+        "--final-pass", action="store_true",
+        help="Mark an unreacted review as skipped (the 23:10 behaviour)",
     )
     args = parser.parse_args()
 
     config = Config.from_env()
     target = date.fromisoformat(args.date) if args.date else date.today()
-    run_reel_publish_job(config, target, dry_run=args.dry_run)
+    run_reel_publish_job(
+        config, target, dry_run=args.dry_run, final_pass=args.final_pass
+    )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_discord_review.py
+++ b/backend/tests/test_discord_review.py
@@ -201,3 +201,49 @@ def test_emoji_constants():
     """Keep the wire-level emoji bytes stable — Discord URLs depend on these."""
     assert APPROVE_EMOJI == "✅"
     assert REJECT_EMOJI == "❌"
+
+
+def test_send_video_for_review_uploads_mp4_then_adds_two_reactions(
+    requests_mock,
+):
+    from lorescape_backend.daily_story.discord_review import (
+        send_video_for_review,
+    )
+
+    fake_mp4 = b"\x00\x00\x00 ftypisomfake-reel-bytes"
+    requests_mock.post(
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages",
+        json={"id": MESSAGE},
+    )
+    requests_mock.put(
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages/{MESSAGE}"
+        f"/reactions/%E2%9C%85/@me",
+        json={},
+    )
+    requests_mock.put(
+        f"https://discord.com/api/v10/channels/{CHANNEL}/messages/{MESSAGE}"
+        f"/reactions/%E2%9D%8C/@me",
+        json={},
+    )
+
+    msg_id = send_video_for_review(
+        bot_token="tok",
+        channel_id=CHANNEL,
+        video_bytes=fake_mp4,
+        publish_date="2026-07-05",
+    )
+
+    assert msg_id == MESSAGE
+    body = requests_mock.request_history[0].body
+    if isinstance(body, str):
+        body = body.encode("latin-1")
+    assert fake_mp4 in body
+    assert b"video/mp4" in body
+    assert b"ig-reel-2026-07-05.mp4" in body
+    # The reel instruction points at the 21:10 reel publish time.
+    assert b"21:10" in body
+    # Both seed reactions were added.
+    reaction_puts = [
+        r for r in requests_mock.request_history if r.method == "PUT"
+    ]
+    assert len(reaction_puts) == 2

--- a/backend/tests/test_post_log.py
+++ b/backend/tests/test_post_log.py
@@ -1,0 +1,104 @@
+"""social_posts helper tests."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from lorescape_backend.social import post_log
+
+
+def _client():
+    client = MagicMock()
+    table = client.table.return_value
+    table.upsert.return_value.execute.return_value = MagicMock(data=None)
+    update_chain = table.update.return_value
+    update_chain.eq.return_value = update_chain
+    update_chain.execute.return_value = MagicMock(data=None)
+    return client, table
+
+
+def test_record_post_upserts_outcome_with_published_at():
+    client, table = _client()
+
+    post_log.record_post(
+        client,
+        publish_date="2026-07-05",
+        media_type="reel",
+        status="published",
+        ig_post_id="ig-1",
+    )
+
+    payload, = table.upsert.call_args.args
+    assert payload["status"] == "published"
+    assert payload["ig_post_id"] == "ig-1"
+    assert payload["published_at"] is not None
+    # discord_message_id is not in the payload, so the upsert preserves it.
+    assert "discord_message_id" not in payload
+    assert (
+        table.upsert.call_args.kwargs["on_conflict"]
+        == "publish_date,media_type"
+    )
+
+
+def test_record_post_failed_has_no_published_at():
+    client, table = _client()
+
+    post_log.record_post(
+        client,
+        publish_date="2026-07-05",
+        media_type="carousel",
+        status="failed",
+        error="boom",
+    )
+
+    payload, = table.upsert.call_args.args
+    assert payload["status"] == "failed"
+    assert payload["error"] == "boom"
+    assert payload["published_at"] is None
+
+
+def test_record_review_pending_resets_prior_outcome():
+    client, table = _client()
+
+    post_log.record_review_pending(
+        client,
+        publish_date="2026-07-05",
+        media_type="reel",
+        discord_message_id="msg-1",
+    )
+
+    payload, = table.upsert.call_args.args
+    assert payload["status"] == "pending"
+    assert payload["discord_message_id"] == "msg-1"
+    assert payload["ig_post_id"] is None
+    assert payload["error"] is None
+    assert payload["published_at"] is None
+
+
+def test_mark_status_updates_by_date_and_type():
+    client, table = _client()
+
+    post_log.mark_status(
+        client,
+        publish_date="2026-07-05",
+        media_type="reel",
+        status="skipped",
+    )
+
+    payload, = table.update.call_args.args
+    assert payload == {"status": "skipped"}
+    eq_calls = table.update.return_value.eq.call_args_list
+    assert ("publish_date", "2026-07-05") in [c.args for c in eq_calls]
+
+
+def test_get_post_returns_row_or_none():
+    client, table = _client()
+    select_chain = table.select.return_value
+    select_chain.eq.return_value = select_chain
+    select_chain.limit.return_value = select_chain
+    select_chain.execute.return_value = MagicMock(
+        data=[{"status": "pending"}]
+    )
+
+    row = post_log.get_post(client, "2026-07-05", "reel")
+
+    assert row == {"status": "pending"}

--- a/backend/tests/test_publisher_daemon.py
+++ b/backend/tests/test_publisher_daemon.py
@@ -91,6 +91,9 @@ def test_reel_jobs_run_for_today(mock_run, fake_config):
         call.args[0]()
 
     assert mock_run.call_count == 2
-    for run_call in mock_run.call_args_list:
-        assert run_call.args[0] is fake_config
-        assert run_call.args[1] == date.today()
+    first, final = mock_run.call_args_list
+    assert first.args == (fake_config, date.today())
+    assert not first.kwargs.get("final_pass")
+    # The 23:10 pass marks a still-unreacted review as skipped.
+    assert final.args == (fake_config, date.today())
+    assert final.kwargs["final_pass"] is True

--- a/backend/tests/test_reel_publisher.py
+++ b/backend/tests/test_reel_publisher.py
@@ -1,4 +1,9 @@
-"""reel_publisher.run_reel_publish_job state-machine tests."""
+"""reel_publisher.run_reel_publish_job state-machine tests.
+
+The reel has its own Discord review (independent of the carousel):
+pending → published / failed / rejected / skipped, driven by the ✅/❌
+reactions on the reel review message referenced by the social_posts row.
+"""
 from __future__ import annotations
 
 from dataclasses import replace
@@ -30,6 +35,17 @@ def _story_row(**overrides):
     return base
 
 
+def _reel_row(**overrides):
+    base = dict(
+        publish_date=DATE_STR,
+        media_type="reel",
+        status="pending",
+        discord_message_id="msg-reel-1",
+    )
+    base.update(overrides)
+    return base
+
+
 @pytest.fixture
 def video_config(fake_config, tmp_path):
     """fake_config pointed at a tmp DAILY_VIDEO_DIR with today's video."""
@@ -42,166 +58,209 @@ def video_config(fake_config, tmp_path):
     return replace(fake_config, daily_video_dir=str(tmp_path))
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_publishes_and_records_success(
-    ig_pub, cover, post_log, create, video_config
-):
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row()
-    cover.narration_hook.return_value = "這座競技場藏著什麼？"
-    cover.build_cover_url.return_value = "https://x/cover.png"
-    ig_pub.return_value = "reel-1"
+@pytest.fixture
+def mocks():
+    """Patch the collaborators and yield them as a namespace."""
+    with (
+        patch("lorescape_backend.social.reel_publisher.create_client"),
+        patch("lorescape_backend.social.reel_publisher.post_log") as post_log,
+        patch("lorescape_backend.social.reel_publisher.reel_cover") as cover,
+        patch(
+            "lorescape_backend.social.reel_publisher.discord_review"
+            ".check_reaction"
+        ) as check,
+        patch(
+            "lorescape_backend.social.reel_publisher.instagram.publish_reel"
+        ) as ig_pub,
+        patch(
+            "lorescape_backend.social.reel_publisher.discord_notify"
+            ".notify_failure"
+        ) as notify,
+    ):
+        cover.load_story_row.return_value = _story_row()
+        cover.narration_hook.return_value = "這座競技場藏著什麼？"
+        cover.build_cover_url.return_value = "https://x/cover.png"
+
+        class Namespace:
+            pass
+
+        ns = Namespace()
+        ns.post_log = post_log
+        ns.cover = cover
+        ns.check = check
+        ns.ig_pub = ig_pub
+        ns.notify = notify
+        yield ns
+
+
+def test_approved_reel_publishes_and_records(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "approved"
+    mocks.ig_pub.return_value = "reel-1"
 
     run_reel_publish_job(video_config, TARGET)
 
-    ig_kwargs = ig_pub.call_args.kwargs
+    assert mocks.check.call_args.kwargs["message_id"] == "msg-reel-1"
+    ig_kwargs = mocks.ig_pub.call_args.kwargs
     assert ig_kwargs["video_path"].endswith(f"{DATE_STR}/final.mp4")
     assert ig_kwargs["cover_url"] == "https://x/cover.png"
     assert "羅馬競技場" in ig_kwargs["caption"]
-    record = post_log.record_post.call_args.kwargs
+    record = mocks.post_log.record_post.call_args.kwargs
     assert record["media_type"] == "reel"
     assert record["status"] == "published"
     assert record["ig_post_id"] == "reel-1"
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_already_published_skips(
-    ig_pub, cover, post_log, create, video_config
-):
-    post_log.get_post.return_value = {"status": "published"}
+def test_rejected_reel_marks_rejected(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "rejected"
 
     run_reel_publish_job(video_config, TARGET)
 
-    ig_pub.assert_not_called()
-    post_log.record_post.assert_not_called()
+    mocks.ig_pub.assert_not_called()
+    mark = mocks.post_log.mark_status.call_args.kwargs
+    assert mark["status"] == "rejected"
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_failed_row_is_retried(
-    ig_pub, cover, post_log, create, video_config
-):
-    """A prior 'failed' social_posts row must not block the retry."""
-    post_log.get_post.return_value = {"status": "failed"}
-    cover.load_story_row.return_value = _story_row()
-    cover.narration_hook.return_value = None
-    cover.build_cover_url.return_value = None
-    ig_pub.return_value = "reel-2"
+def test_no_reaction_stays_pending_on_first_pass(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "none"
 
     run_reel_publish_job(video_config, TARGET)
 
-    ig_pub.assert_called_once()
-    assert post_log.record_post.call_args.kwargs["status"] == "published"
+    mocks.ig_pub.assert_not_called()
+    mocks.post_log.mark_status.assert_not_called()
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_unapproved_story_skips(
-    ig_pub, cover, post_log, create, video_config
-):
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row(review_state="pending")
+def test_no_reaction_marks_skipped_on_final_pass(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "none"
+
+    run_reel_publish_job(video_config, TARGET, final_pass=True)
+
+    mocks.ig_pub.assert_not_called()
+    mark = mocks.post_log.mark_status.call_args.kwargs
+    assert mark["status"] == "skipped"
+
+
+@pytest.mark.parametrize("status", ["published", "rejected", "skipped"])
+def test_terminal_states_are_untouched(mocks, video_config, status):
+    mocks.post_log.get_post.return_value = _reel_row(status=status)
+
+    run_reel_publish_job(video_config, TARGET, final_pass=True)
+
+    mocks.check.assert_not_called()
+    mocks.ig_pub.assert_not_called()
+    mocks.post_log.mark_status.assert_not_called()
+    mocks.post_log.record_post.assert_not_called()
+
+
+def test_failed_row_is_retried_when_approved(mocks, video_config):
+    """failed = approved but the publish attempt raised; retry it."""
+    mocks.post_log.get_post.return_value = _reel_row(status="failed")
+    mocks.check.return_value = "approved"
+    mocks.ig_pub.return_value = "reel-2"
 
     run_reel_publish_job(video_config, TARGET)
 
-    ig_pub.assert_not_called()
-    post_log.record_post.assert_not_called()
+    mocks.ig_pub.assert_called_once()
+    assert mocks.post_log.record_post.call_args.kwargs["status"] == "published"
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-@patch("lorescape_backend.social.reel_publisher.discord_notify.notify_failure")
-def test_missing_video_notifies_and_leaves_no_state(
-    notify, ig_pub, cover, post_log, create, fake_config, tmp_path
+def test_no_review_row_notifies_on_first_pass_only(mocks, video_config):
+    mocks.post_log.get_post.return_value = None
+
+    run_reel_publish_job(video_config, TARGET)
+    assert mocks.notify.call_count == 1
+    assert "no reel" in mocks.notify.call_args.kwargs["error_message"].lower()
+
+    run_reel_publish_job(video_config, TARGET, final_pass=True)
+    assert mocks.notify.call_count == 1  # final pass stays quiet
+
+    mocks.ig_pub.assert_not_called()
+
+
+def test_approved_but_video_missing_notifies(
+    mocks, fake_config, tmp_path
 ):
-    config = replace(fake_config, daily_video_dir=str(tmp_path))
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row()
+    empty_dir = tmp_path / "no-videos"
+    empty_dir.mkdir()
+    config = replace(fake_config, daily_video_dir=str(empty_dir))
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "approved"
 
     run_reel_publish_job(config, TARGET)
 
-    ig_pub.assert_not_called()
-    post_log.record_post.assert_not_called()
-    notify.assert_called_once()
-    assert "no video" in notify.call_args.kwargs["error_message"]
+    mocks.ig_pub.assert_not_called()
+    mocks.post_log.record_post.assert_not_called()
+    mocks.notify.assert_called_once()
+    assert "no video" in mocks.notify.call_args.kwargs["error_message"]
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-@patch("lorescape_backend.social.reel_publisher.discord_notify.notify_failure")
-def test_publish_failure_records_failed_and_notifies(
-    notify, ig_pub, cover, post_log, create, video_config
-):
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row()
-    cover.narration_hook.return_value = None
-    cover.build_cover_url.return_value = None
-    ig_pub.side_effect = RuntimeError("Reel container failed")
+def test_publish_failure_records_failed_and_notifies(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "approved"
+    mocks.ig_pub.side_effect = RuntimeError("Reel container failed")
 
     run_reel_publish_job(video_config, TARGET)
 
-    record = post_log.record_post.call_args.kwargs
+    record = mocks.post_log.record_post.call_args.kwargs
     assert record["status"] == "failed"
     assert "Reel container failed" in record["error"]
-    notify.assert_called_once()
+    mocks.notify.assert_called_once()
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_cover_failure_publishes_without_cover(
-    ig_pub, cover, post_log, create, video_config
-):
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row()
-    cover.narration_hook.return_value = None
-    cover.build_cover_url.side_effect = RuntimeError("render exploded")
-    ig_pub.return_value = "reel-3"
+def test_cover_failure_publishes_without_cover(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "approved"
+    mocks.cover.build_cover_url.side_effect = RuntimeError("render exploded")
+    mocks.ig_pub.return_value = "reel-3"
 
     run_reel_publish_job(video_config, TARGET)
 
-    assert ig_pub.call_args.kwargs["cover_url"] is None
-    assert post_log.record_post.call_args.kwargs["status"] == "published"
+    assert mocks.ig_pub.call_args.kwargs["cover_url"] is None
+    assert mocks.post_log.record_post.call_args.kwargs["status"] == "published"
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.post_log")
-@patch("lorescape_backend.social.reel_publisher.reel_cover")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_dry_run_publishes_nothing(
-    ig_pub, cover, post_log, create, video_config, capsys
-):
-    post_log.get_post.return_value = None
-    cover.load_story_row.return_value = _story_row()
-    cover.narration_hook.return_value = None
-    cover.build_cover_url.return_value = None
+def test_dry_run_publishes_nothing(mocks, video_config, capsys):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "approved"
 
     run_reel_publish_job(video_config, TARGET, dry_run=True)
 
-    ig_pub.assert_not_called()
-    post_log.record_post.assert_not_called()
+    mocks.ig_pub.assert_not_called()
+    mocks.post_log.record_post.assert_not_called()
     assert "[dry-run]" in capsys.readouterr().out
 
 
-@patch("lorescape_backend.social.reel_publisher.create_client")
-@patch("lorescape_backend.social.reel_publisher.instagram.publish_reel")
-def test_no_video_dir_disables_job(ig_pub, create, fake_config):
-    run_reel_publish_job(fake_config, TARGET)
+def test_dry_run_does_not_mark_rejected(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row()
+    mocks.check.return_value = "rejected"
 
-    create.assert_not_called()
-    ig_pub.assert_not_called()
+    run_reel_publish_job(video_config, TARGET, dry_run=True)
+
+    mocks.post_log.mark_status.assert_not_called()
+
+
+def test_row_without_message_id_is_left_alone(mocks, video_config):
+    mocks.post_log.get_post.return_value = _reel_row(discord_message_id=None)
+
+    run_reel_publish_job(video_config, TARGET, final_pass=True)
+
+    mocks.check.assert_not_called()
+    mocks.post_log.mark_status.assert_not_called()
+
+
+def test_no_video_dir_disables_job(fake_config):
+    with (
+        patch(
+            "lorescape_backend.social.reel_publisher.create_client"
+        ) as create,
+        patch(
+            "lorescape_backend.social.reel_publisher.instagram.publish_reel"
+        ) as ig_pub,
+    ):
+        run_reel_publish_job(fake_config, TARGET)
+
+        create.assert_not_called()
+        ig_pub.assert_not_called()

--- a/scripts/send_reel_for_review.py
+++ b/scripts/send_reel_for_review.py
@@ -1,0 +1,113 @@
+"""Send the day's finished reel to Discord for review.
+
+Posts marketing/outputs/daily_video/<date>/final.mp4 to the Discord review
+channel (bot token from backend/.env), seeds ✅/❌, and upserts a 'pending'
+social_posts row carrying the message id. The VPS reel job (21:10 / 23:10
+Asia/Taipei) then publishes only after an approver reacts ✅ — this review
+is independent of the carousel's.
+
+Videos over Discord's 10 MB attachment limit are re-encoded to a 720p
+preview (the preview is only for review; the VPS still publishes the
+original final.mp4).
+
+Run from scripts/ (normally invoked by upload_reel_to_vps.sh):
+
+    uv run python -m send_reel_for_review             # today
+    uv run python -m send_reel_for_review 2026-07-05
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from datetime import date
+from pathlib import Path
+
+from dotenv import load_dotenv
+from supabase import create_client
+
+from lorescape_backend.config import Config
+from lorescape_backend.daily_story import discord_review
+from lorescape_backend.social import post_log
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DAILY_VIDEO_DIR = REPO_ROOT / "marketing" / "outputs" / "daily_video"
+
+# Discord's attachment cap on a non-boosted server is 10 MB; leave headroom
+# for the multipart envelope.
+MAX_ATTACHMENT_BYTES = int(9.5 * 1024 * 1024)
+
+
+def _load_video_bytes(video_path: Path) -> bytes:
+    """Return video bytes, re-encoded to a 720p preview when too large."""
+    if video_path.stat().st_size <= MAX_ATTACHMENT_BYTES:
+        return video_path.read_bytes()
+    print(
+        f"{video_path.name} exceeds Discord's attachment limit; "
+        f"encoding a 720p preview for review..."
+    )
+    with tempfile.NamedTemporaryFile(suffix=".mp4") as preview:
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-i", str(video_path),
+                "-vf", "scale=-2:720",
+                "-c:v", "libx264", "-crf", "28", "-preset", "veryfast",
+                "-c:a", "aac", "-b:a", "96k",
+                preview.name,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        return Path(preview.name).read_bytes()
+
+
+def main(argv: list[str]) -> int:
+    """CLI entrypoint."""
+    load_dotenv(REPO_ROOT / "backend" / ".env")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "date", nargs="?", default=date.today().isoformat(),
+        help="Publish date YYYY-MM-DD (default: today)",
+    )
+    args = parser.parse_args(argv)
+
+    config = Config.from_env()
+    if not (config.discord_bot_token and config.discord_review_channel_id):
+        print(
+            "Discord review not configured: set DISCORD_BOT_TOKEN and "
+            "DISCORD_REVIEW_CHANNEL_ID in backend/.env",
+            file=sys.stderr,
+        )
+        return 1
+
+    video_path = DAILY_VIDEO_DIR / args.date / "final.mp4"
+    if not video_path.is_file():
+        print(f"final.mp4 not found: {video_path}", file=sys.stderr)
+        return 1
+
+    message_id = discord_review.send_video_for_review(
+        bot_token=config.discord_bot_token,
+        channel_id=config.discord_review_channel_id,
+        video_bytes=_load_video_bytes(video_path),
+        publish_date=args.date,
+    )
+
+    supabase = create_client(
+        config.supabase_url, config.supabase_service_role_key
+    )
+    post_log.record_review_pending(
+        supabase,
+        publish_date=args.date,
+        media_type="reel",
+        discord_message_id=message_id,
+    )
+    print(
+        f"Sent reel for review: message_id={message_id} — react ✅ before "
+        f"21:10 (or 23:10) Asia/Taipei to publish."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/test_send_reel_for_review.py
+++ b/scripts/tests/test_send_reel_for_review.py
@@ -1,0 +1,91 @@
+"""Tests for the reel Discord review submission script."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import send_reel_for_review
+
+
+def _config(**overrides):
+    base = dict(
+        discord_bot_token="tok",
+        discord_review_channel_id="chan-1",
+        supabase_url="https://x.supabase.co",
+        supabase_service_role_key="key",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_load_video_bytes_returns_small_file_as_is(tmp_path):
+    video = tmp_path / "final.mp4"
+    video.write_bytes(b"small")
+
+    assert send_reel_for_review._load_video_bytes(video) == b"small"
+
+
+def test_load_video_bytes_encodes_preview_when_too_large(tmp_path, mocker):
+    video = tmp_path / "final.mp4"
+    video.write_bytes(b"x")
+    mocker.patch.object(
+        send_reel_for_review, "MAX_ATTACHMENT_BYTES", 0
+    )
+    run = mocker.patch.object(send_reel_for_review.subprocess, "run")
+
+    send_reel_for_review._load_video_bytes(video)
+
+    cmd = run.call_args.args[0]
+    assert cmd[0] == "ffmpeg"
+    assert "scale=-2:720" in cmd
+    assert str(video) in cmd
+
+
+def test_main_sends_review_and_records_pending_row(tmp_path, mocker):
+    day_dir = tmp_path / "2026-07-05"
+    day_dir.mkdir()
+    (day_dir / "final.mp4").write_bytes(b"v")
+    mocker.patch.object(send_reel_for_review, "DAILY_VIDEO_DIR", tmp_path)
+    mocker.patch("send_reel_for_review.load_dotenv")
+    mocker.patch(
+        "send_reel_for_review.Config.from_env", return_value=_config()
+    )
+    mocker.patch("send_reel_for_review.create_client", return_value=object())
+    send_video = mocker.patch(
+        "send_reel_for_review.discord_review.send_video_for_review",
+        return_value="msg-1",
+    )
+    record = mocker.patch(
+        "send_reel_for_review.post_log.record_review_pending"
+    )
+
+    result = send_reel_for_review.main(["2026-07-05"])
+
+    assert result == 0
+    assert send_video.call_args.kwargs["video_bytes"] == b"v"
+    assert send_video.call_args.kwargs["publish_date"] == "2026-07-05"
+    assert record.call_args.kwargs["discord_message_id"] == "msg-1"
+    assert record.call_args.kwargs["media_type"] == "reel"
+
+
+def test_main_fails_when_video_missing(tmp_path, mocker):
+    mocker.patch.object(send_reel_for_review, "DAILY_VIDEO_DIR", tmp_path)
+    mocker.patch("send_reel_for_review.load_dotenv")
+    mocker.patch(
+        "send_reel_for_review.Config.from_env", return_value=_config()
+    )
+
+    assert send_reel_for_review.main(["2026-07-05"]) == 1
+
+
+def test_main_fails_when_discord_not_configured(tmp_path, mocker):
+    day_dir = tmp_path / "2026-07-05"
+    day_dir.mkdir()
+    (day_dir / "final.mp4").write_bytes(b"v")
+    mocker.patch.object(send_reel_for_review, "DAILY_VIDEO_DIR", tmp_path)
+    mocker.patch("send_reel_for_review.load_dotenv")
+    mocker.patch(
+        "send_reel_for_review.Config.from_env",
+        return_value=_config(discord_bot_token=None),
+    )
+
+    assert send_reel_for_review.main(["2026-07-05"]) == 1

--- a/scripts/upload_reel_to_vps.sh
+++ b/scripts/upload_reel_to_vps.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #
 # 把後製完成的 Reel（final.mp4 + narration.txt）rsync 到 VPS 的
-# /opt/lorescape-media/daily_video/<date>/，讓 publisher 容器在
-# 21:10（或 23:10 補跑）自動發布到 IG Reels。
+# /opt/lorescape-media/daily_video/<date>/，並把影片送進 Discord 審核
+# （✅ 後 publisher 容器在 21:10、或 23:10 補跑，自動發布到 IG Reels）。
 #
 # 用法：
 #   scripts/upload_reel_to_vps.sh            # 日期用今天
@@ -40,6 +40,10 @@ rsync -av --progress \
   "${VPS_HOST}:${VPS_MEDIA_DIR}/${DATE}/"
 
 echo ""
-echo "✅ 已上傳。publisher 會在 21:10（Asia/Taipei）自動發布這支 Reel；"
-echo "   前提是當天 story 已在 Discord 按過 ✅（review_state=published）。"
-echo "   若 21:10 前沒上傳完成，23:10 會再補跑一次。"
+echo "影片送 Discord 審核中..."
+(cd "${SCRIPT_DIR}" && uv run python -m send_reel_for_review "${DATE}")
+
+echo ""
+echo "✅ 已上傳並送審。到 Discord 對這支影片按 ✅，publisher 會在 21:10"
+echo "   （Asia/Taipei）自動發布；21:10 前沒按的話 23:10 會再檢查一次，"
+echo "   到時仍無反應就標 skipped（之後只能手動補發）。"

--- a/supabase/migrations/20260705000000_create_social_posts.sql
+++ b/supabase/migrations/20260705000000_create_social_posts.sql
@@ -1,20 +1,30 @@
--- social_posts: per-day Instagram publish outcomes, one row per media type.
+-- social_posts: per-day Instagram publish state, one row per media type.
 --
--- Written ONLY by the backend publisher (service role):
---   * carousel — the 21:00 publish job (was previously recorded on
---     daily_stories.ig_post_id / publish_error / published_at; those columns
---     are dropped in a follow-up migration once this table is live)
---   * reel     — the 21:10 reel publish job (new)
+-- Written ONLY by backend/local publisher tooling (service role):
+--   * carousel — the 21:00 publish job records its outcome here (was
+--     previously daily_stories.ig_post_id / publish_error / published_at;
+--     those columns are dropped in a follow-up migration once this table
+--     is live). Carousel review state stays on daily_stories.review_state.
+--   * reel — the local send-for-review step inserts a 'pending' row with
+--     the Discord message id of the video review post; the 21:10 / 23:10
+--     reel job then reads that message's ✅/❌ and moves the row to
+--     published / failed / rejected / skipped. The reel review is fully
+--     independent of the carousel's.
 --
--- A publish attempt upserts its row: status 'published' on success (with
--- ig_post_id), 'failed' on error (with the error text). Retries overwrite
--- the same (publish_date, media_type) row, which is what makes the reel
--- job's 21:10 / 23:10 double-run idempotent.
+-- State machine per (publish_date, media_type):
+--   pending   → published  (approver ✅ → IG publish succeeded)
+--   pending   → failed     (publish call raised; error filled in — the
+--                           next scheduled run retries a failed row)
+--   pending   → rejected   (approver ❌)
+--   pending   → skipped    (no reaction by the final 23:10 pass)
 CREATE TABLE IF NOT EXISTS public.social_posts (
   id UUID NOT NULL PRIMARY KEY DEFAULT gen_random_uuid(),
   publish_date DATE NOT NULL,
   media_type TEXT NOT NULL CHECK (media_type IN ('carousel', 'reel')),
-  status TEXT NOT NULL CHECK (status IN ('published', 'failed')),
+  status TEXT NOT NULL CHECK (
+    status IN ('pending', 'published', 'failed', 'rejected', 'skipped')
+  ),
+  discord_message_id TEXT,
   ig_post_id TEXT,
   error TEXT,
   published_at TIMESTAMPTZ,


### PR DESCRIPTION
## Summary

Reel 改為有自己的 Discord 審核，與 carousel 審核完全獨立（接續 #85）：

- `upload_reel_to_vps.sh` rsync 完影片後，自動跑新的 `scripts/send_reel_for_review.py`：把 `final.mp4` 發到 Discord 審核頻道（>9.5MB 自動壓 720p 預覽，只影響審核、不影響發布原檔）、種 ✅/❌、在 `social_posts` 建 `pending` 列
- `social_posts`（#85 的 migration 尚未套用到任何環境，直接原地修改）：status 加 `pending`/`rejected`/`skipped`、新增 `discord_message_id` —— reel 擁有完整審核狀態機；carousel 列維持只記結果
- `reel_publisher` 改讀 reel 自己那則訊息的反應（不再看 story 的 `review_state`）：✅ → 發布；❌ → `rejected`；沒反應 → 21:10 留 `pending`、23:10 final pass 標 `skipped`
- `discord_review` 新增 `send_video_for_review`（multipart 附件泛化）
- skill 文件（manual-daily-story Step 11、publish-reel 排查）、backend README、lorescape-debug 查詢同步更新

## 每日流程（更新後）

1. 產 story → publish → Discord 卡片 ✅（carousel 審核）
2. 做影片 → `upload_reel_to_vps.sh` → Discord 影片 ✅（reel 審核，獨立）
3. 21:00 carousel 自動發、21:10 reel 自動發（23:10 補查，仍無反應標 skipped）

## Test plan

- [x] `cd backend && uv run pytest` — 348 passed
- [x] `cd scripts && uv run pytest` — 92 passed
- [ ] 部署後：實跑一天，確認 Discord 出現影片審核訊息、✅ 後 21:10 發布、`social_posts` 狀態流轉正確

🤖 Generated with [Claude Code](https://claude.com/claude-code)