### PR TITLE
Add NSLocationAlwaysAndWhenInUseUsageDescription to iOS Info.plist

### DIFF
--- a/frontend/ios/Runner/Info.plist
+++ b/frontend/ios/Runner/Info.plist
@@ -53,6 +53,8 @@
 		<false/>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
+		<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+		<string>此應用程式需要存取您的位置來顯示附近的地點</string>
 		<key>NSLocationWhenInUseUsageDescription</key>
 		<string>此應用程式需要存取您的位置來顯示附近的地點</string>
 		<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
Fixes App Store Connect warning ITMS-90683 (missing purpose string):
a dependency references the always-location API, so Apple requires
this key even though the app only uses when-in-use location.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013AKTHqXnPnvvKQd6kY4Ysx