### PR TITLE
探索頁搜尋載入遮罩＋故事生成頁整頁動畫

### DIFF
--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -33,16 +33,26 @@
   "config_screen": {
     "title": "Select Narration Depth",
     "start_button": "Start Guide",
-    "generating": "Generating narration...",
     "generation_error_title": "Generation Failed",
     "generation_error_message": "Failed to generate narration. Please try again later.",
     "generation_insufficient_source_title": "No story to tell",
     "generation_insufficient_source_message": "Wikipedia has no historical figures or events recorded for this place, so we can't tell you a real story here. Try another spot.",
     "generation_error_ok": "OK"
   },
+  "story_generating": {
+    "scan_title": "Unearthing the story of {}",
+    "scan_sub": "Sifting local records, old photos and archives for threads worth telling",
+    "scan_step_1": "Searching Wikipedia and archives",
+    "scan_step_2": "Matching people and events to this place",
+    "scan_step_3": "Curating story angles worth hearing",
+    "write_title": "Writing \"{}\"",
+    "write_sub": "Lorescape is turning the sources into a story you can listen to",
+    "write_step_1": "Organizing sources and timeline",
+    "write_step_2": "Drafting the narration",
+    "write_step_3": "Polishing tone and pacing"
+  },
   "story_hook": {
     "title": "Which story do you want to hear?",
-    "loading": "Digging up this place's history...",
     "fallback_title": "A historical story",
     "fallback_body": "No specific story threads found right now, but we can still share a historical story about this place.",
     "listen_default_button": "Just play a story",

--- a/frontend/assets/translations/en.json
+++ b/frontend/assets/translations/en.json
@@ -143,6 +143,8 @@
     "back_to_globe": "Back to globe",
     "refresh": "Refresh",
     "search_hint": "Search for places, cities, or landmarks…",
+    "searching": "Searching places",
+    "locating": "Locating",
     "empty": "No places found",
     "filter": {
       "title": "Filters",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -144,6 +144,8 @@
     "back_to_globe": "回到地球儀",
     "refresh": "重新整理",
     "search_hint": "搜尋地點、城市或地標……",
+    "searching": "搜尋地點中",
+    "locating": "定位中",
     "empty": "找不到符合的地點",
     "filter": {
       "title": "篩選條件",

--- a/frontend/assets/translations/zh-TW.json
+++ b/frontend/assets/translations/zh-TW.json
@@ -33,16 +33,26 @@
   "config_screen": {
     "title": "選擇解說深度",
     "start_button": "開始導覽",
-    "generating": "正在生成導覽內容...",
     "generation_error_title": "生成失敗",
     "generation_error_message": "導覽內容生成失敗，請稍後再試。",
     "generation_insufficient_source_title": "找不到歷史故事",
     "generation_insufficient_source_message": "我們在維基百科上找不到這個景點的歷史人物或事件，沒辦法為您講一段真實故事。請選擇其他景點試試。",
     "generation_error_ok": "確定"
   },
+  "story_generating": {
+    "scan_title": "正在挖掘「{}」的故事",
+    "scan_sub": "從地方志、老照片與檔案中找出可講的線索",
+    "scan_step_1": "翻查 Wikipedia 與史料",
+    "scan_step_2": "比對這個地點的人物與事件",
+    "scan_step_3": "整理出可講的故事線",
+    "write_title": "正在寫下《{}》",
+    "write_sub": "Lorescape 正把史料寫成一段可以聽的敘事",
+    "write_step_1": "梳理史料與時間軸",
+    "write_step_2": "撰寫可朗讀的敘事",
+    "write_step_3": "潤飾語氣與節奏"
+  },
   "story_hook": {
     "title": "想聽哪段故事？",
-    "loading": "正在挖掘這裡的歷史故事...",
     "fallback_title": "歷史故事",
     "fallback_body": "暫時找不到特定的故事線索，仍然可以直接聽一段這個地方的歷史。",
     "listen_default_button": "直接聽故事",

--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -13,6 +13,7 @@ import 'package:context_app/features/settings/providers.dart';
 import 'package:context_app/shared/widgets/journal/category_tag.dart';
 import 'package:context_app/shared/widgets/journal/glyph_thumb.dart';
 import 'package:context_app/shared/widgets/journal/masthead.dart';
+import 'package:context_app/shared/widgets/journal/search_loader.dart';
 import 'package:context_app/shared/widgets/midnight/_press_scale.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -38,6 +39,14 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
   /// 設計稿：點卡片時 `flyTo(coord, 14)`。
   static const double _kFocusZoom = 14;
 
+  /// 載入遮罩（設計稿 `.search-loader`）的文案模式：定位（附近地點）用
+  /// 「定位中」，其餘搜尋用「搜尋地點中」。在每個觸發點更新，因為
+  /// AsyncValue.loading 本身分不出這次是哪種操作。
+  bool _loadingIsLocate = true;
+
+  /// 關鍵字搜尋時顯示在遮罩上的搜尋詞；定位與可視範圍重搜沒有關鍵字。
+  String? _loadingName;
+
   void _focusOn(Place place) {
     _mapController.move(
       LatLng(place.location.latitude, place.location.longitude),
@@ -51,6 +60,10 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
     final query = widget.initialQuery;
     if (query == null || query.isEmpty) return;
     _searchController.text = query;
+    // 首次載入的 nearby search 也還在跑，但使用者是為了這個關鍵字進來的，
+    // 遮罩從頭到尾都顯示這個搜尋詞。
+    _loadingIsLocate = false;
+    _loadingName = query;
     // build 期間不能改 provider，等第一幀畫完再送出搜尋。
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -93,6 +106,11 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
   void _searchVisibleArea() {
     _searchController.clear();
     ref.read(searchQueryProvider.notifier).state = '';
+    setState(() {
+      // 可視範圍重搜不問定位，遮罩用「搜尋地點中」但沒有關鍵字可顯示。
+      _loadingIsLocate = false;
+      _loadingName = null;
+    });
 
     final camera = _mapController.camera;
     final bounds = camera.visibleBounds;
@@ -128,7 +146,11 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
     _searchController.clear();
     ref.read(searchQueryProvider.notifier).state = '';
     ref.read(placesControllerProvider.notifier).search('');
-    setState(() {});
+    setState(() {
+      // 清除搜尋回到附近地點模式，走定位。
+      _loadingIsLocate = true;
+      _loadingName = null;
+    });
   }
 
   @override
@@ -181,6 +203,11 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
             onSearchChanged: (_) => setState(() {}),
             onSearchSubmitted: (value) {
               ref.read(searchQueryProvider.notifier).state = value;
+              setState(() {
+                // 空字串 search() 會退回附近地點模式（走定位）。
+                _loadingIsLocate = value.isEmpty;
+                _loadingName = value.isEmpty ? null : value;
+              });
               ref.read(placesControllerProvider.notifier).search(value);
             },
             onSearchClear: _searchController.text.isNotEmpty
@@ -224,6 +251,15 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                   context.canPop() ? context.pop() : context.go('/'),
             ),
           ),
+          // 設計稿的 `.search-loader`：搜尋／定位進行中蓋住整頁的置中載入
+          // 卡。放在 Stack 最上層（z-index 120 的等價位置），連 FAB 一起蓋。
+          if (placesState.isLoading)
+            SearchLoader(
+              label:
+                  (_loadingIsLocate ? 'explore.locating' : 'explore.searching')
+                      .tr(),
+              name: _loadingName,
+            ),
         ],
       ),
     );

--- a/frontend/lib/features/narration/presentation/screens/select_story_hook_screen.dart
+++ b/frontend/lib/features/narration/presentation/screens/select_story_hook_screen.dart
@@ -9,6 +9,7 @@ import 'package:context_app/features/narration/domain/models/story_hook.dart';
 import 'package:context_app/features/narration/presentation/controllers/narration_generation_controller.dart';
 import 'package:context_app/features/narration/presentation/controllers/story_hook_controller.dart';
 import 'package:context_app/features/narration/presentation/widgets/editorial_hero.dart';
+import 'package:context_app/features/narration/presentation/widgets/story_generating.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:context_app/shared/widgets/adaptive/adaptive_widgets.dart';
@@ -160,6 +161,69 @@ class _SelectStoryHookScreenState extends ConsumerState<SelectStoryHookScreen> {
 
     final tokens = Theme.of(context).extension<LorescapeTokens>();
     final isGenerating = generationState.isGenerating;
+    final isHookLoading = hookState.status == StoryHookStatus.loading;
+
+    // 生成中（挖掘故事線或寫完整故事）走設計稿的 `.genscr` 版面：210px
+    // 標頭壓縮到上緣，其餘空間交給 StoryGenerating 的整頁動畫。其他狀態
+    // 維持原本的 editorial 版面（大 hero ＋ 內容往下捲）。
+    if (isGenerating || isHookLoading) {
+      return Scaffold(
+        backgroundColor: tokens?.paper ?? Theme.of(context).colorScheme.surface,
+        body: Stack(
+          children: [
+            Positioned.fill(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _HeroSection(
+                    place: widget.place,
+                    capturedImageBytes: widget.capturedImageBytes,
+                    compact: true,
+                  ),
+                  Expanded(
+                    child: isGenerating
+                        ? StoryGenerating(
+                            key: const ValueKey('gen-write'),
+                            title: 'story_generating.write_title'.tr(
+                              args: [_selectedStoryTitle ?? widget.place.name],
+                            ),
+                            subtitle: 'story_generating.write_sub'.tr(),
+                            steps: [
+                              'story_generating.write_step_1'.tr(),
+                              'story_generating.write_step_2'.tr(),
+                              'story_generating.write_step_3'.tr(),
+                            ],
+                            icon: Icons.edit_outlined,
+                          )
+                        : StoryGenerating(
+                            key: const ValueKey('gen-scan'),
+                            title: 'story_generating.scan_title'.tr(
+                              args: [widget.place.name],
+                            ),
+                            subtitle: 'story_generating.scan_sub'.tr(),
+                            steps: [
+                              'story_generating.scan_step_1'.tr(),
+                              'story_generating.scan_step_2'.tr(),
+                              'story_generating.scan_step_3'.tr(),
+                            ],
+                            icon: Icons.menu_book_outlined,
+                          ),
+                  ),
+                ],
+              ),
+            ),
+            // 挖掘中仍可退出；寫作中維持原本「不可中途離開」的行為（生成
+            // 完成會直接導去播放器，中途離開會讓導頁落在錯的畫面上）。
+            if (!isGenerating)
+              Positioned(
+                top: MediaQuery.of(context).padding.top + 6,
+                left: 14,
+                child: _OnPhotoBackButton(onPressed: () => context.pop()),
+              ),
+          ],
+        ),
+      );
+    }
 
     // Editorial layout (design: `PlaceScreen` in screens_story.jsx): a
     // bounded hero on top, with the generation copy flowing below it on the
