### PR TITLE
Improve story rail flick gesture and locate button UI

### DIFF
--- a/frontend/lib/features/home/presentation/screens/globe_home_screen.dart
+++ b/frontend/lib/features/home/presentation/screens/globe_home_screen.dart
@@ -207,27 +207,14 @@ class _LocateButton extends StatelessWidget {
         onTap: onPressed,
         child: Container(
           width: 56,
-          padding: const EdgeInsets.symmetric(vertical: 10),
+          height: 56,
+          alignment: Alignment.center,
           decoration: BoxDecoration(
             color: tokens.clay,
-            borderRadius: BorderRadius.circular(999),
+            shape: BoxShape.circle,
             boxShadow: tokens.e2,
           ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(Icons.my_location, size: 22, color: tokens.paperRaised),
-              const SizedBox(height: 3),
-              Text(
-                'home.locate'.tr(),
-                style: TextStyle(
-                  fontSize: 10.5,
-                  fontWeight: FontWeight.w700,
-                  color: tokens.paperRaised,
-                ),
-              ),
-            ],
-          ),
+          child: Icon(Icons.my_location, size: 22, color: tokens.paperRaised),
         ),
       ),
     );

--- a/frontend/lib/features/home/presentation/widgets/story_rail.dart
+++ b/frontend/lib/features/home/presentation/widgets/story_rail.dart
@@ -158,8 +158,20 @@ class _SnapScrollPhysics extends ScrollPhysics {
     );
   }
 
-  double _targetPixels(ScrollMetrics position) {
-    final page = position.pixels / itemExtent;
+  /// 跟 [PageScrollPhysics] 一樣把甩動速度算進去：只要甩動快過
+  /// [Tolerance.velocity]，就往甩動方向偏半張卡再取整——輕甩即可換到
+  /// 下一張，不必實際拖超過半張卡的距離。
+  double _targetPixels(
+    ScrollMetrics position,
+    Tolerance tolerance,
+    double velocity,
+  ) {
+    var page = position.pixels / itemExtent;
+    if (velocity < -tolerance.velocity) {
+      page -= 0.5;
+    } else if (velocity > tolerance.velocity) {
+      page += 0.5;
+    }
     return page.roundToDouble() * itemExtent;
   }
 
@@ -177,6 +189,8 @@ class _SnapScrollPhysics extends ScrollPhysics {
     final tolerance = toleranceFor(position);
     final target = _targetPixels(
       position,
+      tolerance,
+      velocity,
     ).clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((target - position.pixels).abs() < tolerance.distance) return null;
     return ScrollSpringSimulation(

--- a/frontend/test/features/home/presentation/widgets/story_rail_test.dart
+++ b/frontend/test/features/home/presentation/widgets/story_rail_test.dart
@@ -106,4 +106,28 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'given the story rail at the first card, '
+    'when the user flicks quickly but drags less than half a card, '
+    'then it still advances to the next card instead of springing back',
+    (tester) async {
+      await _givenRail(tester, count: 8);
+
+      // 拖動距離只有 80px（遠小於半張卡的 162px），靠甩動速度換卡。
+      await tester.fling(find.byType(ListView), const Offset(-80, 0), 1200);
+      await tester.pumpAndSettle();
+
+      final offset = tester
+          .widget<ListView>(find.byType(ListView))
+          .controller!
+          .offset;
+
+      expect(
+        offset,
+        closeTo(StoryRail.stride, 1.0),
+        reason: '輕甩就該前進一張卡，不必實際拖超過半張卡的距離',
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Summary
Enhances the story rail's gesture handling to support quick flicks with minimal drag distance, and simplifies the locate button design to a circular icon-only button.

## Key Changes

### Story Rail Flick Gesture (story_rail.dart)
- Modified `_SnapScrollPhysics._targetPixels()` to accept `tolerance` and `velocity` parameters
- Implements velocity-aware snapping: flicks faster than `Tolerance.velocity` now advance/retreat by 0.5 cards before rounding, allowing quick flicks to change cards without dragging past the halfway point
- Behavior mirrors `PageScrollPhysics` for consistent UX

### Locate Button Redesign (globe_home_screen.dart)
- Replaced vertical layout (icon + label) with a simple circular button
- Changed from `padding` + `borderRadius` to explicit `height: 56` + `shape: BoxShape.circle`
- Removed text label ("home.locate") and simplified to icon-only design
- Maintains shadow and color styling

### Test Coverage (story_rail_test.dart)
- Added test case verifying that an 80px flick at 1200 velocity advances to the next card (without requiring the typical 162px drag threshold)
- Validates the velocity-aware snapping behavior

## Implementation Details
The velocity threshold check uses `tolerance.velocity` to determine if a gesture qualifies as a "flick," allowing the physics engine to bias the snap target toward the next/previous card even with minimal drag distance. This improves the feel of quick navigation gestures.

https://claude.ai/code/session_01RmdSv9x1ZHS1XuyjVGKfKj