### PR TITLE
書架改多層堆疊、修書脊鬼影字、移除用不到的 iOS 定位權限 key

### DIFF
--- a/frontend/SETUP_GUIDE.md
+++ b/frontend/SETUP_GUIDE.md
@@ -340,10 +340,11 @@ fvm flutter doctor -v
 **iOS** (`ios/Runner/Info.plist`):
 ```xml
 <key>NSLocationWhenInUseUsageDescription</key>
-<string>需要存取您的位置以顯示附近的餐廳</string>
-<key>NSLocationAlwaysUsageDescription</key>
-<string>需要存取您的位置以提供更好的服務</string>
+<string>此應用程式需要存取您的位置來顯示附近的地點</string>
 ```
+
+App 只在前景使用定位，不需要 `NSLocationAlwaysAndWhenInUseUsageDescription`；
+geolocator 也是有 WhenInUse 這把 key 就只會請求 When In Use 權限。
 
 ---
 

--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -53,8 +53,6 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>此應用程式需要存取您的位置來顯示附近的地點</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>此應用程式需要存取您的位置來顯示附近的地點</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/frontend/lib/features/journey/presentation/widgets/trip_bookshelf.dart
+++ b/frontend/lib/features/journey/presentation/widgets/trip_bookshelf.dart
@@ -217,12 +217,16 @@ class _Book extends StatelessWidget {
                       border: Border.all(color: const Color(0x57FFE8C4)),
                       borderRadius: BorderRadius.circular(2),
                     ),
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 4,
-                        vertical: 10,
+                    // 書名一律畫在框線內：實機 iOS 上曾出現字影跑到框外、
+                    // 落在書脊左緣的鬼影字，這層 clip 是最後一道保險。
+                    child: ClipRect(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 4,
+                          vertical: 10,
+                        ),
+                        child: _VerticalTitle(text: book.title),
                       ),
-                      child: _VerticalTitle(text: book.title),
                     ),
                   ),
                 ),
@@ -254,7 +258,11 @@ class _Book extends StatelessWidget {
 /// 直排書名。
 ///
 /// CJK 的 `writing-mode: vertical-rl` 是「字元直立堆疊」而不是把整行轉 90°，
-/// 所以這裡逐字換行，而不是用 `RotatedBox`——後者會讓中文躺著，完全不對。
+/// 所以這裡逐字堆疊，而不是用 `RotatedBox`——後者會讓中文躺著，完全不對。
+///
+/// 每個字各自是一個單行 `Text`，而不是把字用 `\n` 接成一個多行 paragraph：
+/// 多行版本在實機 iOS 上會有某一行的字影被畫到框線左外側（偏移量剛好等於一個
+/// 行高），變成書脊上的鬼影字。單行 paragraph 沒有跨行版面，結構上不可能發生。
 class _VerticalTitle extends StatelessWidget {
   const _VerticalTitle({required this.text});
 
@@ -263,6 +271,17 @@ class _VerticalTitle extends StatelessWidget {
   /// 對應設計稿 `max-height:132px`：超出的字捨去，避免長名字把書撐爛。
   static const int _maxCharacters = 7;
 
+  static const TextStyle _style = TextStyle(
+    fontSize: 15,
+    height: 1.15,
+    fontWeight: FontWeight.w700,
+    letterSpacing: 0,
+    color: _Book._gilt,
+    shadows: [
+      Shadow(color: Color(0x66000000), offset: Offset(0, 1), blurRadius: 1),
+    ],
+  );
+
   @override
   Widget build(BuildContext context) {
     final characters = text.characters.toList();
@@ -270,19 +289,12 @@ class _VerticalTitle extends StatelessWidget {
         ? [...characters.take(_maxCharacters - 1), '…']
         : characters;
 
-    return Text(
-      visible.join('\n'),
-      textAlign: TextAlign.center,
-      style: const TextStyle(
-        fontSize: 15,
-        height: 1.15,
-        fontWeight: FontWeight.w700,
-        letterSpacing: 0,
-        color: _Book._gilt,
-        shadows: [
-          Shadow(color: Color(0x66000000), offset: Offset(0, 1), blurRadius: 1),
-        ],
-      ),
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final character in visible)
+          Text(character, textAlign: TextAlign.center, style: _style),
+      ],
     );
   }
 }

--- a/frontend/lib/features/journey/presentation/widgets/trip_bookshelf.dart
+++ b/frontend/lib/features/journey/presentation/widgets/trip_bookshelf.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 /// 書架上的一本「旅程」。
@@ -22,6 +24,9 @@ class ShelfBook {
 ///
 /// 書本高度刻意不齊（190 / 204 / 218 循環），跟設計稿一樣，避免看起來像
 /// 一排等高的色塊。
+///
+/// 書放不下時不橫向捲動，而是往下長出新的一層書架——書櫃本來就是這樣長的，
+/// 而且整頁本來就能上下捲，使用者不必為了看見第 8 本書去發現一個橫滑手勢。
 class TripBookshelf extends StatelessWidget {
   const TripBookshelf({super.key, required this.books, required this.caption});
 
@@ -31,7 +36,15 @@ class TripBookshelf extends StatelessWidget {
   final String caption;
 
   static const List<double> _heights = [190, 204, 218];
-  static const double _rowMinHeight = 214;
+
+  /// 書與書之間的間距，也用來算一層放得下幾本。
+  static const double _gap = 11;
+
+  /// 凹槽背板到書之間的內距（左右各一）。
+  static const double _shelfPadding = 14;
+
+  /// 書排相對於背板再內縮的距離（左右各一）。
+  static const double _rowPadding = 12;
 
   @override
   Widget build(BuildContext context) {
@@ -53,64 +66,111 @@ class TripBookshelf extends StatelessWidget {
               ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 32),
-            child: Stack(
-              children: [
-                // 凹槽背板：比書矮一截（底部留 14），讓層板壓在前面。
-                Positioned.fill(
-                  bottom: 14,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      gradient: const LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [Color(0xFFEFE3CA), Color(0xFFE3D3B4)],
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final perShelf = _booksPerShelf(constraints.maxWidth);
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (var start = 0; start < books.length; start += perShelf)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 32),
+                      child: _Shelf(
+                        books: books.sublist(
+                          start,
+                          math.min(start + perShelf, books.length),
+                        ),
+                        // 高度與配色沿用全域序號，換層時花色才會繼續變化。
+                        firstIndex: start,
                       ),
-                      borderRadius: const BorderRadius.vertical(
-                        top: Radius.circular(8),
-                        bottom: Radius.circular(3),
-                      ),
-                      border: Border.all(color: const Color(0x24977850)),
                     ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(14, 14, 14, 0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      ConstrainedBox(
-                        constraints: const BoxConstraints(
-                          minHeight: _rowMinHeight,
-                        ),
-                        child: SingleChildScrollView(
-                          scrollDirection: Axis.horizontal,
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: Row(
-                            crossAxisAlignment: CrossAxisAlignment.end,
-                            children: [
-                              for (var i = 0; i < books.length; i++) ...[
-                                if (i > 0) const SizedBox(width: 11),
-                                _Book(
-                                  book: books[i],
-                                  height: _heights[i % _heights.length],
-                                  palette: _BookPalette.values[i % 4],
-                                ),
-                              ],
-                            ],
-                          ),
-                        ),
-                      ),
-                      const _ShelfPlank(),
-                    ],
-                  ),
-                ),
-              ],
-            ),
+                ],
+              );
+            },
           ),
         ],
       ),
