### PR TITLE
refactor(theme): 收斂 LorescapeTokens fallback 到單一來源

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ dashboard/out/
 # Metrics 累積數據（含營收，repo 為 public 故不進版控）
 # 錨定在 repo 根：只忽略頂層 data/，別誤掃 Flutter 各 feature 的 data/ 層
 /data/
+
+# Graphify 產出的知識圖譜（本地分析工具，不進版控）
+graphify-out/

--- a/frontend/lib/app/config/lorescape_tokens.dart
+++ b/frontend/lib/app/config/lorescape_tokens.dart
@@ -76,6 +76,64 @@ class LorescapeTokens extends ThemeExtension<LorescapeTokens> {
   final List<BoxShadow> e2;
   final List<BoxShadow> e3;
 
+  /// Canonical default token set (terracotta accent, paper reading surface).
+  ///
+  /// The single source of truth for the values widgets should fall back to
+  /// when the [LorescapeTokens] theme extension is absent (e.g. a widget test
+  /// that pumps without the full app theme). Read it via [BuildContext.tokens]
+  /// rather than re-hardcoding literals at each call site.
+  static const LorescapeTokens fallback = LorescapeTokens(
+    paper: Color(0xFFF7F1E6),
+    paperRaised: Color(0xFFFDFAF3),
+    paperSunk: Color(0xFFECE3D3),
+    line: Color(0xFFE4DAC8),
+    lineStrong: Color(0xFFCDBFA6),
+    ink: Color(0xFF221C14),
+    ink2: Color(0xFF5E5341),
+    ink3: Color(0xFF918471),
+    clay: Color(0xFFBC5E3E),
+    clayDeep: Color(0xFF97442A),
+    claySoft: Color(0xFFF1DDCE),
+    clayTint: Color(0xFFF7E8DD),
+    inkBg: Color(0xFF1B1611),
+    inkBg2: Color(0xFF251E17),
+    inkBg3: Color(0xFF312820),
+    onDark: Color(0xFFF7F1E6),
+    onDark2: Color(0xFFC3B7A4),
+    onDark3: Color(0xFF8C8170),
+    readBg: Color(0xFFF7F1E6),
+    readInk: Color(0xFF221C14),
+    readDim: Color(0xFF5E5341),
+    readLine: Color(0xFFE4DAC8),
+    readCap: Color(0xFF97442A),
+    rSm: 8,
+    rMd: 12,
+    rLg: 16,
+    rXl: 22,
+    rImg: 10,
+    e1: [
+      BoxShadow(
+        color: Color.fromRGBO(40, 30, 18, 0.06),
+        offset: Offset(0, 1),
+        blurRadius: 2,
+      ),
+    ],
+    e2: [
+      BoxShadow(
+        color: Color.fromRGBO(40, 30, 18, 0.09),
+        offset: Offset(0, 6),
+        blurRadius: 18,
+      ),
+    ],
+    e3: [
+      BoxShadow(
+        color: Color.fromRGBO(28, 20, 10, 0.20),
+        offset: Offset(0, 18),
+        blurRadius: 44,
+      ),
+    ],
+  );
+
   /// Resolves the full token set for a given [accent] + [reading].
   factory LorescapeTokens.forAppearance({
     required BrandAccent accent,
@@ -284,4 +342,15 @@ class LorescapeTokens extends ThemeExtension<LorescapeTokens> {
       e3: s(e3, other.e3),
     );
   }
+}
+
+/// Non-null access to the active [LorescapeTokens].
+///
+/// Returns the registered theme extension, or [LorescapeTokens.fallback] when
+/// none is present. Prefer `context.tokens.paper` over
+/// `Theme.of(context).extension<LorescapeTokens>()?.paper ?? <literal>` so the
+/// fallback values live in exactly one place.
+extension LorescapeTokensContext on BuildContext {
+  LorescapeTokens get tokens =>
+      Theme.of(this).extension<LorescapeTokens>() ?? LorescapeTokens.fallback;
 }

--- a/frontend/lib/features/daily_story/presentation/widgets/story_card.dart
+++ b/frontend/lib/features/daily_story/presentation/widgets/story_card.dart
@@ -5,11 +5,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-/// Fallback warm image shadow (design token `e1`).
-const List<BoxShadow> _kImageShadow = [
-  BoxShadow(color: Color(0x0F281E12), offset: Offset(0, 1), blurRadius: 2),
-];
-
 /// An editorial feed card showing a single [DailyStory] (Field Journal).
 ///
 /// A rounded hero image, a clay chapter overline, a serif title, a
@@ -26,7 +21,7 @@ class StoryCard extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final tokens = Theme.of(context).extension<LorescapeTokens>();
     final ink3 = tokens?.ink3 ?? cs.onSurfaceVariant;
-    final radius = tokens?.rImg ?? 10;
+    final radius = context.tokens.rImg;
 
     final dateLabel = DateFormat.yMMMd(
       Localizations.localeOf(context).toLanguageTag(),
@@ -51,7 +46,7 @@ class StoryCard extends StatelessWidget {
             DecoratedBox(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(radius),
-                boxShadow: tokens?.e1 ?? _kImageShadow,
+                boxShadow: context.tokens.e1,
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(radius),

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -19,12 +19,6 @@ import 'package:latlong2/latlong.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-/// Fallback warm card shadow (design token `e1`) for contexts where the
-/// [LorescapeTokens] theme extension is not installed (e.g. widget tests).
-const List<BoxShadow> _kCardShadow = [
-  BoxShadow(color: Color(0x0F281E12), offset: Offset(0, 1), blurRadius: 2),
-];
-
 class ExploreScreen extends ConsumerStatefulWidget {
   const ExploreScreen({super.key});
 
@@ -641,8 +635,7 @@ class _MapTopOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    final paper = tokens?.paper ?? const Color(0xFFF7F1E6);
+    final paper = context.tokens.paper;
     final topPadding = MediaQuery.paddingOf(context).top;
 
     return Positioned(
@@ -837,9 +830,9 @@ class _RailNotice extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
         decoration: BoxDecoration(
           color: tokens?.paperRaised ?? colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+          borderRadius: BorderRadius.circular(context.tokens.rLg),
           border: Border.all(color: tokens?.line ?? colorScheme.outlineVariant),
-          boxShadow: tokens?.e2 ?? _kCardShadow,
+          boxShadow: context.tokens.e2,
         ),
         child: Text(
           text,
@@ -892,9 +885,9 @@ class _LocationGateCard extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 28),
       decoration: BoxDecoration(
         color: tokens?.paperRaised ?? colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+        borderRadius: BorderRadius.circular(context.tokens.rLg),
         border: Border.all(color: tokens?.line ?? colorScheme.outlineVariant),
-        boxShadow: tokens?.e3 ?? _kCardShadow,
+        boxShadow: context.tokens.e3,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -946,7 +939,7 @@ class _MapCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final tokens = Theme.of(context).extension<LorescapeTokens>();
     final colorScheme = Theme.of(context).colorScheme;
-    final radius = tokens?.rLg ?? 16;
+    final radius = context.tokens.rLg;
     final savedLocations = ref.watch(savedLocationsProvider);
     final isSaved =
         savedLocations.valueOrNull?.any((e) => e.placeId == place.id) ?? false;
@@ -960,7 +953,7 @@ class _MapCard extends ConsumerWidget {
           color: tokens?.paperRaised ?? colorScheme.surfaceContainerLow,
           borderRadius: BorderRadius.circular(radius),
           border: Border.all(color: tokens?.line ?? colorScheme.outlineVariant),
-          boxShadow: tokens?.e3 ?? _kCardShadow,
+          boxShadow: context.tokens.e3,
         ),
         child: Row(
           children: [
@@ -975,10 +968,9 @@ class _MapCard extends ConsumerWidget {
                   // 紙色底盤：書籤壓在照片上時，深色圖示在深色照片上幾乎看不見。
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: (tokens?.paperRaised ?? const Color(0xFFFDFAF3))
-                          .withValues(alpha: 0.92),
+                      color: context.tokens.paperRaised.withValues(alpha: 0.92),
                       shape: BoxShape.circle,
-                      boxShadow: tokens?.e1 ?? _kCardShadow,
+                      boxShadow: context.tokens.e1,
                     ),
                     child: _BookmarkButton(
                       isSaved: isSaved,

--- a/frontend/lib/features/explore/presentation/widgets/place_map_pin.dart
+++ b/frontend/lib/features/explore/presentation/widgets/place_map_pin.dart
@@ -21,18 +21,17 @@ class PlaceMapPin extends StatelessWidget {
   static const Color _urban = Color(0xFF6A4A2F);
 
   /// 設計稿只替 urban 與 heritage 指定了顏色，其餘沿用 clay。
-  Color _fill(LorescapeTokens? tokens) {
-    final clay = tokens?.clay ?? const Color(0xFFBC5E3E);
+  Color _fill(LorescapeTokens tokens) {
     return switch (category) {
       JournalCategory.urban => _urban,
-      JournalCategory.heritage => tokens?.clayDeep ?? const Color(0xFF97442A),
-      _ => clay,
+      JournalCategory.heritage => tokens.clayDeep,
+      _ => tokens.clay,
     };
   }
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
+    final tokens = context.tokens;
 
     return GestureDetector(
       onTap: onTap,

--- a/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
+++ b/frontend/lib/features/journey/presentation/widgets/timeline_entry.dart
@@ -181,8 +181,8 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
   Widget build(BuildContext context) {
     final timeFormat = DateFormat('HH:mm');
     final colorScheme = Theme.of(context).colorScheme;
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    final clayTint = tokens?.clayTint ?? const Color(0xFFF7E8DD);
+    final tokens = context.tokens;
+    final clayTint = tokens.clayTint;
 
     return GestureDetector(
       onTap: _navigateToPlayer,
@@ -308,17 +308,9 @@ class _TimelineEntryState extends ConsumerState<TimelineEntry> {
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
                     color: colorScheme.surfaceContainerLow,
-                    borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+                    borderRadius: BorderRadius.circular(tokens.rLg),
                     border: Border.all(color: colorScheme.outlineVariant),
-                    boxShadow:
-                        tokens?.e1 ??
-                        const [
-                          BoxShadow(
-                            color: Color(0x0F281E12),
-                            offset: Offset(0, 1),
-                            blurRadius: 2,
-                          ),
-                        ],
+                    boxShadow: tokens.e1,
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/frontend/lib/features/narration/presentation/screens/select_story_hook_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_story_hook_screen.dart
@@ -19,9 +19,6 @@ import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 /// Fallback warm card shadow (design token `e1`).
-const List<BoxShadow> _kCardShadow = [
-  BoxShadow(color: Color(0x0F281E12), offset: Offset(0, 1), blurRadius: 2),
-];
 
 /// 「挑一段歷史故事」選擇頁。
 ///
@@ -427,7 +424,7 @@ class _HookInsufficientSourceState extends StatelessWidget {
     final ink2 = tokens?.ink2 ?? cs.onSurfaceVariant;
     final line = tokens?.line ?? cs.outlineVariant;
     final paperRaised = tokens?.paperRaised ?? cs.surface;
-    final radius = BorderRadius.circular(tokens?.rLg ?? 16);
+    final radius = BorderRadius.circular(context.tokens.rLg);
 
     return Container(
       decoration: BoxDecoration(
@@ -546,13 +543,13 @@ class StoryHookCard extends StatelessWidget {
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: cs.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+          borderRadius: BorderRadius.circular(context.tokens.rLg),
           border: Border.fromBorderSide(BorderSide(color: cs.outlineVariant)),
-          boxShadow: tokens?.e1 ?? _kCardShadow,
+          boxShadow: context.tokens.e1,
         ),
         child: Material(
           type: MaterialType.transparency,
-          borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+          borderRadius: BorderRadius.circular(context.tokens.rLg),
           clipBehavior: Clip.antiAlias,
           child: InkWell(
             onTap: onTap,

--- a/frontend/lib/features/narration/presentation/widgets/editorial_hero.dart
+++ b/frontend/lib/features/narration/presentation/widgets/editorial_hero.dart
@@ -72,13 +72,12 @@ class _GlyphBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [category.ink, tokens?.inkBg ?? const Color(0xFF1B1611)],
+          colors: [category.ink, context.tokens.inkBg],
         ),
       ),
       child: Center(

--- a/frontend/lib/features/narration/presentation/widgets/reading_palette.dart
+++ b/frontend/lib/features/narration/presentation/widgets/reading_palette.dart
@@ -3,10 +3,11 @@ import 'package:flutter/material.dart';
 
 /// Resolved colours for the Field Journal narration reader.
 ///
-/// The reader uses the warm "reading surface" (sepia by default) for its body
-/// and dark chrome for the floating audio bar. Colours come from
-/// [LorescapeTokens] (or const fallbacks when the extension is absent, e.g.
-/// widget tests); the accent follows the active brand accent via `tokens.clay`.
+/// The reader uses the warm "reading surface" for its body and dark chrome for
+/// the floating audio bar. Colours are a projection of [LorescapeTokens] via
+/// [BuildContext.tokens], which supplies [LorescapeTokens.fallback] when the
+/// extension is absent (e.g. widget tests); the accent follows the active brand
+/// accent via `tokens.clay`.
 class ReadingPalette {
   const ReadingPalette({
     required this.readBg,
@@ -35,19 +36,19 @@ class ReadingPalette {
   final double rLg;
 
   factory ReadingPalette.of(BuildContext context) {
-    final t = Theme.of(context).extension<LorescapeTokens>();
+    final t = context.tokens;
     return ReadingPalette(
-      readBg: t?.readBg ?? const Color(0xFFEFE2CB),
-      readInk: t?.readInk ?? const Color(0xFF2A2013),
-      readDim: t?.readDim ?? const Color(0xFF6A5A3E),
-      readLine: t?.readLine ?? const Color(0xFFDDCBA8),
-      readCap: t?.readCap ?? const Color(0xFF97442A),
-      clay: t?.clay ?? const Color(0xFFBC5E3E),
-      inkBg: t?.inkBg ?? const Color(0xFF1B1611),
-      inkBg2: t?.inkBg2 ?? const Color(0xFF251E17),
-      onDark: t?.onDark ?? const Color(0xFFF7F1E6),
-      onDark2: t?.onDark2 ?? const Color(0xFFC3B7A4),
-      rLg: t?.rLg ?? 16,
+      readBg: t.readBg,
+      readInk: t.readInk,
+      readDim: t.readDim,
+      readLine: t.readLine,
+      readCap: t.readCap,
+      clay: t.clay,
+      inkBg: t.inkBg,
+      inkBg2: t.inkBg2,
+      onDark: t.onDark,
+      onDark2: t.onDark2,
+      rLg: t.rLg,
     );
   }
 }

--- a/frontend/lib/features/onboarding/presentation/screens/onboarding_welcome_screen.dart
+++ b/frontend/lib/features/onboarding/presentation/screens/onboarding_welcome_screen.dart
@@ -64,7 +64,7 @@ class _OnboardingWelcomeScreenState
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final dark = _isDark(_step);
 
     return Scaffold(
@@ -104,7 +104,7 @@ class _WelcomeStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -221,7 +221,7 @@ class _ValueStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final textTheme = Theme.of(context).textTheme;
 
     return Container(
@@ -318,7 +318,7 @@ class _Pillar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final textTheme = Theme.of(context).textTheme;
     return Container(
       padding: const EdgeInsets.all(15),
@@ -417,7 +417,7 @@ class _CategoriesStep extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final textTheme = Theme.of(context).textTheme;
 
     return Container(
@@ -505,7 +505,7 @@ class _CategoryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     return ClipRRect(
       borderRadius: BorderRadius.circular(palette.rLg),
       child: Stack(
@@ -600,7 +600,7 @@ class _ObTopBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final muted = dark
         ? palette.onDark.withValues(alpha: 0.22)
         : palette.lineStrong.withValues(alpha: 0.5);
@@ -675,7 +675,7 @@ class _ObDock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     final isLast = step == 2;
 
     return Positioned(
@@ -733,7 +733,7 @@ class _FinishOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final palette = _Palette.of(context);
+    final palette = context.tokens;
     return Positioned.fill(
       child: DecoratedBox(
         decoration: BoxDecoration(
@@ -796,79 +796,6 @@ class _FinishOverlay extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-// ============================================================================
-// Palette — resolves Field Journal tokens with fallbacks for plain themes
-// ============================================================================
-
-class _Palette {
-  const _Palette({
-    required this.paper,
-    required this.paperRaised,
-    required this.paperSunk,
-    required this.line,
-    required this.lineStrong,
-    required this.ink,
-    required this.ink2,
-    required this.ink3,
-    required this.inkBg,
-    required this.onDark,
-    required this.onDark2,
-    required this.clay,
-    required this.clayDeep,
-    required this.clayTint,
-    required this.rLg,
-    required this.e1,
-  });
-
-  final Color paper;
-  final Color paperRaised;
-  final Color paperSunk;
-  final Color line;
-  final Color lineStrong;
-  final Color ink;
-  final Color ink2;
-  final Color ink3;
-  final Color inkBg;
-  final Color onDark;
-  final Color onDark2;
-  final Color clay;
-  final Color clayDeep;
-  final Color clayTint;
-  final double rLg;
-  final List<BoxShadow> e1;
-
-  factory _Palette.of(BuildContext context) {
-    final t = Theme.of(context).extension<LorescapeTokens>();
-    final cs = Theme.of(context).colorScheme;
-    return _Palette(
-      paper: t?.paper ?? const Color(0xFFF7F1E6),
-      paperRaised: t?.paperRaised ?? const Color(0xFFFDFAF3),
-      paperSunk: t?.paperSunk ?? const Color(0xFFECE3D3),
-      line: t?.line ?? const Color(0xFFE4DAC8),
-      lineStrong: t?.lineStrong ?? const Color(0xFFCDBFA6),
-      ink: t?.ink ?? const Color(0xFF221C14),
-      ink2: t?.ink2 ?? const Color(0xFF5E5341),
-      ink3: t?.ink3 ?? const Color(0xFF918471),
-      inkBg: t?.inkBg ?? const Color(0xFF1B1611),
-      onDark: t?.onDark ?? const Color(0xFFF7F1E6),
-      onDark2: t?.onDark2 ?? const Color(0xFFC3B7A4),
-      clay: t?.clay ?? cs.primary,
-      clayDeep: t?.clayDeep ?? const Color(0xFF97442A),
-      clayTint: t?.clayTint ?? const Color(0xFFF7E8DD),
-      rLg: t?.rLg ?? 16,
-      e1:
-          t?.e1 ??
-          const [
-            BoxShadow(
-              color: Color(0x0F281E12),
-              offset: Offset(0, 1),
-              blurRadius: 2,
-            ),
-          ],
     );
   }
 }

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_sheet.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_sheet.dart
@@ -15,15 +15,13 @@ import 'package:go_router/go_router.dart';
 /// Opens the saved-locations list as a Field Journal bottom sheet.
 Future<void> showSavedLocationsSheet(BuildContext context) {
   final colorScheme = Theme.of(context).colorScheme;
-  final tokens = Theme.of(context).extension<LorescapeTokens>();
+  final tokens = context.tokens;
   return showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: colorScheme.surface,
     shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(
-        top: Radius.circular(tokens?.rXl ?? 22),
-      ),
+      borderRadius: BorderRadius.vertical(top: Radius.circular(tokens.rXl)),
     ),
     builder: (sheetContext) {
       final height = MediaQuery.of(sheetContext).size.height * 0.75;

--- a/frontend/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/screens/settings_screen.dart
@@ -11,19 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-/// Fallback warm shadows / dark-surface colours for contexts where the
-/// [LorescapeTokens] theme extension is not installed (e.g. widget tests).
-const List<BoxShadow> _kCardShadow = [
-  BoxShadow(color: Color(0x0F281E12), offset: Offset(0, 1), blurRadius: 2),
-];
-const List<BoxShadow> _kBannerShadow = [
-  BoxShadow(color: Color(0x17281E12), offset: Offset(0, 6), blurRadius: 18),
-];
-const Color _kInkBg = Color(0xFF1B1611);
-const Color _kInkBg2 = Color(0xFF251E17);
-const Color _kOnDark = Color(0xFFF7F1E6);
-const Color _kOnDark2 = Color(0xFFC3B7A4);
-
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
@@ -71,10 +58,10 @@ class _UpgradeBanner extends ConsumerWidget {
     final isPremium = ref.watch(isPremiumProvider);
     final statusAsync = ref.watch(subscriptionStatusProvider);
     final colorScheme = Theme.of(context).colorScheme;
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    final radius = tokens?.rLg ?? 16;
-    final onDark = tokens?.onDark ?? _kOnDark;
-    final onDark2 = tokens?.onDark2 ?? _kOnDark2;
+    final tokens = context.tokens;
+    final radius = tokens.rLg;
+    final onDark = tokens.onDark;
+    final onDark2 = tokens.onDark2;
 
     String title;
     String subtitle;
@@ -98,10 +85,10 @@ class _UpgradeBanner extends ConsumerWidget {
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
-          colors: [tokens?.inkBg2 ?? _kInkBg2, tokens?.inkBg ?? _kInkBg],
+          colors: [tokens.inkBg2, tokens.inkBg],
         ),
         borderRadius: BorderRadius.circular(radius),
-        boxShadow: tokens?.e2 ?? _kBannerShadow,
+        boxShadow: tokens.e2,
       ),
       child: Material(
         type: MaterialType.transparency,
@@ -483,8 +470,8 @@ class _SettingsCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    final radius = tokens?.rLg ?? 16;
+    final tokens = context.tokens;
+    final radius = tokens.rLg;
 
     final rows = <Widget>[];
     for (var i = 0; i < children.length; i++) {
@@ -503,7 +490,7 @@ class _SettingsCard extends StatelessWidget {
         border: Border.fromBorderSide(
           BorderSide(color: colorScheme.outlineVariant),
         ),
-        boxShadow: tokens?.e1 ?? _kCardShadow,
+        boxShadow: tokens.e1,
       ),
       child: Material(
         type: MaterialType.transparency,

--- a/frontend/lib/features/subscription/presentation/widgets/paywall_palette.dart
+++ b/frontend/lib/features/subscription/presentation/widgets/paywall_palette.dart
@@ -4,9 +4,10 @@ import 'package:flutter/material.dart';
 /// Resolved colours for the immersive (always-dark) Field Journal paywall.
 ///
 /// The paywall stays dark regardless of the app's light theme, so its colours
-/// come from [LorescapeTokens] (or const fallbacks when the extension is
-/// absent, e.g. widget tests). The accent still follows the active brand
-/// accent via `tokens.clay`.
+/// are a projection of [LorescapeTokens] via [BuildContext.tokens], which
+/// supplies [LorescapeTokens.fallback] when the extension is absent (e.g.
+/// widget tests). The accent still follows the active brand accent via
+/// `tokens.clay`. [lineDark] is paywall-specific and not a token.
 class PaywallPalette {
   const PaywallPalette({
     required this.inkBg,
@@ -35,16 +36,16 @@ class PaywallPalette {
   Color get badgeSurface => onDark.withValues(alpha: 0.12);
 
   factory PaywallPalette.of(BuildContext context) {
-    final t = Theme.of(context).extension<LorescapeTokens>();
+    final t = context.tokens;
     return PaywallPalette(
-      inkBg: t?.inkBg ?? const Color(0xFF1B1611),
-      clay: t?.clay ?? const Color(0xFFBC5E3E),
-      clayDeep: t?.clayDeep ?? const Color(0xFF97442A),
-      onDark: t?.onDark ?? const Color(0xFFF7F1E6),
-      onDark2: t?.onDark2 ?? const Color(0xFFC3B7A4),
-      onDark3: t?.onDark3 ?? const Color(0xFF8C8170),
+      inkBg: t.inkBg,
+      clay: t.clay,
+      clayDeep: t.clayDeep,
+      onDark: t.onDark,
+      onDark2: t.onDark2,
+      onDark3: t.onDark3,
       lineDark: const Color(0x1FF7F1E6),
-      rLg: t?.rLg ?? 16,
+      rLg: t.rLg,
     );
   }
 }

--- a/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_edit_screen.dart
@@ -237,7 +237,7 @@ class _FieldBox extends StatelessWidget {
     final cs = Theme.of(context).colorScheme;
     final tokens = Theme.of(context).extension<LorescapeTokens>();
     final ink3 = tokens?.ink3 ?? cs.onSurfaceVariant;
-    final radius = tokens?.rMd ?? 12;
+    final radius = context.tokens.rMd;
 
     final content = Container(
       decoration: BoxDecoration(

--- a/frontend/lib/features/trip/presentation/widgets/trip_card.dart
+++ b/frontend/lib/features/trip/presentation/widgets/trip_card.dart
@@ -4,10 +4,6 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-const List<BoxShadow> _kTileShadow = [
-  BoxShadow(color: Color(0x17281E12), offset: Offset(0, 6), blurRadius: 18),
-];
-
 /// 顯示單一 Trip 的卡片（Field Journal clay 磚）。
 class TripCard extends StatelessWidget {
   final Trip trip;
@@ -30,9 +26,9 @@ class TripCard extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final tokens = Theme.of(context).extension<LorescapeTokens>();
     final clay = tokens?.clay ?? colorScheme.primary;
-    final clayDeep = tokens?.clayDeep ?? const Color(0xFF97442A);
+    final clayDeep = context.tokens.clayDeep;
     const onClay = Color(0xFFFBEFE7);
-    final radius = tokens?.rXl ?? 22;
+    final radius = context.tokens.rXl;
 
     return Material(
       color: Colors.transparent,
@@ -51,7 +47,7 @@ class TripCard extends StatelessWidget {
             border: isCurrent
                 ? Border.all(color: onClay.withValues(alpha: 0.7), width: 2)
                 : null,
-            boxShadow: tokens?.e2 ?? _kTileShadow,
+            boxShadow: context.tokens.e2,
           ),
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -153,8 +149,7 @@ class UncategorizedTripCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    final radius = tokens?.rXl ?? 22;
+    final radius = context.tokens.rXl;
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -165,7 +160,7 @@ class UncategorizedTripCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(radius),
             color: colorScheme.surfaceContainerLow,
             border: Border.all(color: colorScheme.outlineVariant),
-            boxShadow: tokens?.e1 ?? _kTileShadow,
+            boxShadow: context.tokens.e1,
           ),
           child: Padding(
             padding: const EdgeInsets.all(16),

--- a/frontend/lib/shared/widgets/journal/lorescape_date_picker.dart
+++ b/frontend/lib/shared/widgets/journal/lorescape_date_picker.dart
@@ -11,15 +11,13 @@ Future<DateTime?> showLorescapeDatePicker({
   required DateTime firstDate,
   required DateTime lastDate,
 }) {
-  final tokens = Theme.of(context).extension<LorescapeTokens>();
+  final tokens = context.tokens;
   return showModalBottomSheet<DateTime>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Theme.of(context).colorScheme.surface,
     shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(
-        top: Radius.circular(tokens?.rXl ?? 22),
-      ),
+      borderRadius: BorderRadius.vertical(top: Radius.circular(tokens.rXl)),
     ),
     builder: (_) => _CalendarSheet(
       initialDate: _clamp(initialDate, firstDate, lastDate),

--- a/frontend/lib/shared/widgets/journal/notebook_pager.dart
+++ b/frontend/lib/shared/widgets/journal/notebook_pager.dart
@@ -112,7 +112,7 @@ class _NotebookPageView extends StatelessWidget {
         padding: const EdgeInsets.fromLTRB(20, 20, 20, 14),
         decoration: BoxDecoration(
           color: paper,
-          borderRadius: BorderRadius.circular(tokens?.rLg ?? 16),
+          borderRadius: BorderRadius.circular(context.tokens.rLg),
           border: Border.all(color: tokens?.line ?? colorScheme.outlineVariant),
           boxShadow: tokens?.e2,
         ),
@@ -211,7 +211,7 @@ class _Polaroid extends StatelessWidget {
                           style: GoogleFonts.longCang(
                             fontSize: 24,
                             height: 1.1,
-                            color: tokens?.ink ?? const Color(0xFF221C14),
+                            color: context.tokens.ink,
                           ),
                         ),
                       ),
@@ -264,7 +264,6 @@ class _EmptyPhoto extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
     return ColoredBox(
       color: const Color(0xFFEFE7D6),
       child: Center(
@@ -274,7 +273,7 @@ class _EmptyPhoto extends StatelessWidget {
             Icon(
               Icons.image_not_supported_outlined,
               size: 30,
-              color: tokens?.lineStrong ?? const Color(0xFFCDBFA6),
+              color: context.tokens.lineStrong,
             ),
             const SizedBox(height: 8),
             Text(
@@ -282,7 +281,7 @@ class _EmptyPhoto extends StatelessWidget {
               style: TextStyle(
                 fontSize: 12,
                 letterSpacing: 1.2,
-                color: tokens?.ink3 ?? const Color(0xFF918471),
+                color: context.tokens.ink3,
               ),
             ),
           ],

--- a/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/narration_screen_test.dart
@@ -1,3 +1,4 @@
+import 'package:context_app/app/config/lorescape_tokens.dart';
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/domain/models/narration_content.dart';
 import 'package:context_app/features/narration/presentation/screens/narration_screen.dart';
@@ -64,8 +65,16 @@ void main() {
         );
 
         final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
-        expect(scaffold.backgroundColor, equals(const Color(0xFFEFE2CB)));
-        expect(scaffold.backgroundColor, isNot(const Color(0xFF1B1611)));
+        // Without the theme extension the reader falls back to the canonical
+        // warm reading surface (paper), never the dark night chrome.
+        expect(
+          scaffold.backgroundColor,
+          equals(LorescapeTokens.fallback.readBg),
+        );
+        expect(
+          scaffold.backgroundColor,
+          isNot(LorescapeTokens.fallback.inkBg),
+        );
       },
     );
 


### PR DESCRIPTION
## 背景

用 Graphify 對 `frontend/` 建知識圖譜時，低內聚訊號指向 `onboarding · presentation`，追下去發現一個實質問題：design-token 的 fallback 值散落在整個 codebase、彼此還不一致。

- 各 widget 與三個 `*Palette` adapter 各自 hardcode 一份 `tokens?.x ?? <字面值>` 的 token fallback，散落約 58 處
- 不一致：onboarding 假設 paper、reading 假設 sepia、`forAppearance` 預設 paper —— 這是 design-token 漂移

## 做法

新增 `LorescapeTokens.fallback` 常數與 `context.tokens` 存取器作為**唯一** fallback 來源：

- onboarding `_Palette` 整個刪除，改用 `context.tokens`
- `ReadingPalette.of` / `PaywallPalette.of` 委派 `context.tokens`（PaywallPalette 保留非 token 的 `lineDark` 與衍生 getter）
- 12 個 widget 的內聯 `tokens?.x ?? <字面值 / _k 私有常數>` 收斂到 `context.tokens.x`，並刪除已無用的 shadow / 顏色常數
- narration 測試的 reading-surface 斷言改綁 `LorescapeTokens.fallback`（修正並鎖住 sepia/paper 漂移）

**刻意保留 `?? colorScheme.x` 形式**：那是元件在非 Lorescape 主題下降級融入 Material 的設計意圖，非 token 字面值重複，故 `masthead` 與 `lorescape_map`（全屬此類）整檔不動。

## 影響

- 主題正常註冊時（production）行為完全不變；差異僅在無主題（widget test）時 fallback 統一為 canonical 預設值
- 至此 `tokens?.x ?? <字面值>` 已從 `lib/` 全數清除，fallback 僅存於 `LorescapeTokens.fallback` 一處

## 驗證

- `fvm flutter analyze --fatal-infos` 全綠
- `fvm flutter test` 547 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)