### PR TITLE
ci(publisher): 在 CI 安裝 Playwright chromium browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,5 +108,10 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
+      # card/wander renderer 測試用 Playwright(Chromium) 把 HTML 渲染成圖，
+      # 需要下載 browser binary（uv sync 只裝 Python 套件）。
+      - name: Install Playwright browser
+        run: uv run playwright install --with-deps chromium
+
       - name: Run tests
         run: uv run python -m pytest


### PR DESCRIPTION
## 問題

publisher 的 card / wander renderer 測試用 **Playwright（Chromium）** 把 HTML 渲染成 PNG/JPEG（`pw.chromium.launch()`）。CI 的 `uv sync --extra dev` 只裝 playwright 的 Python 套件，**沒下載 browser binary**，導致：

```
playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at
.../chrome-headless-shell-linux64/chrome-headless-shell
```

結果：`4 failed, 217 passed, 11 errors`。本地會過是因為開發機早已 `playwright install` 過。

這是 #98 首次引入 publisher CI job 時漏掉的一步，與任何應用程式碼無關（master 上就已紅）。

## 修法

在「Install dependencies」後補一步：

```yaml
- name: Install Playwright browser
  run: uv run playwright install --with-deps chromium
```

只改 publisher-test job（backend-test 不需要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)