### PR TITLE
調整手記頁版面：拍立得圖說移除、重聽鍵改為標題右側 icon 圓鈕

### DIFF
--- a/frontend/lib/features/trip/presentation/screens/trip_detail_screen.dart
+++ b/frontend/lib/features/trip/presentation/screens/trip_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:context_app/app/config/lorescape_tokens.dart';
 import 'package:context_app/features/export/domain/models/pdf_export_result.dart';
 import 'package:context_app/features/export/domain/services/trip_pdf_export_service.dart';
 import 'package:context_app/features/export/providers.dart';
@@ -33,30 +32,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   bool _selectionMode = false;
   bool _moving = false;
 
-  /// 手記翻頁器目前停在第幾則——lead 列的重聽鍵要播的就是這一則。純粹
-  /// 記錄用，不觸發 rebuild（重繪 lead 反而會打斷翻頁動畫）。
-  int _notebookIndex = 0;
-
   bool get _isUncategorized => widget.tripId == null;
-
-  /// 重聽目前這一則：記錄裡就存著完整敘事文字，播放頁只要拿到地點與
-  /// [NarrationContent] 就能重新合成語音，不必再打一次生成 API。
-  void _replayCurrentNote(List<JourneyItem> items) {
-    if (items.isEmpty) return;
-    final item = items[_notebookIndex.clamp(0, items.length - 1)];
-    switch (item) {
-      case NarrationJourneyItem(:final entry):
-        context.pushNamed(
-          'player',
-          extra: {
-            'place': entry.place.toPlace(),
-            'narrationContent': entry.narrationContent,
-            // 按下「重聽」的意圖就是要聽，不必再多按一次播放鍵。
-            'autoPlay': true,
-          },
-        );
-    }
-  }
 
   void _enterSelectionMode() {
     setState(() {
@@ -142,18 +118,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       appBar: _buildAppBar(tripAsync, items),
       body: Column(
         children: [
-          if (!_selectionMode)
-            _NotebookLead(
-              trip: tripAsync.asData?.value,
-              onReplay: items.isEmpty ? null : () => _replayCurrentNote(items),
-            ),
+          if (!_selectionMode) _NotebookLead(trip: tripAsync.asData?.value),
           Expanded(
             child: _ItemsList(
               itemsAsync: itemsAsync,
               selectionMode: _selectionMode,
               selectedIds: _selectedIds,
               onToggleSelection: _toggleSelection,
-              onPageChanged: (i) => _notebookIndex = i,
             ),
           ),
         ],
@@ -229,16 +200,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 }
 
-/// 手記上方的 lead 列（設計稿 `.trip-lead`）：左側是旅程日期，右側是 clay
-/// 色的重聽鍵。重聽鍵放在筆記外面而不是塞進 `.nb-foot`——那三格是留給
-/// 加入旅程 / 分享 / 刪除的。
+/// 手記上方的 lead 列（設計稿 `.trip-lead`）：顯示旅程日期。重聽鍵已改成
+/// 每頁手記標題右側的 icon 圓鈕（見 `NotebookPage.onReplay`），不在這裡。
 class _NotebookLead extends StatelessWidget {
-  const _NotebookLead({required this.trip, required this.onReplay});
+  const _NotebookLead({required this.trip});
 
   final Trip? trip;
-
-  /// null 代表這本旅程還沒有記錄，沒東西可重聽。
-  final VoidCallback? onReplay;
 
   @override
   Widget build(BuildContext context) {
@@ -246,41 +213,25 @@ class _NotebookLead extends StatelessWidget {
     final range = trip == null
         ? null
         : _formatDateRange(trip!.startDate, trip!.endDate);
-    if (range == null && onReplay == null) return const SizedBox.shrink();
+    if (range == null) return const SizedBox.shrink();
 
     return Padding(
       padding: const EdgeInsets.fromLTRB(22, 4, 22, 8),
       child: Row(
         children: [
-          Expanded(
-            child: range == null
-                ? const SizedBox.shrink()
-                : Row(
-                    children: [
-                      Icon(
-                        Icons.event,
-                        size: 17,
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      const SizedBox(width: 6),
-                      Flexible(
-                        child: Text(
-                          range,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: TextStyle(
-                            color: colorScheme.onSurfaceVariant,
-                            fontSize: 13,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
+          Icon(Icons.event, size: 17, color: colorScheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              range,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: colorScheme.onSurfaceVariant,
+                fontSize: 13,
+              ),
+            ),
           ),
-          if (onReplay != null) ...[
-            const SizedBox(width: 12),
-            _ReplayButton(onTap: onReplay!),
-          ],
         ],
       ),
     );
@@ -293,54 +244,6 @@ class _NotebookLead extends StatelessWidget {
       return '${fmt.format(start)} – ${fmt.format(end)}';
     }
     return fmt.format(start ?? end!);
-  }
-}
-
-/// 設計稿的 `.replay-btn`：clay 實心藥丸，按下時壓深一階並微縮。
-class _ReplayButton extends StatelessWidget {
-  const _ReplayButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = context.tokens;
-
-    return Material(
-      color: tokens.clay,
-      borderRadius: BorderRadius.circular(999),
-      elevation: 0,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(999),
-        highlightColor: tokens.clayDeep,
-        child: Container(
-          height: 38,
-          padding: const EdgeInsets.symmetric(horizontal: 15),
-          alignment: Alignment.center,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.play_arrow_rounded,
-                size: 18,
-                color: Color(0xFFFBF1E9),
-              ),
-              const SizedBox(width: 7),
-              Text(
-                'journey.replay_note'.tr(),
-                style: const TextStyle(
-                  color: Color(0xFFFBF1E9),
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 0.28,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }
 
@@ -521,15 +424,27 @@ class _ItemsList extends ConsumerWidget {
   final bool selectionMode;
   final Set<String> selectedIds;
   final void Function(String id) onToggleSelection;
-  final ValueChanged<int> onPageChanged;
 
   const _ItemsList({
     required this.itemsAsync,
     required this.selectionMode,
     required this.selectedIds,
     required this.onToggleSelection,
-    required this.onPageChanged,
   });
+
+  /// 重聽這一則：記錄裡就存著完整敘事文字，播放頁只要拿到地點與
+  /// narration 內容就能重新合成語音，不必再打一次生成 API。
+  void _replay(BuildContext context, JourneyEntry entry) {
+    context.pushNamed(
+      'player',
+      extra: {
+        'place': entry.place.toPlace(),
+        'narrationContent': entry.narrationContent,
+        // 按下「重聽」的意圖就是要聽，不必再多按一次播放鍵。
+        'autoPlay': true,
+      },
+    );
+  }
 
   /// 把這則手記收進另一本旅程，對應設計稿的「加入旅程」。
   Future<void> _addToTrip(
@@ -606,7 +521,6 @@ class _ItemsList extends ConsumerWidget {
         // 一張，沒辦法批次勾選、移動或匯出，硬套會把既有功能弄殘。
         if (!selectionMode) {
           return NotebookPager(
-            onPageChanged: onPageChanged,
             pages: [
               for (var i = 0; i < items.length; i++)
                 switch (items[i]) {
@@ -618,6 +532,7 @@ class _ItemsList extends ConsumerWidget {
                     text: entry.narrationContent.text,
                     address: entry.place.address,
                     imageUrl: entry.place.imageUrl,
+                    onReplay: () => _replay(context, entry),
                     onAddToTrip: () => _addToTrip(context, ref, entry),
                     onShare: () => _share(context, entry),
                     onDelete: () => _delete(context, ref, entry),

--- a/frontend/lib/shared/widgets/journal/notebook_pager.dart
+++ b/frontend/lib/shared/widgets/journal/notebook_pager.dart
@@ -95,6 +95,7 @@ class NotebookPage {
     required this.text,
     this.address,
     this.imageUrl,
+    this.onReplay,
     this.onAddToTrip,
     this.onShare,
     this.onDelete,
@@ -105,6 +106,9 @@ class NotebookPage {
   final String text;
   final String? address;
   final String? imageUrl;
+
+  /// 重聽這一則手記；null 時標題右側不顯示重聽鍵。
+  final VoidCallback? onReplay;
 
   /// 把這則手記收進另一本旅程；null 時不顯示該動作。
   final VoidCallback? onAddToTrip;
@@ -123,7 +127,7 @@ class NotebookPager extends StatefulWidget {
 
   final List<NotebookPage> pages;
 
-  /// 翻到第幾頁；外面的 lead 列要靠它知道現在停在哪一則。
+  /// 翻到第幾頁；外層需要知道現在停在哪一則時使用。
   final ValueChanged<int>? onPageChanged;
 
   @override
@@ -329,7 +333,9 @@ class _Polaroid extends StatelessWidget {
                   clipBehavior: Clip.none,
                   children: [
                     Container(
-                      padding: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+                      // 底邊留厚一點，保住拍立得的相紙感；圖說改由下方的
+                      // 筆記標題承擔，不再重複景點名。
+                      padding: const EdgeInsets.fromLTRB(12, 12, 12, 28),
                       decoration: BoxDecoration(
                         color: const Color(0xFFFFFDF8),
                         boxShadow: const [
@@ -341,34 +347,10 @@ class _Polaroid extends StatelessWidget {
                         ],
                         borderRadius: BorderRadius.circular(3),
                       ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SizedBox(
-                            width: side,
-                            height: side,
-                            child: _PolaroidPhoto(imageUrl: page.imageUrl),
-                          ),
-                          SizedBox(
-                            width: side,
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(6, 14, 6, 16),
-                              child: Text(
-                                page.title,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                textAlign: TextAlign.center,
-                                // Long Cang：設計稿指定的手寫體，撐起「手記」
-                                // 的味道。
-                                style: GoogleFonts.longCang(
-                                  fontSize: 26,
-                                  height: 1.1,
-                                  color: context.tokens.ink,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
+                      child: SizedBox(
+                        width: side,
+                        height: side,
+                        child: _PolaroidPhoto(imageUrl: page.imageUrl),
                       ),
                     ),
                     // 膠帶：奇偶頁貼在不同側。
@@ -462,14 +444,24 @@ class _Note extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Text(
-          page.title,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            fontSize: 19,
-            fontWeight: FontWeight.w700,
-          ),
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                page.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontSize: 19,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            if (page.onReplay != null) ...[
+              const SizedBox(width: 10),
+              _ReplayIconButton(onTap: page.onReplay!),
+            ],
+          ],
         ),
         if (address != null && address.isNotEmpty) ...[
           const SizedBox(height: 6),
@@ -511,6 +503,42 @@ class _Note extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// 標題右側的重聽鍵：clay 色圓鈕、只放播放 icon——設計稿的文字藥丸版
+/// 放進筆記標題列會擠掉長景點名，縮成 icon 才擺得下。
+class _ReplayIconButton extends StatelessWidget {
+  const _ReplayIconButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+
+    return Semantics(
+      button: true,
+      label: 'journey.replay_note'.tr(),
+      child: Material(
+        color: tokens.clay,
+        shape: const CircleBorder(),
+        child: InkWell(
+          onTap: onTap,
+          customBorder: const CircleBorder(),
+          highlightColor: tokens.clayDeep,
+          child: const SizedBox(
+            width: 34,
+            height: 34,
+            child: Icon(
+              Icons.play_arrow_rounded,
+              size: 20,
+              color: Color(0xFFFBF1E9),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/frontend/test/features/trip/presentation/screens/trip_detail_screen_test.dart
+++ b/frontend/test/features/trip/presentation/screens/trip_detail_screen_test.dart
@@ -37,11 +37,11 @@ void main() {
 
         _thenTripNameIsVisible('Kyoto Temples');
         _thenNotebookPagerIsShown();
-        // 手記本身帶三顆動作；重播鍵在筆記外的 lead 列。
+        // 手記本身帶三顆動作；重聽鍵是筆記標題右側的 icon 圓鈕。
         expect(find.text('trip.add_to_trip'), findsOneWidget);
         expect(find.text('common.share'), findsOneWidget);
         expect(find.text('common.delete'), findsOneWidget);
-        expect(find.text('journey.replay_note'), findsOneWidget);
+        expect(find.byIcon(Icons.play_arrow_rounded), findsOneWidget);
       },
     );
 
@@ -121,7 +121,7 @@ void main() {
           playerExtras: playerExtras,
         );
 
-        await tester.tap(find.text('journey.replay_note'));
+        await tester.tap(find.byIcon(Icons.play_arrow_rounded));
         await tester.pumpAndSettle();
 
         final extra = playerExtras.single as Map<String, dynamic>;

--- a/frontend/test/shared/widgets/journal/notebook_pager_test.dart
+++ b/frontend/test/shared/widgets/journal/notebook_pager_test.dart
@@ -40,20 +40,24 @@ void main() {
   group('NotebookPager', () {
     testWidgets(
       'given a page with no callbacks, when the pager renders, '
-      'then the footer shows no actions',
+      'then no actions are shown and the title appears only in the note',
       (tester) async {
         await _givenPager(tester, pages: [_buildPage()]);
 
         expect(find.text('trip.add_to_trip'), findsNothing);
         expect(find.text('common.share'), findsNothing);
         expect(find.text('common.delete'), findsNothing);
+        expect(find.byIcon(Icons.play_arrow_rounded), findsNothing);
+        // 拍立得下方不再放手寫圖說，景點名只出現在筆記標題一處。
+        expect(find.text('Kinkaku-ji'), findsOneWidget);
       },
     );
 
     testWidgets(
       'given a page with every callback, when the user taps each action, '
-      'then add-to-trip, share and delete each fire once',
+      'then replay, add-to-trip, share and delete each fire once',
       (tester) async {
+        var replayCount = 0;
         var addCount = 0;
         var shareCount = 0;
         var deleteCount = 0;
@@ -62,17 +66,20 @@ void main() {
           tester,
           pages: [
             _buildPage(
+              onReplay: () => replayCount += 1,
               onAddToTrip: () => addCount += 1,
               onShare: () => shareCount += 1,
               onDelete: () => deleteCount += 1,
             ),
           ],
         );
+        await tester.tap(find.byIcon(Icons.play_arrow_rounded));
         await tester.tap(find.text('trip.add_to_trip'));
         await tester.tap(find.text('common.share'));
         await tester.tap(find.text('common.delete'));
         await tester.pump();
 
+        expect(replayCount, 1);
         expect(addCount, 1);
         expect(shareCount, 1);
         expect(deleteCount, 1);
@@ -82,6 +89,7 @@ void main() {
 }
 
 NotebookPage _buildPage({
+  VoidCallback? onReplay,
   VoidCallback? onAddToTrip,
   VoidCallback? onShare,
   VoidCallback? onDelete,
@@ -89,6 +97,7 @@ NotebookPage _buildPage({
   title: 'Kinkaku-ji',
   dateLabel: '2024/05/01 · 10:00',
   text: 'A golden pavilion by the pond.',
+  onReplay: onReplay,
   onAddToTrip: onAddToTrip,
   onShare: onShare,
   onDelete: onDelete,


### PR DESCRIPTION
- 拍立得照片下方不再放手寫景點名，景點名只保留筆記標題一處；
  相紙底邊留厚保住拍立得感
- 重聽鍵從手記上方的 lead 列移進每頁筆記：標題右側、置右的
  clay 色 icon 圓鈕，不帶文字（Semantics 仍標示「重聽這則手記」）
- lead 列只剩旅程日期；重聽改由 NotebookPage.onReplay 逐頁接線，
  不再需要追蹤目前頁碼

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016TWJkEBN8tqU7FrgZR4pYb