@@ -179,25 +243,22 @@ class _SelectStoryHookScreenState extends ConsumerState<SelectStoryHookScreen> {
                   ),
                   Padding(
                     padding: const EdgeInsets.all(22),
-                    child: isGenerating
-                        ? _GenState(message: 'config_screen.generating'.tr())
-                        : _HookContent(
-                            state: hookState,
-                            onHookTap: _onHookSelected,
-                            onListenDefault: () => _onHookSelected(null),
-                            onExplore: () => context.pop(),
-                          ),
+                    child: _HookContent(
+                      state: hookState,
+                      onHookTap: _onHookSelected,
+                      onListenDefault: () => _onHookSelected(null),
+                      onExplore: () => context.pop(),
+                    ),
                   ),
                 ],
               ),
             ),
           ),
-          if (!isGenerating)
-            Positioned(
-              top: MediaQuery.of(context).padding.top + 6,
-              left: 14,
-              child: _OnPhotoBackButton(onPressed: () => context.pop()),
-            ),
+          Positioned(
+            top: MediaQuery.of(context).padding.top + 6,
+            left: 14,
+            child: _OnPhotoBackButton(onPressed: () => context.pop()),
+          ),
         ],
       ),
     );
@@ -211,14 +272,21 @@ class _HeroSection extends StatelessWidget {
   final Place place;
   final Uint8List? capturedImageBytes;
 
-  const _HeroSection({required this.place, this.capturedImageBytes});
+  /// 生成中的壓縮標頭（設計稿 `.genscr__hd`）：固定 210 高、字級縮小、
+  /// 不放分類標籤，把版面讓給底下的生成動畫。
+  final bool compact;
+
+  const _HeroSection({
+    required this.place,
+    this.capturedImageBytes,
+    this.compact = false,
+  });
 
   @override
   Widget build(BuildContext context) {
-    final height = (MediaQuery.of(context).size.height * 0.5).clamp(
-      320.0,
-      440.0,
-    );
+    final height = compact
+        ? 210.0
+        : (MediaQuery.of(context).size.height * 0.5).clamp(320.0, 440.0);
     return SizedBox(
       height: height,
       child: Stack(
@@ -234,7 +302,7 @@ class _HeroSection extends StatelessWidget {
           Positioned(
             left: 22,
             right: 22,
-            bottom: 22,
+            bottom: compact ? 18 : 22,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -242,7 +310,7 @@ class _HeroSection extends StatelessWidget {
                 Text(
                   place.name,
                   style: GoogleFonts.notoSerifTc(
-                    fontSize: 32,
+                    fontSize: compact ? 27 : 32,
                     fontWeight: FontWeight.w700,
                     color: Colors.white,
                     height: 1.12,
@@ -255,11 +323,13 @@ class _HeroSection extends StatelessWidget {
                     ],
                   ),
                 ),
-                const SizedBox(height: 10),
-                CategoryTag(
-                  category: place.category.journalCategory,
-                  onPhoto: true,
-                ),
+                if (!compact) ...[
+                  const SizedBox(height: 10),
+                  CategoryTag(
+                    category: place.category.journalCategory,
+                    onPhoto: true,
+                  ),
+                ],
               ],
             ),
           ),
@@ -314,7 +384,8 @@ class _HookContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (state.status) {
-      StoryHookStatus.loading => _GenState(message: 'story_hook.loading'.tr()),
+      // 載入中由外層的 StoryGenerating 整頁動畫接手，這裡不會被 render 到。
+      StoryHookStatus.loading => const SizedBox.shrink(),
       StoryHookStatus.success => _HookListState(
         hooks: state.hooks,
         onTap: onHookTap,
@@ -325,83 +396,6 @@ class _HookContent extends StatelessWidget {
       StoryHookStatus.empty ||
       StoryHookStatus.error => _HookFallbackState(onListen: onListenDefault),
     };
-  }
-}
-
-/// The "digging up history" loading state (design: `.gen-state`): a clay
-/// spinner with a status line, followed by shimmer placeholder lines on the
-/// warm paper surface.
-class _GenState extends StatelessWidget {
-  const _GenState({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Row(
-          children: [
-            SizedBox(
-              width: 22,
-              height: 22,
-              child: CircularProgressIndicator(
-                strokeWidth: 2.4,
-                color: tokens?.clay ?? cs.primary,
-                backgroundColor: tokens?.claySoft ?? cs.primaryContainer,
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                message,
-                style: TextStyle(
-                  fontSize: 15,
-                  height: 1.4,
-                  color: tokens?.ink2 ?? cs.onSurfaceVariant,
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 18),
-        const _ShimmerLine(widthFactor: 0.92),
-        const SizedBox(height: 18),
-        const _ShimmerLine(widthFactor: 0.78),
-        const SizedBox(height: 18),
-        const _ShimmerLine(widthFactor: 0.85),
-      ],
-    );
-  }
-}
-
-class _ShimmerLine extends StatelessWidget {
-  const _ShimmerLine({required this.widthFactor});
-
-  final double widthFactor;
-
-  @override
-  Widget build(BuildContext context) {
-    final tokens = Theme.of(context).extension<LorescapeTokens>();
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: FractionallySizedBox(
-        widthFactor: widthFactor,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color:
-                tokens?.paperSunk ??
-                Theme.of(context).colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(6),
-          ),
-          child: const SizedBox(height: 14),
-        ),
-      ),
-    );
   }
 }
 

--- a/frontend/lib/features/narration/presentation/widgets/story_generating.dart
+++ b/frontend/lib/features/narration/presentation/widgets/story_generating.dart
@@ -1,0 +1,681 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:context_app/app/config/lorescape_tokens.dart';
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+/// 故事生成中的整頁動畫，對應設計稿的 `.gen`（screens_story.jsx 的
+/// StoryGenerating）：
+///
+/// - 88px 勳章：虛線外環 9s 順轉、實線內環（頂端 clay 弧）6s 逆轉、
+///   兩個交錯的脈衝光暈、中央紙色圓章彈跳進場。
+/// - 襯線標題與說明小字。
+/// - 步驟清單：進行中的 dot 帶漣漪、完成打勾、未到的半透明。
+/// - 底部「手稿卡」：四行文字逐行填入，一支羽毛筆沿著行掃過去，
+///   寫完稍停後換頁重寫（真實生成時間比設計稿的 3.6s 長，凍住會像當機）。
+/// - 最底 2px 進度條。
+///
+/// 步驟只是「感覺有進度」的舞台效果：固定間隔逐步推進，最後一步保持
+/// 進行中直到外層把這個 widget 換掉（API 回來）。切換階段（挖掘 → 寫作）
+/// 時請換 [Key]，讓步驟與筆跡從頭開始。
+class StoryGenerating extends StatefulWidget {
+  const StoryGenerating({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.steps,
+    this.icon = Icons.menu_book_outlined,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<String> steps;
+
+  /// 勳章中央的圖示（挖掘用書本、寫作用筆）。
+  final IconData icon;
+
+  /// 每隔多久推進一個步驟。
+  static const Duration stepInterval = Duration(milliseconds: 2600);
+
+  @override
+  State<StoryGenerating> createState() => _StoryGeneratingState();
+}
+
+class _StoryGeneratingState extends State<StoryGenerating>
+    with TickerProviderStateMixin {
+  late final AnimationController _outerRing = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 9),
+  )..repeat();
+  late final AnimationController _innerRing = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 6),
+  )..repeat();
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 2200),
+  )..repeat();
+  late final AnimationController _blip = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1400),
+  )..repeat();
+  late final AnimationController _write = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 4600),
+  )..repeat();
+
+  /// 進度條慢慢逼近 95% 後停住：真實生成時間未知，跑滿會像「完成了卻
+  /// 沒反應」，比停在九成五更糟。
+  late final AnimationController _bar = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 18),
+  )..forward();
+
+  int _activeStep = 0;
+  Timer? _stepTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _stepTimer = Timer.periodic(StoryGenerating.stepInterval, (timer) {
+      if (_activeStep >= widget.steps.length - 1) {
+        timer.cancel();
+        return;
+      }
+      setState(() => _activeStep += 1);
+    });
+  }
+
+  @override
+  void dispose() {
+    _stepTimer?.cancel();
+    _outerRing.dispose();
+    _innerRing.dispose();
+    _pulse.dispose();
+    _blip.dispose();
+    _write.dispose();
+    _bar.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(26, 24, 26, 30),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: Center(
+              // 小螢幕（或測試的 600px 視窗）擠不下時捲動，而不是 overflow。
+              child: SingleChildScrollView(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _Medal(
+                      outerTurns: _outerRing,
+                      innerTurns: _innerRing,
+                      pulse: _pulse,
+                      icon: widget.icon,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      widget.title,
+                      textAlign: TextAlign.center,
+                      style: GoogleFonts.notoSerifTc(
+                        fontSize: 21,
+                        fontWeight: FontWeight.w700,
+                        height: 1.35,
+                        color: tokens.ink,
+                      ),
+                    ),
+                    const SizedBox(height: 7),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 250),
+                      child: Text(
+                        widget.subtitle,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 13,
+                          height: 1.55,
+                          color: tokens.ink3,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 18),
+                    for (final (index, step) in widget.steps.indexed)
+                      Padding(
+                        padding: EdgeInsets.only(top: index == 0 ? 0 : 10),
+                        child: _StepRow(
+                          label: step,
+                          isDone: index < _activeStep,
+                          isActive: index == _activeStep,
+                          blip: _blip,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          _WritingPage(progress: _write),
+          const SizedBox(height: 14),
+          _ProgressBar(progress: _bar),
+        ],
+      ),
+    );
+  }
+}
+
+/// `.gen__medal`：雙環＋脈衝＋中央圓章。
+class _Medal extends StatelessWidget {
+  const _Medal({
+    required this.outerTurns,
+    required this.innerTurns,
+    required this.pulse,
+    required this.icon,
+  });
+
+  final Animation<double> outerTurns;
+  final Animation<double> innerTurns;
+  final Animation<double> pulse;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return SizedBox(
+      width: 88,
+      height: 88,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          // 兩個交錯的脈衝光暈（`.gen__pulse` / `--b`，錯開半個週期）。
+          AnimatedBuilder(
+            animation: pulse,
+            builder: (context, _) => Stack(
+              alignment: Alignment.center,
+              children: [
+                for (final phase in [pulse.value, (pulse.value + 0.5) % 1])
+                  Opacity(
+                    opacity: 0.22 * (1 - phase),
+                    child: Transform.scale(
+                      scale: 0.7 + 0.85 * phase,
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          color: tokens.clay,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const SizedBox(width: 52, height: 52),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          RotationTransition(
+            turns: outerTurns,
+            child: CustomPaint(
+              size: const Size(88, 88),
+              painter: _DashedRingPainter(
+                color: tokens.clay.withValues(alpha: 0.55),
+              ),
+            ),
+          ),
+          RotationTransition(
+            turns: ReverseAnimation(innerTurns),
+            child: CustomPaint(
+              size: const Size(60, 60),
+              painter: _InnerRingPainter(
+                base: tokens.claySoft,
+                accent: tokens.clay,
+              ),
+            ),
+          ),
+          // `.gen__ic`：彈跳進場的中央圓章。
+          TweenAnimationBuilder<double>(
+            tween: Tween(begin: 0, end: 1),
+            duration: const Duration(milliseconds: 380),
+            curve: Curves.easeOutBack,
+            builder: (context, t, child) => Opacity(
+              opacity: t.clamp(0, 1),
+              child: Transform.rotate(
+                angle: (1 - t) * -12 * math.pi / 180,
+                child: Transform.scale(scale: 0.6 + 0.4 * t, child: child),
+              ),
+            ),
+            child: Container(
+              width: 48,
+              height: 48,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: tokens.paperRaised,
+                shape: BoxShape.circle,
+                boxShadow: tokens.e2,
+              ),
+              child: Icon(icon, size: 22, color: tokens.clay),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 1.5px 虛線圓環（`.gen__ring`）。
+class _DashedRingPainter extends CustomPainter {
+  const _DashedRingPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..color = color;
+    final radius = size.width / 2 - 0.75;
+    final center = size.center(Offset.zero);
+    const dashCount = 26;
+    const sweep = 2 * math.pi / dashCount;
+    for (var i = 0; i < dashCount; i++) {
+      canvas.drawArc(
+        Rect.fromCircle(center: center, radius: radius),
+        i * sweep,
+        sweep * 0.55,
+        false,
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_DashedRingPainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+/// 內環（`.gen__ring--in`）：整圈 clay-soft，頂端四分之一圈 clay。
+class _InnerRingPainter extends CustomPainter {
+  const _InnerRingPainter({required this.base, required this.accent});
+
+  final Color base;
+  final Color accent;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Rect.fromCircle(
+      center: size.center(Offset.zero),
+      radius: size.width / 2 - 0.75,
+    );
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..color = base;
+    canvas.drawArc(rect, 0, 2 * math.pi, false, paint);
+    // CSS 圓形只上 border-top-color 時，上色的是頂端四分之一圈。
+    canvas.drawArc(
+      rect,
+      -3 * math.pi / 4,
+      math.pi / 2,
+      false,
+      paint..color = accent,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_InnerRingPainter oldDelegate) =>
+      oldDelegate.base != base || oldDelegate.accent != accent;
+}
+
+/// `.gen__step`：一列步驟（dot ＋ 文字）。
+class _StepRow extends StatelessWidget {
+  const _StepRow({
+    required this.label,
+    required this.isDone,
+    required this.isActive,
+    required this.blip,
+  });
+
+  final String label;
+  final bool isDone;
+  final bool isActive;
+  final Animation<double> blip;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return AnimatedOpacity(
+      opacity: isDone || isActive ? 1 : 0.42,
+      duration: const Duration(milliseconds: 350),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: isDone
+                ? DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: tokens.clay,
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(
+                      Icons.check,
+                      size: 13,
+                      color: Color(0xFFFBF1E9),
+                    ),
+                  )
+                : Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      if (isActive)
+                        AnimatedBuilder(
+                          animation: blip,
+                          builder: (context, _) => CustomPaint(
+                            size: const Size(20, 20),
+                            painter: _BlipPainter(
+                              color: tokens.clay,
+                              t: blip.value,
+                            ),
+                          ),
+                        ),
+                      DecoratedBox(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: isActive ? tokens.clay : tokens.lineStrong,
+                            width: 1.5,
+                          ),
+                        ),
+                        child: const SizedBox(width: 20, height: 20),
+                      ),
+                    ],
+                  ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: AnimatedDefaultTextStyle(
+              duration: const Duration(milliseconds: 300),
+              style: TextStyle(
+                fontSize: 15,
+                fontWeight: isActive ? FontWeight.w600 : FontWeight.w400,
+                color: isActive ? tokens.ink : tokens.ink2,
+              ),
+              child: Text(label),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 進行中步驟的漣漪（`gen-blip` 的 box-shadow 外擴）。
+class _BlipPainter extends CustomPainter {
+  const _BlipPainter({required this.color, required this.t});
+
+  final Color color;
+  final double t;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.5
+      ..color = color.withValues(alpha: 0.45 * (1 - t));
+    canvas.drawCircle(size.center(Offset.zero), 10 + 9 * t, paint);
+  }
+
+  @override
+  bool shouldRepaint(_BlipPainter oldDelegate) =>
+      oldDelegate.t != t || oldDelegate.color != color;
+}
+
+/// `.gen__page`：底部手稿卡——四行文字逐行填入＋羽毛筆掃行。
+///
+/// 時間軸照設計稿的 `gen-quill` keyframes：每行掃約 22%，行距間 3% 快速
+/// 回行；controller 的最後 8% 是整頁寫滿的停頓，之後換頁重寫。
+class _WritingPage extends StatelessWidget {
+  const _WritingPage({required this.progress});
+
+  final Animation<double> progress;
+
+  /// 每行的 (開始, 結束, 行末位置)；行末位置同時是該行文字的目標寬度。
+  static const List<(double, double, double)> _lines = [
+    (0.00, 0.22, 0.88),
+    (0.25, 0.47, 0.82),
+    (0.50, 0.72, 0.86),
+    (0.75, 0.92, 0.68),
+  ];
+
+  static const double _rowHeight = 11;
+  static const double _rowGap = 11;
+
+  /// 寫字段落佔整個週期的比例，其餘是寫滿後的停頓。
+  static const double _writeSpan = 0.92;
+
+  double _fillFor(int index, double t) {
+    final (start, end, width) = _lines[index];
+    return (((t - start) / (end - start)).clamp(0.0, 1.0)) * width;
+  }
+
+  /// 羽毛筆現在的（行進度 x、行 index y），沿設計稿 keyframes 折線走。
+  (double, double) _quillAt(double t) {
+    for (var i = 0; i < _lines.length; i++) {
+      final (start, end, width) = _lines[i];
+      if (t < start) {
+        // 行距間的快速回行：從上一行行末拉回本行起點。
+        final (_, prevEnd, prevWidth) = _lines[i - 1];
+        final q = (t - prevEnd) / (start - prevEnd);
+        return (prevWidth + (0.02 - prevWidth) * q, (i - 1) + q);
+      }
+      if (t <= end) {
+        final q = (t - start) / (end - start);
+        return (0.02 + (width - 0.02) * q, i.toDouble());
+      }
+    }
+    final (_, _, lastWidth) = _lines.last;
+    return (lastWidth, (_lines.length - 1).toDouble());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    final inkFill = tokens.ink.withValues(alpha: 0.27);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(18, 20, 18, 16),
+      decoration: BoxDecoration(
+        color: tokens.paperRaised,
+        border: Border.all(color: tokens.line),
+        borderRadius: BorderRadius.circular(tokens.rLg),
+        boxShadow: tokens.e1,
+      ),
+      child: AnimatedBuilder(
+        animation: progress,
+        builder: (context, _) {
+          final t = (progress.value / _writeSpan).clamp(0.0, 1.0);
+          final (quillX, quillLine) = _quillAt(t);
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              final width = constraints.maxWidth;
+              return Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Column(
+                    children: [
+                      for (var i = 0; i < _lines.length; i++)
+                        Padding(
+                          padding: EdgeInsets.only(top: i == 0 ? 0 : _rowGap),
+                          child: _WritingRow(
+                            fill: _fillFor(i, t),
+                            fillColor: inkFill,
+                            background: tokens.paperSunk,
+                          ),
+                        ),
+                    ],
+                  ),
+                  Positioned(
+                    left: quillX * width - 3,
+                    top: quillLine * (_rowHeight + _rowGap) - 22,
+                    child: Opacity(
+                      opacity: (t / 0.04).clamp(0.0, 1.0),
+                      child: _Quill(color: tokens.clayDeep),
+                    ),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _WritingRow extends StatelessWidget {
+  const _WritingRow({
+    required this.fill,
+    required this.fillColor,
+    required this.background,
+  });
+
+  final double fill;
+  final Color fillColor;
+  final Color background;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: _WritingPage._rowHeight,
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(5),
+      ),
+      alignment: Alignment.centerLeft,
+      child: FractionallySizedBox(
+        widthFactor: fill,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: fillColor,
+            borderRadius: BorderRadius.circular(5),
+          ),
+          child: const SizedBox(height: _WritingPage._rowHeight),
+        ),
+      ),
+    );
+  }
+}
+
+/// 微微擺動的羽毛筆（`.gen__quill` ＋ `gen-bob`）。
+class _Quill extends StatefulWidget {
+  const _Quill({required this.color});
+
+  final Color color;
+
+  @override
+  State<_Quill> createState() => _QuillState();
+}
+
+class _QuillState extends State<_Quill> with SingleTickerProviderStateMixin {
+  late final AnimationController _bob = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 280),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _bob.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _bob,
+      builder: (context, child) => Transform.rotate(
+        // gen-bob：-2.5° ↔ +1.5° 的小幅擺動，筆尖為軸心。
+        angle: (-2.5 + 4 * _bob.value) * math.pi / 180,
+        alignment: Alignment.bottomLeft,
+        child: child,
+      ),
+      child: CustomPaint(
+        size: const Size(20, 26),
+        painter: _QuillPainter(color: widget.color),
+      ),
+    );
+  }
+}
+
+/// 手繪羽毛筆：葉形羽身＋筆桿＋筆尖墨點。
+class _QuillPainter extends CustomPainter {
+  const _QuillPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final feather = Path()
+      ..moveTo(4.5, 21)
+      ..quadraticBezierTo(2.5, 9, 15, 2)
+      ..quadraticBezierTo(19.5, 8.5, 8, 19)
+      ..close();
+    canvas.drawShadow(feather, const Color(0x383C2819), 3, false);
+    canvas.drawPath(feather, Paint()..color = color);
+    // 筆桿。
+    canvas.drawLine(
+      const Offset(4.5, 21),
+      const Offset(1.5, 25.5),
+      Paint()
+        ..color = color
+        ..strokeWidth = 1.6
+        ..strokeCap = StrokeCap.round,
+    );
+    // 筆尖墨點（`.gen__nib`）。
+    canvas.drawCircle(
+      const Offset(1.5, 25.5),
+      2.2,
+      Paint()..color = color.withValues(alpha: 0.75),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_QuillPainter oldDelegate) => oldDelegate.color != color;
+}
+
+/// `.gen__bar`：2px 進度條。
+class _ProgressBar extends StatelessWidget {
+  const _ProgressBar({required this.progress});
+
+  final Animation<double> progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return AnimatedBuilder(
+      animation: progress,
+      builder: (context, _) {
+        final eased = Curves.easeOutCubic.transform(progress.value);
+        return Container(
+          height: 2,
+          decoration: BoxDecoration(
+            color: tokens.line,
+            borderRadius: BorderRadius.circular(2),
+          ),
+          alignment: Alignment.centerLeft,
+          child: FractionallySizedBox(
+            widthFactor: 0.95 * eased,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: tokens.clay,
+                borderRadius: BorderRadius.circular(2),
+              ),
+              child: const SizedBox(height: 2),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/frontend/lib/shared/widgets/journal/search_loader.dart
+++ b/frontend/lib/shared/widgets/journal/search_loader.dart
@@ -1,0 +1,185 @@
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:context_app/app/config/lorescape_tokens.dart';
+import 'package:flutter/material.dart';
+
+/// 搜尋／定位進行中的全螢幕遮罩，對應設計稿的 `.search-loader`：
+/// 半透明墨色底加輕微模糊，中央一張浮起紙卡，左側雙環 spinner，
+/// 右側是主標與（可選的）搜尋關鍵字小字。
+///
+/// 設計上蓋住整個畫面、吃掉所有觸控——搜尋中不該再拖地圖或連按重新整理。
+/// 只能放在全螢幕的 [Stack] 裡（自帶 [Positioned.fill]）。
+class SearchLoader extends StatelessWidget {
+  const SearchLoader({super.key, required this.label, this.name});
+
+  /// 主標（「搜尋地點中」／「定位中」）。沒有 [name] 時尾端補上刪節號。
+  final String label;
+
+  /// 搜尋關鍵字；設計稿以全大寫小字顯示在主標下方。
+  final String? name;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return Positioned.fill(
+      child: TweenAnimationBuilder<double>(
+        tween: Tween(begin: 0, end: 1),
+        duration: const Duration(milliseconds: 200),
+        builder: (context, t, child) => Opacity(opacity: t, child: child),
+        child: ClipRect(
+          child: BackdropFilter(
+            filter: ui.ImageFilter.blur(sigmaX: 2, sigmaY: 2),
+            child: Container(
+              color: const Color.fromRGBO(23, 18, 13, 0.24),
+              alignment: Alignment.center,
+              child: TweenAnimationBuilder<double>(
+                tween: Tween(begin: 0, end: 1),
+                duration: const Duration(milliseconds: 320),
+                curve: Curves.easeOutBack,
+                builder: (context, t, child) =>
+                    Transform.scale(scale: 0.9 + 0.1 * t, child: child),
+                child: Container(
+                  padding: const EdgeInsets.fromLTRB(20, 18, 24, 18),
+                  decoration: BoxDecoration(
+                    color: tokens.paperRaised,
+                    border: Border.all(color: tokens.line),
+                    borderRadius: BorderRadius.circular(tokens.rLg),
+                    boxShadow: tokens.e3,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      _DualRing(
+                        outerColor: tokens.clay,
+                        innerColor: tokens.clayDeep.withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(width: 16),
+                      Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            name == null ? '$label……' : label,
+                            style: Theme.of(context).textTheme.titleLarge
+                                ?.copyWith(fontSize: 16, letterSpacing: 0.3),
+                          ),
+                          if (name case final name?)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 4),
+                              child: Text(
+                                name.toUpperCase(),
+                                key: const Key('search-loader-name'),
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w700,
+                                  letterSpacing: 1.3,
+                                  color: tokens.clay,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 設計稿 `.search-loader__ring`：40px 內外兩圈四分之一弧，外圈 clay 順時針
+/// 0.8s 一圈、內圈 clay-deep 半透明逆時針 1.1s 一圈。
+///
+/// 用一支 8.8 秒（0.8 與 1.1 的最小公倍數）的 controller 驅動兩圈：外圈轉
+/// 11 圈、內圈反向轉 8 圈，週期交界處角度連續，repeat 不會跳格。
+class _DualRing extends StatefulWidget {
+  const _DualRing({required this.outerColor, required this.innerColor});
+
+  final Color outerColor;
+  final Color innerColor;
+
+  @override
+  State<_DualRing> createState() => _DualRingState();
+}
+
+class _DualRingState extends State<_DualRing>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 8800),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) => CustomPaint(
+        size: const Size(40, 40),
+        painter: _DualRingPainter(
+          outerAngle: _controller.value * 11 * 2 * math.pi,
+          innerAngle: -_controller.value * 8 * 2 * math.pi,
+          outerColor: widget.outerColor,
+          innerColor: widget.innerColor,
+        ),
+      ),
+    );
+  }
+}
+
+class _DualRingPainter extends CustomPainter {
+  const _DualRingPainter({
+    required this.outerAngle,
+    required this.innerAngle,
+    required this.outerColor,
+    required this.innerColor,
+  });
+
+  final double outerAngle;
+  final double innerAngle;
+  final Color outerColor;
+  final Color innerColor;
+
+  static const double _stroke = 3;
+
+  /// CSS 圓形只上 border-top-color 時，上色的是頂端四分之一圈。
+  static const double _sweep = math.pi / 2;
+
+  void _arc(Canvas canvas, Size size, double inset, double angle, Color color) {
+    final rect = Offset(inset, inset) & Size.square(size.width - inset * 2);
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _stroke
+      ..color = color;
+    canvas.drawArc(
+      rect.deflate(_stroke / 2),
+      angle - math.pi / 2 - _sweep / 2,
+      _sweep,
+      false,
+      paint,
+    );
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _arc(canvas, size, 0, outerAngle, outerColor);
+    _arc(canvas, size, 7, innerAngle, innerColor);
+  }
+
+  @override
+  bool shouldRepaint(_DualRingPainter oldDelegate) =>
+      oldDelegate.outerAngle != outerAngle ||
+      oldDelegate.innerAngle != innerAngle ||
+      oldDelegate.outerColor != outerColor ||
+      oldDelegate.innerColor != innerColor;
+}

--- a/frontend/test/fakes/fake_narration_service.dart
+++ b/frontend/test/fakes/fake_narration_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:context_app/features/explore/domain/models/place.dart';
 import 'package:context_app/features/narration/domain/models/story_hook.dart';
 import 'package:context_app/features/narration/domain/services/narration_service.dart';
@@ -7,6 +9,10 @@ import 'package:context_app/features/settings/domain/models/language.dart';
 class FakeNarrationService implements NarrationService {
   final String text;
   final Exception? error;
+
+  /// 設定後 [generateNarration] 會停在 pending 直到 gate 完成——用來在
+  /// 測試裡觀察「生成中」的畫面。
+  Completer<void>? gate;
 
   Place? lastPlace;
   StoryHook? lastHook;
@@ -28,6 +34,7 @@ class FakeNarrationService implements NarrationService {
     lastPlace = place;
     lastHook = hook;
     lastLanguage = language;
+    if (gate != null) await gate!.future;
     if (error != null) throw error!;
     return (text: text, grounding: null);
   }

--- a/frontend/test/fakes/fake_places_repository.dart
+++ b/frontend/test/fakes/fake_places_repository.dart
@@ -30,6 +30,10 @@ class FakePlacesRepository implements PlacesRepository {
   /// 是哪一套語言判定。
   Language? lastSuggestLanguage;
 
+  /// 模擬網路延遲。預設零；要在測試裡觀察「載入中」的畫面時設成非零值，
+  /// 記得在斷言後把延遲 pump 完，否則 tear-down 會抱怨 Timer 未結束。
+  Duration delay = Duration.zero;
+
   FakePlacesRepository({
     this.nearbyPlaces = const [],
     this.searchResults = const [],
@@ -44,6 +48,7 @@ class FakePlacesRepository implements PlacesRepository {
     nearbyCallCount += 1;
     lastNearbyCenter = location;
     lastNearbyRadius = radius;
+    if (delay != Duration.zero) await Future<void>.delayed(delay);
     return nearbyPlaces;
   }
 
@@ -54,6 +59,7 @@ class FakePlacesRepository implements PlacesRepository {
   }) async {
     searchCallCount += 1;
     lastSearchQuery = query;
+    if (delay != Duration.zero) await Future<void>.delayed(delay);
     return searchResults;
   }
 

--- a/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
+++ b/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:context_app/features/explore/presentation/widgets/place_map_pin.
 import 'package:context_app/features/explore/providers.dart';
 import 'package:context_app/features/saved_locations/providers.dart';
 import 'package:context_app/shared/widgets/journal/masthead.dart';
+import 'package:context_app/shared/widgets/journal/search_loader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -456,6 +457,107 @@ void main() {
 
         expect(repo.lastSearchQuery, '京都');
       });
+    });
+
+    group('search loader', () {
+      testWidgets(
+        'given a slow search, when the user submits a query, '
+        'then the centred loader shows the searching copy with the query, '
+        'and disappears once results arrive',
+        (tester) async {
+          final repo = FakePlacesRepository(
+            nearbyPlaces: [buildPlace(id: 'p1', name: 'Nearby Place')],
+            searchResults: [buildPlace(id: 's1', name: 'Searched Place')],
+          );
+          await _givenExploreScreen(tester, repo: repo);
+          repo.delay = const Duration(milliseconds: 400);
+
+          await tester.enterText(find.byType(TextField), '京都');
+          await tester.testTextInput.receiveAction(TextInputAction.done);
+          await tester.pump(const Duration(milliseconds: 20));
+
+          expect(find.byType(SearchLoader), findsOneWidget);
+          expect(find.text('explore.searching'), findsOneWidget);
+          expect(
+            tester
+                .widget<Text>(find.byKey(const Key('search-loader-name')))
+                .data,
+            '京都',
+          );
+
+          await tester.pump(const Duration(milliseconds: 500));
+          expect(find.byType(SearchLoader), findsNothing);
+          expect(find.text('Searched Place'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'given a slow nearby lookup, when the screen is still loading, '
+        'then the loader shows the locating copy without a place name',
+        (tester) async {
+          final repo = FakePlacesRepository(
+            nearbyPlaces: [buildPlace(id: 'p1', name: 'Nearby Place')],
+          )..delay = const Duration(milliseconds: 400);
+
+          // 不走 _givenExploreScreen：它會把載入整段 pump 完，看不到
+          // 載入中的畫面。
+          await pumpScreen(
+            tester,
+            child: const ExploreScreen(),
+            overrides: [
+              locationServiceProvider.overrideWithValue(
+                FakeLocationService(
+                  location: const PlaceLocation(
+                    latitude: 25.0,
+                    longitude: 121.0,
+                  ),
+                ),
+              ),
+              placesRepositoryProvider.overrideWithValue(repo),
+              savedLocationsRepositoryProvider.overrideWithValue(
+                InMemorySavedLocationsRepository(),
+              ),
+              dailyStoryRepositoryProvider.overrideWithValue(
+                InMemoryDailyStoryRepository(),
+              ),
+              ...fakeMapStyleOverrides(),
+            ],
+          );
+          await tester.pump(const Duration(milliseconds: 20));
+
+          expect(find.byType(SearchLoader), findsOneWidget);
+          expect(find.textContaining('explore.locating'), findsOneWidget);
+          expect(find.byKey(const Key('search-loader-name')), findsNothing);
+
+          // 把延遲與地圖排程的 timer 跑完，避免 tear-down 抱怨 Timer 未結束。
+          await tester.pump(const Duration(milliseconds: 500));
+          await settleMapTimers(tester);
+        },
+      );
+
+      testWidgets(
+        'given places on screen, when the user taps refresh, '
+        'then the loader shows the searching copy while the area search runs',
+        (tester) async {
+          final repo = FakePlacesRepository(
+            nearbyPlaces: [buildPlace(id: 'p1', name: 'Nearby')],
+          );
+          await _givenExploreScreen(tester, repo: repo);
+          repo.delay = const Duration(milliseconds: 400);
+
+          await tester.tap(find.byIcon(Icons.refresh));
+          await tester.pump(const Duration(milliseconds: 20));
+
+          // 以可視範圍重搜不是定位，所以是「搜尋地點中」而不是「定位中」，
+          // 而且沒有關鍵字可以顯示。
+          expect(find.byType(SearchLoader), findsOneWidget);
+          expect(find.textContaining('explore.searching'), findsOneWidget);
+          expect(find.byKey(const Key('search-loader-name')), findsNothing);
+
+          await tester.pump(const Duration(milliseconds: 500));
+          expect(find.byType(SearchLoader), findsNothing);
+        },
+      );
     });
 
     group('globe back button', () {

--- a/frontend/test/features/narration/presentation/screens/select_story_hook_screen_test.dart
+++ b/frontend/test/features/narration/presentation/screens/select_story_hook_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:context_app/features/journey/providers.dart';
 import 'package:context_app/features/narration/domain/models/story_hook.dart';
 import 'package:context_app/features/narration/domain/services/story_hook_service.dart';
 import 'package:context_app/features/narration/presentation/screens/select_story_hook_screen.dart';
+import 'package:context_app/features/narration/presentation/widgets/story_generating.dart';
 import 'package:context_app/features/narration/providers.dart';
 import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:context_app/features/usage/providers.dart';
@@ -79,7 +80,8 @@ void main() {
 
     testWidgets(
       'given the hook service is still loading, '
-      'then the loading state shows the loading copy',
+      'then the scan-phase generating animation shows the digging copy '
+      'and its step checklist',
       (tester) async {
         final gate = Completer<void>();
         await _pumpScreen(
@@ -90,13 +92,69 @@ void main() {
           ),
           settle: false,
         );
+        await tester.pump(const Duration(milliseconds: 50));
 
-        expect(find.text('story_hook.loading'), findsOneWidget);
+        expect(find.byType(StoryGenerating), findsOneWidget);
+        expect(find.text('story_generating.scan_title'), findsOneWidget);
+        expect(find.text('story_generating.scan_sub'), findsOneWidget);
+        expect(find.text('story_generating.scan_step_1'), findsOneWidget);
+        expect(find.text('story_generating.scan_step_3'), findsOneWidget);
 
         // Release the gate so autoDispose teardown doesn't leak a pending
         // future into the next test.
         gate.complete();
         await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'given the generating animation runs, when the step interval elapses, '
+      'then the first step is marked done with a check',
+      (tester) async {
+        final gate = Completer<void>();
+        await _pumpScreen(
+          tester,
+          hookService: _FakeStoryHookService(gate: gate),
+          settle: false,
+        );
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(find.byIcon(Icons.check), findsNothing);
+
+        await tester.pump(const Duration(seconds: 3));
+
+        expect(find.byIcon(Icons.check), findsOneWidget);
+
+        gate.complete();
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'given a hook is tapped and generation is in flight, '
+      'then the write-phase animation shows the writing copy, '
+      'and the player opens once generation completes',
+      (tester) async {
+        final narrationService = FakeNarrationService()
+          ..gate = Completer<void>();
+
+        await _pumpScreenWithRouter(
+          tester,
+          hookService: _FakeStoryHookService(hooks: const [_hook1]),
+          narrationService: narrationService,
+        );
+
+        await tester.tap(find.text(_hook1.title));
+        await tester.pump(const Duration(milliseconds: 50));
+
+        expect(find.byType(StoryGenerating), findsOneWidget);
+        expect(find.text('story_generating.write_title'), findsOneWidget);
+        expect(find.text('story_generating.write_step_1'), findsOneWidget);
+
+        narrationService.gate!.complete();
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('player-screen')), findsOneWidget);
       },
     );
 


### PR DESCRIPTION
## Summary
依 Claude Design 設計稿（Lorescape Redesign v3）補上兩處載入體驗：

- **探索頁搜尋／定位載入遮罩**（`.search-loader`）：半透明遮罩＋雙環 spinner 紙卡；定位顯示「定位中」、關鍵字搜尋顯示搜尋詞、可視範圍重搜顯示「搜尋地點中」。
- **故事生成頁整頁動畫**（`.gen` / `.genscr`）：勳章雙環＋脈衝、步驟清單（進行中漣漪、完成打勾）、羽毛筆手稿卡循環書寫、底部進度條；「挖掘故事線」與「寫下故事」兩階段共用，生成中版面切為 210px 標頭＋動畫填滿其餘空間。

## Test plan
- [x] `fvm flutter test`（641 tests 全數通過，含新增的 6 個 widget tests）
- [x] `fvm flutter analyze --fatal-infos` 無問題

🤖 Generated with [Claude Code](https://claude.com/claude-code)