+    );
+  }
+
+  /// 一層書架放得下幾本；至少放 1 本，免得寬度極窄時除出 0。
+  static int _booksPerShelf(double maxWidth) {
+    final available = maxWidth - (_shelfPadding + _rowPadding) * 2 + _gap;
+    return math.max(1, available ~/ (_Book._width + _gap));
+  }
+}
+
+/// 一層書架：凹槽背板 ＋ 一排書 ＋ 木層板。
+class _Shelf extends StatelessWidget {
+  const _Shelf({required this.books, required this.firstIndex});
+
+  final List<ShelfBook> books;
+
+  /// 這層第一本書在整個書架裡的序號，用來延續高度與配色的循環。
+  final int firstIndex;
+
+  static const double _rowMinHeight = 214;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        // 凹槽背板：比書矮一截（底部留 14），讓層板壓在前面。
+        Positioned.fill(
+          bottom: 14,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [Color(0xFFEFE3CA), Color(0xFFE3D3B4)],
+              ),
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(8),
+                bottom: Radius.circular(3),
+              ),
+              border: Border.all(color: const Color(0x24977850)),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            TripBookshelf._shelfPadding,
+            TripBookshelf._shelfPadding,
+            TripBookshelf._shelfPadding,
+            0,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: _rowMinHeight),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: TripBookshelf._rowPadding,
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      for (var i = 0; i < books.length; i++) ...[
+                        if (i > 0) const SizedBox(width: TripBookshelf._gap),
+                        _Book(
+                          book: books[i],
+                          height:
+                              TripBookshelf._heights[(firstIndex + i) %
+                                  TripBookshelf._heights.length],
+                          palette: _BookPalette.values[(firstIndex + i) % 4],
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+              const _ShelfPlank(),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/frontend/test/features/journey/presentation/widgets/trip_bookshelf_test.dart
+++ b/frontend/test/features/journey/presentation/widgets/trip_bookshelf_test.dart
@@ -1,0 +1,100 @@
+import 'package:context_app/features/journey/presentation/widgets/trip_bookshelf.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+void main() {
+  setUpAll(initTestEnvironment);
+
+  group('TripBookshelf', () {
+    testWidgets(
+      'given more books than fit the shelf width, when the shelf is rendered, '
+      'then the extra books wrap onto further rows instead of scrolling '
+      'sideways, and every row starts at the same left edge',
+      (tester) async {
+        await _givenBookshelf(tester, bookCount: 9);
+
+        final rows = _thenBooksGroupedByRow(tester, bookCount: 9);
+
+        expect(rows.length, greaterThan(1));
+        expect(
+          rows.values.map((row) => row.first.dx).toSet(),
+          hasLength(1),
+          reason: '每一層書架都應該從同一個左邊界開始排',
+        );
+        expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Scrollable &&
+                widget.axisDirection == AxisDirection.right,
+          ),
+          findsNothing,
+          reason: '書架本身不再橫向捲動，改由外層的頁面上下捲',
+        );
+      },
+    );
+
+    testWidgets('given fewer books than fit the shelf width, when the shelf is '
+        'rendered, then they all stay on a single row', (tester) async {
+      await _givenBookshelf(tester, bookCount: 3);
+
+      expect(_thenBooksGroupedByRow(tester, bookCount: 3), hasLength(1));
+    });
+
+    testWidgets(
+      'given a caption, when the shelf is rendered, then the caption is shown '
+      'above the books',
+      (tester) async {
+        await _givenBookshelf(tester, bookCount: 3);
+
+        expect(find.text('旅程書架 · 3 本'), findsOneWidget);
+      },
+    );
+  });
+}
+
+/// 固定 390 邏輯寬度，讓「一層放得下幾本」在測試裡是確定的。
+Future<void> _givenBookshelf(
+  WidgetTester tester, {
+  required int bookCount,
+}) async {
+  tester.view.physicalSize = const Size(390 * 3, 900 * 3);
+  tester.view.devicePixelRatio = 3;
+  addTearDown(tester.view.reset);
+
+  await pumpScreen(
+    tester,
+    child: Scaffold(
+      body: SingleChildScrollView(
+        child: TripBookshelf(
+          caption: '旅程書架 · $bookCount 本',
+          books: [
+            for (var i = 0; i < bookCount; i++)
+              ShelfBook(
+                title: '旅程$i',
+                subtitle: '#$i',
+                hasEntries: false,
+                onTap: () {},
+              ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// 用每本書底部的 subtitle 當定位點，依 y 座標把書分層。
+///
+/// 同一層的書是靠底部對齊的（書高刻意不齊），所以 subtitle 的 y 相同即同層。
+Map<double, List<Offset>> _thenBooksGroupedByRow(
+  WidgetTester tester, {
+  required int bookCount,
+}) {
+  final rows = <double, List<Offset>>{};
+  for (var i = 0; i < bookCount; i++) {
+    final offset = tester.getTopLeft(find.text('#$i'));
+    rows.putIfAbsent(offset.dy, () => []).add(offset);
+  }
+  return rows;
+}


### PR DESCRIPTION
## 內容

三個獨立的小改動，都在 journey / iOS 設定範圍內。

### 1. 移除用不到的 `NSLocationAlwaysAndWhenInUseUsageDescription`（`b86d547d`）

App 只在前景使用定位。geolocator 的 `PermissionHandler` 是 WhenInUse 優先——只要有 `NSLocationWhenInUseUsageDescription`，就只會呼叫 `requestWhenInUseAuthorization`，Always 那把 key 從未被用到，留著只會在 App Review 多一個要解釋的權限。`SETUP_GUIDE.md` 的權限段一併同步。

### 2. 書脊上的鬼影字（`8c840e38`）

實機 iOS 上書名的某一行會有一份「字影」被畫到框線左外側。像素量測結果：偏移量剛好等於一個行高（fontSize 15 × height 1.15 = 17.25px），往下 1px（＝ `Shadow.offset`），顏色是 `#66000000`，也就是 `TextStyle` 的 shadow 那一層。多行 paragraph 的跨行版面是唯一會出現這個數字的地方。

- `_VerticalTitle` 改成逐字各一個單行 `Text` 堆在 `Column`（原本是把字用 `\n` 接成一個多行 paragraph）。單行 paragraph 沒有跨行版面，結構上不可能發生。
- 書名外框再加一層 `ClipRect` 當保險。

改前改後的渲染逐像素 diff 為 None，是純結構重構。

⚠️ 本地重現不出鬼影（測試環境走 Skia CPU raster、字型也不是實機那套 Noto Sans TC），所以這個修法**尚未在實機驗證**。若仍存在，下一步是拿掉 `_VerticalTitle` 的 `shadows`。

### 3. 書架改成多層堆疊（`b4f9f720`）

書放不下時原本要橫滑才看得到後面的書，發現成本高。改成一層放不下就往下長出新的一層書架（各自有凹槽背板與木層板），整頁本來就能上下捲。

- 一層放幾本依可用寬度算（`LayoutBuilder`）；390pt 下是一層 4 本。
- 書高與配色沿用全域序號，換層時花色繼續變化，不會每層都長一樣。

## 測試

- 新增 `test/features/journey/presentation/widgets/trip_bookshelf_test.dart`：換行成多層且每層靠同一左邊界、沒有橫向 `Scrollable`、書少時維持單層、caption 顯示。換行那個測試先寫成紅燈，改完才轉綠。
- `fvm flutter analyze --fatal-infos` 乾淨；full suite 545 個測試通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)