### PR TITLE
Fix notebook pager gesture handling for flicks and direction lock

### DIFF
--- a/frontend/lib/shared/widgets/journal/notebook_pager.dart
+++ b/frontend/lib/shared/widgets/journal/notebook_pager.dart
@@ -165,6 +165,11 @@ class _NotebookPagerState extends State<NotebookPager>
   /// 鬆手時翻過這個比例才算翻頁，否則彈回。
   static const double _commitThreshold = 0.28;
 
+  /// 鬆手速度超過這個值（邏輯像素／秒）就視為甩動，不足距離門檻也翻頁。
+  /// 沒有這條的話，從螢幕左半起手的往左快滑永遠滑不滿 [_commitThreshold]
+  /// 的距離（手指先碰到螢幕邊緣），翻頁就變成「只有某些位置滑得動」。
+  static const double _flingVelocity = 700;
+
   /// 已經到頭時仍讓紙翻起一點點，手感上知道「沒有下一頁了」。
   static const double _edgeResistance = 0.07;
 
@@ -211,6 +216,13 @@ class _NotebookPagerState extends State<NotebookPager>
     final last = widget.pages.length - 1;
 
     setState(() {
+      // 進度已歸零而手指正往反方向走時解除方向鎖：起手的微小抖動（先往右
+      // 一兩個像素再往左滑）不該讓整個手勢卡死在錯的方向、放手也沒反應。
+      if (_flipPage != null &&
+          _flipT == 0 &&
+          (_flipForward ? dx > 0 : dx < 0)) {
+        _flipPage = null;
+      }
       if (_flipPage == null) {
         // 第一個有效位移決定方向：往左翻下一頁、往右翻回上一頁。
         if (dx < 0) {
@@ -235,8 +247,18 @@ class _NotebookPagerState extends State<NotebookPager>
     if (_flipPage == null) return;
     final last = widget.pages.length - 1;
     final canFlip = _flipForward ? _index < last : _index > 0;
+
+    // 甩動優先於距離：順著翻頁方向甩就翻、逆著甩就收回，距離門檻只在
+    // 慢慢拖、鬆手沒有速度時才出場——與 PageView 的手感一致。
+    final vx = details.primaryVelocity ?? 0;
+    final flungAlong = _flipForward ? vx < -_flingVelocity : vx > _flingVelocity;
+    final flungBack = _flipForward ? vx > _flingVelocity : vx < -_flingVelocity;
+
     _settleFrom = _flipT;
-    _settleTo = (canFlip && _flipT > _commitThreshold) ? 1 : 0;
+    _settleTo =
+        (canFlip && !flungBack && (flungAlong || _flipT > _commitThreshold))
+        ? 1
+        : 0;
     _settle.forward(from: 0);
   }
 

--- a/frontend/test/shared/widgets/journal/notebook_pager_test.dart
+++ b/frontend/test/shared/widgets/journal/notebook_pager_test.dart
@@ -153,6 +153,144 @@ void main() {
     );
 
     testWidgets(
+      'given three pages, when the user drags left past the commit threshold, '
+      'then the pager flips to the next page',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(tester, pages: _threePages, onPageChanged: seen.add);
+
+        await tester.dragFrom(
+          tester.getCenter(find.byType(NotebookPager)),
+          const Offset(-300, 0),
+        );
+        await tester.pumpAndSettle();
+
+        expect(seen, [1]);
+        expect(find.text('Body 1'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given three pages, when the user flicks left fast but shorter than '
+      'the distance threshold, then the fling still flips to the next page',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(tester, pages: _threePages, onPageChanged: seen.add);
+
+        // 100px 遠低於 28% 螢幕寬的距離門檻，只靠甩動速度過關——修正前這
+        // 種真實世界的快滑（起手點偏左時滑不出長距離）會被彈回原頁。
+        await tester.fling(find.byType(NotebookPager), const Offset(-100, 0), 2000);
+        await tester.pumpAndSettle();
+
+        expect(seen, [1]);
+        expect(find.text('Body 1'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given the pager on its second page, when the user flicks right with a '
+      'short fast swipe, then the pager flips back to the previous page',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(tester, pages: _threePages, onPageChanged: seen.add);
+        await tester.fling(find.byType(NotebookPager), const Offset(-100, 0), 2000);
+        await tester.pumpAndSettle();
+
+        await tester.fling(find.byType(NotebookPager), const Offset(100, 0), 2000);
+        await tester.pumpAndSettle();
+
+        expect(seen, [1, 0]);
+        expect(find.text('Body 0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given a leftward swipe that starts with a small rightward jitter, '
+      'when the finger settles into dragging left, then the direction lock '
+      'releases and the pager still flips forward',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(tester, pages: _threePages, onPageChanged: seen.add);
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(NotebookPager)),
+        );
+        // 起手先往右一小段（手指抖動），再一路往左滑過門檻。
+        await gesture.moveBy(const Offset(30, 0));
+        for (var i = 0; i < 10; i += 1) {
+          await gesture.moveBy(const Offset(-30, 0));
+          await tester.pump(const Duration(milliseconds: 16));
+        }
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(seen, [1]);
+      },
+    );
+
+    testWidgets(
+      'given a swipe starting on the footer actions, when the user drags '
+      'left past the threshold, then the pager still flips forward',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(
+          tester,
+          pages: [
+            for (var i = 0; i < 3; i += 1)
+              _buildPage(text: 'Body $i', onShare: () {}),
+          ],
+          onPageChanged: seen.add,
+        );
+
+        await tester.dragFrom(
+          tester.getCenter(find.text('common.share')),
+          const Offset(-300, 0),
+        );
+        await tester.pumpAndSettle();
+
+        expect(seen, [1]);
+      },
+    );
+
+    testWidgets(
+      'given a slow short drag under both thresholds, when the user lets '
+      'go, then the page springs back and no page change is reported',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(tester, pages: _threePages, onPageChanged: seen.add);
+
+        await tester.timedDragFrom(
+          tester.getCenter(find.byType(NotebookPager)),
+          const Offset(-100, 0),
+          const Duration(milliseconds: 500),
+        );
+        await tester.pumpAndSettle();
+
+        expect(seen, isEmpty);
+        expect(find.text('Body 0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given the pager on its last page, when the user flicks left, '
+      'then the pager stays put',
+      (tester) async {
+        final seen = <int>[];
+        await _givenPager(
+          tester,
+          pages: [_buildPage(text: 'Body 0')],
+          onPageChanged: seen.add,
+        );
+
+        await tester.fling(find.byType(NotebookPager), const Offset(-100, 0), 2000);
+        await tester.pumpAndSettle();
+
+        expect(seen, isEmpty);
+        expect(find.text('Body 0'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
       'given more pages than the indicator cap, when the pager renders, '
       'then the page dots stay capped like the story deck',
       (tester) async {
@@ -188,6 +326,11 @@ const _longNote =
     'doubles the building at dusk, and the garden path loops behind the hill '
     'to a small teahouse where the shogun once received his guests.';
 
+/// 翻頁測試用的三頁，正文帶頁碼方便斷言目前停在哪一頁。
+List<NotebookPage> get _threePages => [
+  for (var i = 0; i < 3; i += 1) _buildPage(text: 'Body $i'),
+];
+
 NotebookPage _buildPage({
   String text = 'A golden pavilion by the pond.',
   VoidCallback? onReplay,
@@ -207,6 +350,10 @@ NotebookPage _buildPage({
 Future<void> _givenPager(
   WidgetTester tester, {
   required List<NotebookPage> pages,
+  ValueChanged<int>? onPageChanged,
 }) async {
-  await pumpScreen(tester, child: NotebookPager(pages: pages));
+  await pumpScreen(
+    tester,
+    child: NotebookPager(pages: pages, onPageChanged: onPageChanged),
+  );
 }


### PR DESCRIPTION
## Summary

Improves the notebook pager's gesture recognition to properly handle fast flicks (甩動) and fix direction lock behavior that could get stuck on initial jitter.

## Key Changes

- **Added fling velocity threshold** (`_flingVelocity = 700` px/s): Fast swipes now trigger page flips even if they don't meet the distance threshold (28% of screen width). This fixes the real-world issue where starting a leftward swipe from the left side of the screen couldn't travel far enough to meet the distance threshold before hitting the screen edge.

- **Implemented direction lock release**: When drag progress returns to zero while moving in the opposite direction, the direction lock is released. This prevents initial finger jitter (small rightward movement before settling into a leftward drag) from locking the gesture into the wrong direction.

- **Updated settle logic**: Page flip now commits if:
  - User flicks in the flip direction (velocity-based), OR
  - User drags past the distance threshold (28%), AND
  - User doesn't fling in the opposite direction

- **Enhanced test coverage**: Added 7 new widget tests covering:
  - Drag past commit threshold
  - Fast flick with short distance
  - Flick back to previous page
  - Direction lock release on jitter
  - Swipe from footer actions
  - Slow drag under both thresholds (no flip)
  - Flick on last page (no-op)

- **Test infrastructure**: Added `_threePages` helper and updated `_givenPager` to support `onPageChanged` callback for assertion.

## Implementation Details

The gesture handling now prioritizes velocity over distance, matching PageView's feel. The direction lock release specifically checks for `_flipT == 0` (progress back to zero) combined with opposite-direction movement, ensuring only genuine jitter triggers the release, not intentional back-and-forth gestures.

https://claude.ai/code/session_01DNRVk2iCez1vc8accQviR2