### PR TITLE
chore(frontend): gitignore 本地 UI preview 入口（lib/*_preview.dart）

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -52,3 +52,6 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+# 本地 UI preview 入口（不接後端，餵假資料看單一 widget 的渲染／手感）。
+# 命名為 lib/*_preview.dart 即自動忽略；用 fvm flutter run -t <檔案> 執行。
+lib/*_preview.dart


### PR DESCRIPTION
保留一個不接後端、餵假資料的 preview 入口機制，用來在真機/模擬器上目視驗證
單一 widget 的渲染與手感。命名 `lib/*_preview.dart` 即自動忽略、不進版控。

背景：F18 的 `NotebookPager`（手記翻頁器）需要真實 journey 資料才有內容，而
產生真實資料需接 Supabase + 帳號 + 產故事。preview 入口讓 UI 視覺（Long Cang
手寫體、拍立得+膠帶、滑動翻頁、頁點）能獨立於後端驗證。已用它確認翻頁器渲染
與滑動互動皆正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)