### PR TITLE
Add canonical URLs to legal pages metadata

### DIFF
--- a/landing/src/app/(legal)/credits/page.tsx
+++ b/landing/src/app/(legal)/credits/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Image Credits — Lorescape",
   description:
     "Attribution for the photography used on the Lorescape landing page.",
+  alternates: { canonical: "/credits" },
 };
 
 interface Credit {

--- a/landing/src/app/(legal)/privacy/page.tsx
+++ b/landing/src/app/(legal)/privacy/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Privacy Policy — Lorescape",
   description:
     "How Lorescape collects, uses, and protects your information when you use our AI audio guide.",
+  alternates: { canonical: "/privacy" },
 };
 
 export default function PrivacyPage() {

--- a/landing/src/app/(legal)/support/page.tsx
+++ b/landing/src/app/(legal)/support/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Support — Lorescape",
   description:
     "Contact Lorescape support or browse frequently asked questions about the AI audio guide.",
+  alternates: { canonical: "/support" },
 };
 
 export default function SupportPage() {

--- a/landing/src/app/(legal)/terms/page.tsx
+++ b/landing/src/app/(legal)/terms/page.tsx
@@ -7,6 +7,7 @@ export const metadata: Metadata = {
   title: "Terms of Use — Lorescape",
   description:
     "The rules and conditions that govern your use of the Lorescape app and services.",
+  alternates: { canonical: "/terms" },
 };
 
 export default function TermsPage() {


### PR DESCRIPTION
## Summary
Added canonical URL metadata to all legal pages in the landing site to improve SEO and prevent duplicate content issues.

## Changes
- Added `alternates: { canonical: "/credits" }` to the credits page metadata
- Added `alternates: { canonical: "/privacy" }` to the privacy policy page metadata
- Added `alternates: { canonical: "/support" }` to the support page metadata
- Added `alternates: { canonical: "/terms" }` to the terms of use page metadata

## Implementation Details
Each legal page now explicitly declares its canonical URL in the Next.js metadata object. This helps search engines understand the authoritative version of each page and prevents potential SEO issues from duplicate content or URL variations.

https://claude.ai/code/session_01RHhztY4cCs6aDt1qj7QnZc