### PR TITLE
fix(explore): 地圖框景 maxZoom 6→14，避免本地地點全擠成一點

### DIFF
--- a/frontend/lib/features/explore/presentation/widgets/lorescape_map.dart
+++ b/frontend/lib/features/explore/presentation/widgets/lorescape_map.dart
@@ -15,8 +15,8 @@ import 'package:vector_map_tiles/vector_map_tiles.dart';
 ///
 /// [children] 疊在底圖之上（pin、polyline 等），由呼叫端提供。
 ///
-/// [fitToPoints] 一旦從空變成有值，鏡頭會自動框住所有點（設計稿的
-/// `fitBounds(pad(0.35), maxZoom: 6)`）。只框一次，之後不再干擾使用者操作。
+/// [fitToPoints] 一旦從空變成有值，鏡頭會自動框住所有點。只框一次，之後
+/// 不再干擾使用者操作。
 class LorescapeMap extends ConsumerStatefulWidget {
   const LorescapeMap({
     super.key,
@@ -54,8 +54,12 @@ class _LorescapeMapState extends ConsumerState<LorescapeMap> {
   bool _mapReady = false;
   bool _hasFitted = false;
 
-  /// 設計稿：`fitBounds(grp.getBounds().pad(0.35), { maxZoom: 6 })`
-  static const double _kFitMaxZoom = 6;
+  /// 框景時的最大 zoom。**不要用設計稿的 6**：設計稿的假資料是全世界散布
+  /// 的景點，maxZoom 6 是為了「框住整個世界時別放太大」；但真實資料全來自
+  /// 使用者當前位置附近的 Wikipedia geosearch（預設 10km 內），套 zoom 6 會
+  /// 讓所有 pin 縮成中心一個點。14 對應 tile 的最大原生層級（見 OpenFreeMap
+  /// TileJSON），也是只有單一地點時的合理街區級 fallback。
+  static const double _kFitMaxZoom = 14;
   static const EdgeInsets _kFitPadding = EdgeInsets.all(48);
 
   @override


### PR DESCRIPTION
## 問題
F17 的 `fitCamera` 沿用了設計稿的 `maxZoom: 6`。設計稿的假資料是全世界散布
的景點，`maxZoom 6` 是為了「框整個世界時別放太大」；但真實 App 的資料全來自
使用者當前位置附近的 Wikipedia geosearch（預設 10km 內）。

結果：所有 pin 縮成中心一個點——**眼眉線寫「4 個地點」但地圖上只看得到 1 根 pin**。

## 修正
`_kFitMaxZoom` 6 → 14（tile 最大原生層級，也是單一地點時的合理街區級 fallback）。
本地地點即以街區視野展開、pin 清楚分開。

## 驗證
`analyze --fatal-infos` 乾淨、explore 測試通過、pre-commit 全套件綠、
iPhone 16 Pro 模擬器目視確認 4 根 pin 在街區地圖上分開顯示。

🤖 Generated with [Claude Code](https://claude.com/claude-code)