### PR TITLE
Fix badge and search field styling issues

### DIFF
--- a/frontend/lib/features/home/presentation/widgets/home_top_bar.dart
+++ b/frontend/lib/features/home/presentation/widgets/home_top_bar.dart
@@ -112,8 +112,17 @@ class HomeTopBar extends ConsumerWidget {
                     key: const Key('home-search'),
                     controller: controller,
                     onChanged: onQueryChanged,
+                    // The field carries its own pill container, so it must
+                    // fully opt out of the global outlined+filled
+                    // inputDecorationTheme — setting only `border` still
+                    // inherits enabledBorder/focusedBorder/fill.
                     decoration: InputDecoration(
+                      isCollapsed: true,
+                      filled: false,
                       border: InputBorder.none,
+                      enabledBorder: InputBorder.none,
+                      focusedBorder: InputBorder.none,
+                      disabledBorder: InputBorder.none,
                       hintText: 'home.search_hint'.tr(),
                     ),
                   ),

--- a/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_fab.dart
+++ b/frontend/lib/features/saved_locations/presentation/widgets/saved_locations_fab.dart
@@ -48,18 +48,20 @@ class SavedLocationsButton extends ConsumerWidget {
       key: const Key('explore-saved-locations'),
       button: true,
       label: 'saved_locations.title'.tr(),
-      child: Material(
-        color: tokens?.paperSunk ?? colorScheme.surfaceContainerHighest,
-        shape: const CircleBorder(),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: () => showSavedLocationsSheet(context),
-          child: SizedBox(
-            width: 40,
-            height: 40,
-            child: Badge(
-              isLabelVisible: count > 0,
-              label: Text('$count', style: const TextStyle(fontSize: 10)),
+      // Badge 要包在 Material 外層：Material 以 CircleBorder 裁切，放在裡面
+      // 會把 badge 一起塞進圓鈕還裁掉邊，這裡讓它浮在按鈕右上角。
+      child: Badge(
+        isLabelVisible: count > 0,
+        label: Text('$count', style: const TextStyle(fontSize: 10)),
+        child: Material(
+          color: tokens?.paperSunk ?? colorScheme.surfaceContainerHighest,
+          shape: const CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: () => showSavedLocationsSheet(context),
+            child: SizedBox(
+              width: 40,
+              height: 40,
               child: Icon(
                 Icons.bookmark,
                 size: 21,


### PR DESCRIPTION
## Summary
Fixes two UI styling issues: the saved locations badge was being clipped by the circular button, and the home search field was inheriting unwanted border styles from the global theme.

## Changes

- **Saved Locations FAB**: Moved `Badge` widget outside the `Material` widget so it floats above the circular button instead of being clipped by the `CircleBorder` and `Clip.antiAlias`. The badge now properly displays in the top-right corner.

- **Home Search Field**: Explicitly disabled all border variants (`border`, `enabledBorder`, `focusedBorder`, `disabledBorder`) and set `filled: false` to fully opt out of the global `inputDecorationTheme`. Added `isCollapsed: true` for proper spacing. The field now renders cleanly without inheriting unwanted outline/filled styles.

## Implementation Details

Both fixes address the same root cause: child widgets inheriting or being constrained by parent styling. The solutions follow Flutter best practices:
- Restructuring widget hierarchy to achieve desired visual layering (badge)
- Explicitly overriding inherited theme properties where needed (search field)

https://claude.ai/code/session_01CSXAWiqF6mah7wNhZfAGA1