### PR TITLE
Fix map attribution badge positioning in explore screen

### DIFF
--- a/docs/adr/0005-map-tile-provider.md
+++ b/docs/adr/0005-map-tile-provider.md
@@ -100,9 +100,11 @@ Geoapify Free + raster（見「未採納但保留的選項」），但那將是�
   - **地圖右下角的文字角標**（`LorescapeMap._AttributionBadge`）——OSM
     attribution guideline 要求署名要能從地圖上直接可及，這一份就是那個義務。
     角標畫在 `LorescapeMap` 內而非呼叫端，任何用到這張底圖的畫面都會自動帶
-    著署名。呼叫端若在地圖上疊了貼底的浮層，**必須**用
-    `attributionBottomInset` 把角標推到浮層上方（探索頁的地點卡片列就是這種
-    情況）——署名被蓋掉等同沒有署名。
+    著署名。呼叫端若在地圖上疊了貼底的浮層，**必須**確保角標不被蓋掉——用
+    `attributionBottomInset` 把角標推到浮層上方，或確保浮層下方留有角標放
+    得下的透空縫隙（2026-07-30 起探索頁走後者：角標在地點卡片列下方的縫隙，
+    卡片列 ListView 的底部內距保證卡片不會壓到它）——署名被蓋掉等同沒有
+    署名。
   - **設定頁的「地圖資料來源」**（`_MapSourceGroup`）——完整出處與
     openstreetmap.org/copyright 連結。
 

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -141,12 +141,13 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
         children: [
           LorescapeMap(
             mapController: _mapController,
-            // 出處角標要落在卡片列上方，否則會被整個蓋住——署名被蓋掉等同
-            // 沒有署名。
-            attributionBottomInset:
-                MediaQuery.paddingOf(context).bottom +
-                _MapCardsRail.railBottomGap +
-                _MapCardsRail.railHeight,
+            // 出處角標放在卡片列「下方」的縫隙（卡片列與 body 底緣之間），
+            // 只墊安全區。幾何依據：角標高 16（字 12 ＋ 上下內距各 2），比
+            // railBottomGap 的 12 高 4px，多出的部分伸進卡片列的範圍——但
+            // 卡片列的 ListView 自帶 8 的底部內距，卡片實際下緣仍在角標上緣
+            // 之上 4px，署名不會被卡片蓋到。署名被蓋掉等同沒有署名，是授權
+            // 違規（見 ADR 0005）。
+            attributionBottomInset: MediaQuery.paddingOf(context).bottom,
             fitToPoints: [
               for (final place in places)
                 LatLng(place.location.latitude, place.location.longitude),

--- a/frontend/lib/features/explore/presentation/widgets/lorescape_map.dart
+++ b/frontend/lib/features/explore/presentation/widgets/lorescape_map.dart
@@ -45,9 +45,11 @@ class LorescapeMap extends ConsumerStatefulWidget {
   final List<Widget> children;
   final List<LatLng> fitToPoints;
 
-  /// 出處角標距離底緣的距離。呼叫端若在地圖上疊了貼底的浮層（探索頁的地點
-  /// 卡片列就是），要把這個值設成那層的高度，否則角標會被蓋掉——而署名被蓋
-  /// 掉等同沒有署名，是授權違規。見 `docs/adr/0005-map-tile-provider.md`。
+  /// 出處角標距離底緣的距離。角標不得被任何浮層蓋掉——署名被蓋掉等同沒有
+  /// 署名，是授權違規。呼叫端若在地圖上疊了貼底的浮層，要嘛用這個值把角標
+  /// 推到浮層上方，要嘛確保浮層下方留有角標放得下的透空縫隙（探索頁的地點
+  /// 卡片列走後者，幾何依據見 explore_screen.dart 傳這個參數處的註解）。
+  /// 見 `docs/adr/0005-map-tile-provider.md`。
   final double attributionBottomInset;
 
   @override

--- a/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
+++ b/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
@@ -71,6 +71,33 @@ void main() {
       );
     });
 
+    testWidgets('given place cards are shown, '
+        'when the attribution badge is rendered, '
+        'then the badge sits below the card rail and clear of the cards', (
+      tester,
+    ) async {
+      await _givenExploreScreen(
+        tester,
+        places: [buildPlace(id: 'p1', name: 'Senso-ji')],
+      );
+
+      // 角標放卡片列下方的縫隙（見 explore_screen.dart 的幾何註解）。這裡
+      // 驗實際幾何：卡片的下緣必須在角標上緣之上——署名被蓋掉等同沒有署名
+      // （見 ADR 0005）。
+      final badgeTop = tester
+          .getRect(
+            find.text('OpenFreeMap © OpenMapTiles Data from OpenStreetMap'),
+          )
+          .top;
+      final card = find
+          .ancestor(
+            of: find.text('Senso-ji'),
+            matching: find.byType(Container),
+          )
+          .first;
+      expect(badgeTop, greaterThanOrEqualTo(tester.getRect(card).bottom));
+    });
+
     testWidgets('given nearby places are returned, when the screen loads, '
         'then a place card is rendered for each place', (tester) async {
       final places = [


### PR DESCRIPTION
## Summary

Adjusts the map attribution badge positioning in the explore screen to sit in the gap below the place cards rail rather than being pushed above it. This approach leverages the ListView's built-in bottom padding to ensure cards don't overlap the attribution text.

## Changes

- **explore_screen.dart**: Simplified `attributionBottomInset` calculation to only account for safe area padding instead of also accounting for the card rail height and gap. The badge now sits in the transparent space between the card rail and the screen bottom, with the ListView's 8px bottom padding preventing card overlap.

- **explore_screen_test.dart**: Added new test case verifying the geometric constraint that the badge top position is at or below the card bottom edge, ensuring attribution text remains visible and unobstructed.

- **lorescape_map.dart**: Updated parameter documentation to clarify that callers can either push the badge above overlays using `attributionBottomInset`, or ensure transparent gaps below overlays for the badge to fit (as the explore screen now does).

- **docs/adr/0005-map-tile-provider.md**: Updated ADR to document both positioning strategies and note the explore screen's adoption of the gap-based approach as of 2026-07-30.

## Implementation Details

The badge height (16px: 12px text + 2px padding top/bottom) exceeds the `railBottomGap` (12px), but the ListView's 8px bottom padding ensures cards remain 4px above the badge top, preventing attribution obscuration. This satisfies the licensing requirement that attribution must not be covered (per ADR 0005).

https://claude.ai/code/session_01WrdAwnd9iRAjUsAgPNgPyT