### PR TITLE
首頁地球儀釘點互動與探索頁地圖地名標籤

### DIFF
--- a/frontend/lib/features/explore/presentation/screens/explore_screen.dart
+++ b/frontend/lib/features/explore/presentation/screens/explore_screen.dart
@@ -183,11 +183,12 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen> {
                         place.location.latitude,
                         place.location.longitude,
                       ),
-                      width: PlaceMapPin.markerSize,
-                      height: PlaceMapPin.markerSize,
+                      width: LabeledPlaceMapPin.markerWidth,
+                      height: LabeledPlaceMapPin.markerHeight,
                       // 尖端落在座標上：把標記整個往上推一個身高。
                       alignment: Alignment.topCenter,
-                      child: PlaceMapPin(
+                      child: LabeledPlaceMapPin(
+                        label: place.name,
                         category: place.category.journalCategory,
                         onTap: () => context.pushNamed('config', extra: place),
                       ),

--- a/frontend/lib/features/explore/presentation/widgets/place_map_pin.dart
+++ b/frontend/lib/features/explore/presentation/widgets/place_map_pin.dart
@@ -4,6 +4,81 @@ import 'package:context_app/app/config/lorescape_tokens.dart';
 import 'package:context_app/shared/widgets/journal/journal_category.dart';
 import 'package:flutter/material.dart';
 
+/// 地圖上的地點標記＋上方的地名 chip，樣式對齊首頁地球儀選中地點的紙卡
+/// chip（紙色圓角膠囊、陶土色小圓點、粗體地名），但每個標記都常駐顯示，
+/// 沒有「選中」狀態。
+class LabeledPlaceMapPin extends StatelessWidget {
+  const LabeledPlaceMapPin({
+    super.key,
+    required this.label,
+    required this.category,
+    this.onTap,
+  });
+
+  final String label;
+  final JournalCategory category;
+
+  /// 點 chip 或水滴 pin 都觸發同一個動作。
+  final VoidCallback? onTap;
+
+  /// `Marker` 的尺寸：寬要放得下地名 chip（超過就省略號），高是
+  /// chip＋間距＋pin；多出來的空間靠 [MainAxisAlignment.end] 留在上方，
+  /// 讓 pin 的底邊貼齊 Marker 底邊（尖端錨在座標上的邏輯不變）。
+  static const double markerWidth = 168;
+  static const double markerHeight = 64;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        GestureDetector(
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+            decoration: BoxDecoration(
+              color: tokens.paperRaised,
+              border: Border.all(color: tokens.line),
+              borderRadius: BorderRadius.circular(999),
+              boxShadow: tokens.e1,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 6,
+                  height: 6,
+                  decoration: BoxDecoration(
+                    color: tokens.clay,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.4,
+                      color: tokens.ink,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        PlaceMapPin(category: category, onTap: onTap),
+      ],
+    );
+  }
+}
+
 /// 地圖上的地點標記，對應設計稿的 `.map-pin`：水滴造型、紙色描邊與內點。
 ///
 /// 造型做法與設計稿一致——圓角 `50% 50% 50% 0` 的方塊旋轉 -45°，讓左下角

--- a/frontend/lib/features/home/presentation/screens/globe_home_screen.dart
+++ b/frontend/lib/features/home/presentation/screens/globe_home_screen.dart
@@ -129,6 +129,23 @@ class _GlobeHomeScreenState extends ConsumerState<GlobeHomeScreen> {
                           outline: outline,
                           pins: pins,
                           focus: active,
+                          // 點非選中的釘點：把那篇故事切成選中，地球飛過
+                          // 去、卡片列也捲到那張卡（StoryRail 會跟上）。
+                          onPinTap: (pin) {
+                            final index = stories.indexWhere(
+                              (story) =>
+                                  story.publishDate.toIso8601String() == pin.id,
+                            );
+                            if (index < 0 || index == _activeIndex) return;
+                            setState(() => _activeIndex = index);
+                          },
+                          // 點選中地點的地名 chip：直接進那篇每日故事。
+                          onFocusTap: _activeIndex < stories.length
+                              ? () => context.push(
+                                  '/daily-story/detail',
+                                  extra: stories[_activeIndex],
+                                )
+                              : null,
                         ),
                       ),
                     ),

--- a/frontend/lib/features/home/presentation/widgets/globe_painter.dart
+++ b/frontend/lib/features/home/presentation/widgets/globe_painter.dart
@@ -31,6 +31,10 @@ class GlobePainter extends CustomPainter {
   /// 網格線的間隔（度）。
   static const double _graticuleStep = 10;
 
+  /// 釘點可見的角距上限（弧度）。太靠近球緣的點視覺上已貼在邊上，標籤會
+  /// 壓到球外，不畫也不參與點擊命中（GlobeView 的 tap 判定共用這個值）。
+  static const double maxPinAngularDistance = 1.4;
+
   @override
   void paint(Canvas canvas, Size size) {
     final radius = size.width / 2 - 3;
@@ -154,8 +158,10 @@ class GlobePainter extends CustomPainter {
 
     for (final pin in pins) {
       if (pin.id == focusId) continue;
-      // 太靠近球緣的點在視覺上已經貼在邊上，標籤會壓到球外，直接不畫。
-      if (projection.angularDistanceTo(pin.coordinate) > 1.4) continue;
+      if (projection.angularDistanceTo(pin.coordinate) >
+          maxPinAngularDistance) {
+        continue;
+      }
       final offset = projection.project(pin.coordinate);
       if (offset == null) continue;
 

--- a/frontend/lib/features/home/presentation/widgets/globe_view.dart
+++ b/frontend/lib/features/home/presentation/widgets/globe_view.dart
@@ -19,6 +19,8 @@ class GlobeView extends StatefulWidget {
     required this.outline,
     required this.pins,
     required this.focus,
+    this.onPinTap,
+    this.onFocusTap,
     this.size = 344,
   });
 
@@ -30,10 +32,24 @@ class GlobeView extends StatefulWidget {
   /// 目前選中的故事地點。可能不在 [pins] 內（捲到更舊的卡片時）。
   final GlobePin? focus;
 
+  /// 點到非選中的釘點時回呼，首頁拿它把該篇故事切成選中（地球飛過去）。
+  final ValueChanged<GlobePin>? onPinTap;
+
+  /// 點選中地點的紙卡 chip（地名）時回呼，首頁拿它開那篇每日故事。
+  final VoidCallback? onFocusTap;
+
   final double size;
 
   /// 測試用來抓畫布與拖曳目標。
   static const Key canvasKey = Key('globe-canvas');
+
+  /// focus marker 的固定外框（Positioned 的尺寸）。不能用
+  /// FractionalTranslation 把內容平移出外框——畫得出來（Stack 不裁切）但
+  /// hit test 過不了 RenderBox 的 bounds 檢查，chip 會點不到。改成外框直接
+  /// 罩住內容的實際位置，內容靠 [Alignment.bottomCenter] 貼底，pin 尖端
+  /// 仍然錨在投影點上。寬高留給大字級的餘裕（chip 一行、最長地名省略）。
+  static const double focusMarkerWidth = 280;
+  static const double focusMarkerHeight = 132;
 
   @override
   State<GlobeView> createState() => _GlobeViewState();
@@ -82,9 +98,52 @@ class _GlobeViewState extends State<GlobeView>
     super.dispose();
   }
 
-  void _onDragStart(DragStartDetails _) => _controller.stop();
+  /// 釘點只是 4.5px 的小圓，命中判定放寬到這個半徑才點得到。
+  static const double _pinTapRadius = 24;
+
+  /// pan 累積位移小於這個值就當成點擊。不另掛 TapGestureRecognizer——它會
+  /// 跟 pan 搶 gesture arena，pan 得先吃掉 touch slop 才啟動，拖曳的前
+  /// ~20px 會不轉（drag gain 測試抓得到這個回歸）。
+  static const double _tapSlop = 12;
+
+  Offset _panStart = Offset.zero;
+  double _panDistance = 0;
+
+  void _onDragStart(DragStartDetails details) {
+    _controller.stop();
+    _panStart = details.localPosition;
+    _panDistance = 0;
+  }
+
+  /// pan 放開時若幾乎沒有位移，視為點擊：找出最近且在命中半徑內的非選中
+  /// 釘點。
+  void _onDragEnd(OrthographicProjection projection) {
+    if (_panDistance > _tapSlop) return;
+    final onPinTap = widget.onPinTap;
+    if (onPinTap == null) return;
+
+    GlobePin? nearest;
+    var nearestDistance = _pinTapRadius;
+    for (final pin in widget.pins) {
+      if (pin.id == widget.focus?.id) continue;
+      // 跟 GlobePainter 同一套可見性判斷：畫不出來的點也不該點得到。
+      if (projection.angularDistanceTo(pin.coordinate) >
+          GlobePainter.maxPinAngularDistance) {
+        continue;
+      }
+      final offset = projection.project(pin.coordinate);
+      if (offset == null) continue;
+      final distance = (offset - _panStart).distance;
+      if (distance < nearestDistance) {
+        nearest = pin;
+        nearestDistance = distance;
+      }
+    }
+    if (nearest != null) onPinTap(nearest);
+  }
 
   void _onDragUpdate(DragUpdateDetails details) {
+    _panDistance += details.delta.distance;
     setState(() {
       _rotation = GlobeRotation(
         _rotation.lambda + details.delta.dx * _dragGain,
@@ -130,6 +189,7 @@ class _GlobeViewState extends State<GlobeView>
               GestureDetector(
                 onPanStart: _onDragStart,
                 onPanUpdate: _onDragUpdate,
+                onPanEnd: (_) => _onDragEnd(projection),
                 child: CustomPaint(
                   key: GlobeView.canvasKey,
                   size: Size.square(effectiveSize),
@@ -146,13 +206,22 @@ class _GlobeViewState extends State<GlobeView>
               // 等飛行動畫轉過去再顯示。
               if (focus != null && focusOffset != null)
                 Positioned(
-                  left: focusOffset.dx,
-                  top: focusOffset.dy,
+                  // 外框的底邊中點對齊投影點，水滴 pin 的尖端剛好落在座標
+                  // 上（外框尺寸的取捨見 focusMarkerWidth 的註解）。
+                  left: focusOffset.dx - GlobeView.focusMarkerWidth / 2,
+                  top: focusOffset.dy - GlobeView.focusMarkerHeight,
+                  width: GlobeView.focusMarkerWidth,
+                  height: GlobeView.focusMarkerHeight,
+                  // 淡出（轉到背面）期間整組不可點，避免點到看不見的 chip。
                   child: IgnorePointer(
+                    ignoring: !focusVisible,
                     child: AnimatedOpacity(
                       opacity: focusVisible ? 1 : 0,
                       duration: const Duration(milliseconds: 250),
-                      child: _FocusMarker(label: focus.label),
+                      child: _FocusMarker(
+                        label: focus.label,
+                        onTap: widget.onFocusTap,
+                      ),
                     ),
                   ),
                 ),
@@ -176,50 +245,59 @@ const double _pinBox = _pinSize * 1.4142135624;
 const Color _pinBorder = Color(0xFFFBF1E9);
 
 class _FocusMarker extends StatelessWidget {
-  const _FocusMarker({required this.label});
+  const _FocusMarker({required this.label, this.onTap});
 
   final String label;
+
+  /// 點地名 chip 時回呼；水滴 pin 本身不可點（讓點擊穿透到底下的地球）。
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final tokens = context.tokens;
-    // 外層 Positioned 把左上角放在投影點上。這裡水平往左推半個自身寬度做
-    // 置中、垂直往上推一整個高度，讓水滴 pin 的尖端剛好落在座標上。寬度
-    // 隨地名長短變動，所以用比例位移而不是寫死的 Offset。
-    return FractionalTranslation(
-      translation: const Offset(-0.5, -1),
+    // 外層 Positioned 給的是比內容大的固定外框；貼底置中讓 pin 尖端錨在
+    // 投影點上，多出來的空間留在上方（Align 本身不擋點擊）。
+    return Align(
+      alignment: Alignment.bottomCenter,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            decoration: BoxDecoration(
-              color: tokens.paperRaised,
-              border: Border.all(color: tokens.line),
-              borderRadius: BorderRadius.circular(999),
-              boxShadow: tokens.e2,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 8,
-                  height: 8,
-                  decoration: BoxDecoration(
-                    color: tokens.clay,
-                    shape: BoxShape.circle,
+          GestureDetector(
+            onTap: onTap,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: tokens.paperRaised,
+                border: Border.all(color: tokens.line),
+                borderRadius: BorderRadius.circular(999),
+                boxShadow: tokens.e2,
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: tokens.clay,
+                      shape: BoxShape.circle,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  label,
-                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: 0.96,
-                    color: tokens.ink,
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        letterSpacing: 0.96,
+                        color: tokens.ink,
+                      ),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 6),
@@ -230,38 +308,40 @@ class _FocusMarker extends StatelessWidget {
           // 尺寸取 ls3.css 的 `.gpin .map-pin`：36×36、內圈 11、2.5px 乳白
           // 描邊。旋轉後對角線比邊長多出 (√2-1)×36/2 ≈ 7.5px，所以外層要留
           // 這段空間，尖端才不會被 Column 的邊界裁掉。
-          SizedBox(
-            width: _pinBox,
-            height: _pinBox,
-            child: Center(
-              child: Transform.rotate(
-                angle: -math.pi / 4,
-                child: Container(
-                  width: _pinSize,
-                  height: _pinSize,
-                  decoration: BoxDecoration(
-                    color: tokens.clay,
-                    border: Border.all(color: _pinBorder, width: 2.5),
-                    borderRadius: const BorderRadius.only(
-                      topLeft: Radius.circular(_pinSize / 2),
-                      topRight: Radius.circular(_pinSize / 2),
-                      bottomRight: Radius.circular(_pinSize / 2),
-                    ),
-                    boxShadow: const [
-                      BoxShadow(
-                        color: Color.fromRGBO(28, 20, 10, 0.4),
-                        offset: Offset(0, 4),
-                        blurRadius: 9,
+          IgnorePointer(
+            child: SizedBox(
+              width: _pinBox,
+              height: _pinBox,
+              child: Center(
+                child: Transform.rotate(
+                  angle: -math.pi / 4,
+                  child: Container(
+                    width: _pinSize,
+                    height: _pinSize,
+                    decoration: BoxDecoration(
+                      color: tokens.clay,
+                      border: Border.all(color: _pinBorder, width: 2.5),
+                      borderRadius: const BorderRadius.only(
+                        topLeft: Radius.circular(_pinSize / 2),
+                        topRight: Radius.circular(_pinSize / 2),
+                        bottomRight: Radius.circular(_pinSize / 2),
                       ),
-                    ],
-                  ),
-                  child: Center(
-                    child: Container(
-                      width: 11,
-                      height: 11,
-                      decoration: const BoxDecoration(
-                        color: _pinBorder,
-                        shape: BoxShape.circle,
+                      boxShadow: const [
+                        BoxShadow(
+                          color: Color.fromRGBO(28, 20, 10, 0.4),
+                          offset: Offset(0, 4),
+                          blurRadius: 9,
+                        ),
+                      ],
+                    ),
+                    child: Center(
+                      child: Container(
+                        width: 11,
+                        height: 11,
+                        decoration: const BoxDecoration(
+                          color: _pinBorder,
+                          shape: BoxShape.circle,
+                        ),
                       ),
                     ),
                   ),

--- a/frontend/lib/features/home/presentation/widgets/story_rail.dart
+++ b/frontend/lib/features/home/presentation/widgets/story_rail.dart
@@ -44,6 +44,34 @@ class StoryRail extends StatefulWidget {
 class _StoryRailState extends State<StoryRail> {
   final ScrollController _controller = ScrollController();
 
+  /// didUpdateWidget 觸發的程式化捲動進行中。這段期間 [_onScroll] 要閉嘴：
+  /// activeIndex 已經是目的地了，中途經過的卡再回報 onActiveChanged 只會把
+  /// 它改回中間值；而且 animateTo 是在 build 中被呼叫的，它同步發出的
+  /// ScrollStart 若一路傳回 setState 會直接炸 setState-during-build。
+  bool _autoScrolling = false;
+
+  @override
+  void didUpdateWidget(StoryRail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // activeIndex 從外部改變時（點地球儀上的釘點）把那張卡捲到中間。
+    // 捲動自己觸發的變更（_onScroll 回報上來的）此時捲動位置已經在該卡
+    // 附近，round 出來就是新 index，直接略過，才不會跟使用者的手指打架。
+    if (widget.activeIndex == oldWidget.activeIndex) return;
+    if (!_controller.hasClients) return;
+    final scrollIndex = (_controller.position.pixels / StoryRail.stride)
+        .round();
+    if (scrollIndex == widget.activeIndex) return;
+    _autoScrolling = true;
+    _controller
+        .animateTo(
+          widget.activeIndex * StoryRail.stride,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        )
+        // 使用者中途伸手打斷也會 complete，flag 一定會被清掉。
+        .whenComplete(() => _autoScrolling = false);
+  }
+
   @override
   void dispose() {
     _controller.dispose();
@@ -51,6 +79,7 @@ class _StoryRailState extends State<StoryRail> {
   }
 
   bool _onScroll(ScrollNotification notification) {
+    if (_autoScrolling) return false;
     final index = (notification.metrics.pixels / StoryRail.stride)
         .round()
         .clamp(0, widget.stories.length - 1);

--- a/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
+++ b/frontend/test/features/explore/presentation/screens/explore_screen_test.dart
@@ -92,7 +92,7 @@ void main() {
           .top;
       final card = find
           .ancestor(
-            of: find.text('Senso-ji'),
+            of: _cardText('Senso-ji'),
             matching: find.byType(Container),
           )
           .first;
@@ -126,7 +126,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 20));
       await tester.pump(const Duration(milliseconds: 20));
 
-      expect(find.text('Searched Place'), findsOneWidget);
+      expect(_cardText('Searched Place'), findsOneWidget);
       expect(find.text('Nearby Place'), findsNothing);
     });
 
@@ -154,7 +154,7 @@ void main() {
 
         final textField = tester.widget<TextField>(find.byType(TextField));
         expect(textField.controller?.text, isEmpty);
-        expect(find.text('Nearby Place'), findsOneWidget);
+        expect(_cardText('Nearby Place'), findsOneWidget);
       },
     );
 
@@ -302,7 +302,7 @@ void main() {
           onConfigPush: extras.add,
         );
 
-        await tester.tap(find.text('Senso-ji'));
+        await tester.tap(_cardText('Senso-ji'));
         await tester.pumpAndSettle();
 
         // 點卡片本體是「把地圖飛到該地點」，不該離開探索頁——導頁只在
@@ -312,7 +312,8 @@ void main() {
     );
 
     testWidgets('given nearby places, when the screen loads, '
-        'then one map pin is rendered per place', (tester) async {
+        'then one map pin is rendered per place, '
+        'each with its name chip shown without needing focus', (tester) async {
       await _givenExploreScreen(
         tester,
         places: [
@@ -322,7 +323,29 @@ void main() {
       );
 
       expect(find.byType(PlaceMapPin), findsNWidgets(2));
+      expect(_markerLabel('Senso-ji'), findsOneWidget);
+      expect(_markerLabel('Meiji Shrine'), findsOneWidget);
     });
+
+    testWidgets(
+      'given a map pin under a router, when its name chip is tapped, '
+      'then the config route is pushed with the place as extra',
+      (tester) async {
+        final extras = <Object?>[];
+
+        await _givenExploreScreenWithRouter(
+          tester,
+          places: [buildPlace(id: 'p1', name: 'Senso-ji')],
+          onConfigPush: extras.add,
+        );
+
+        await tester.tap(_markerLabel('Senso-ji'));
+        await tester.pumpAndSettle();
+
+        expect(extras.single, isA<Place>());
+        expect((extras.single as Place).id, equals('p1'));
+      },
+    );
 
     group('location gate', () {
       testWidgets(
@@ -487,7 +510,7 @@ void main() {
 
           await tester.pump(const Duration(milliseconds: 500));
           expect(find.byType(SearchLoader), findsNothing);
-          expect(find.text('Searched Place'), findsOneWidget);
+          expect(_cardText('Searched Place'), findsOneWidget);
         },
       );
 
@@ -750,9 +773,20 @@ void _thenEmptyStateIsVisible() {
   expect(find.text('explore.empty'), findsOneWidget);
 }
 
+/// 地名同時出現在底部卡片與地圖 marker 的地名 chip 上；這裡限定在卡片列
+/// （唯一的 ListView）底下找，才不會誤數到 marker 的標籤。
+Finder _cardText(String name) =>
+    find.descendant(of: find.byType(ListView), matching: find.text(name));
+
+/// 地圖 marker 地名 chip 上的文字。
+Finder _markerLabel(String name) => find.descendant(
+  of: find.byType(LabeledPlaceMapPin),
+  matching: find.text(name),
+);
+
 void _thenPlaceNamesAreVisible(List<String> names) {
   for (final name in names) {
-    expect(find.text(name), findsOneWidget);
+    expect(_cardText(name), findsOneWidget);
   }
 }
 

--- a/frontend/test/features/home/presentation/screens/globe_home_screen_test.dart
+++ b/frontend/test/features/home/presentation/screens/globe_home_screen_test.dart
@@ -1,14 +1,18 @@
 import 'package:context_app/features/daily_story/domain/models/daily_story.dart';
 import 'package:context_app/features/daily_story/providers.dart';
 import 'package:context_app/features/explore/providers.dart';
+import 'package:context_app/features/home/domain/globe/globe_rotation.dart';
+import 'package:context_app/features/home/domain/globe/orthographic_projection.dart';
 import 'package:context_app/features/home/domain/globe/world_outline.dart';
 import 'package:context_app/features/home/presentation/screens/globe_home_screen.dart';
 import 'package:context_app/features/home/presentation/widgets/globe_view.dart';
+import 'package:context_app/features/home/presentation/widgets/story_rail.dart';
 import 'package:context_app/features/home/providers.dart';
 import 'package:context_app/features/settings/domain/models/language.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:latlong2/latlong.dart';
 
 import '../../../../fakes/fake_places_repository.dart';
 import '../../../../fakes/in_memory_daily_story_repository.dart';
@@ -148,6 +152,71 @@ void main() {
     await _givenHome(tester, pushed: pushed);
 
     await tester.tap(find.byKey(const Key('story-card-2026-07-28')));
+    await tester.pumpAndSettle();
+
+    expect(pushed.single, isA<DailyStory>());
+    expect((pushed.single as DailyStory).placeName, '聖伯多祿大殿');
+  });
+
+  testWidgets('given the globe home, '
+      'when the user taps a non-focused pin on the globe, '
+      'then that story becomes the selected one (globe focus + rail scroll) '
+      'without opening the story', (tester) async {
+    // 地點放得近，選中第 0 篇時其他釘點也在球的正面、點得到；6 篇讓卡片
+    // 列的內容超出視窗寬度，捲到第 1 張卡的斷言才有捲動距離可用。
+    _stories.seed([
+      for (var i = 0; i < 6; i++)
+        _story(
+          date: _dateAt(i),
+          place: '地點$i',
+          latitude: 30 + i.toDouble(),
+          longitude: 100 + i.toDouble(),
+        ),
+    ]);
+    final pushed = <Object?>[];
+    await _givenHome(tester, pushed: pushed);
+
+    // 用跟 GlobeView 相同的投影參數（預設尺寸 344）算出第 1 篇釘點的
+    // 畫布座標，直接點在它上面。
+    const size = 344.0;
+    final projection = OrthographicProjection(
+      rotation: GlobeRotation.facing(const LatLng(30, 100)),
+      center: const Offset(size / 2, size / 2),
+      radius: size / 2 - 3,
+    );
+    final target =
+        tester.getTopLeft(find.byKey(GlobeView.canvasKey)) +
+        projection.project(const LatLng(31, 101))!;
+    await tester.tapAt(target);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<GlobeView>(find.byType(GlobeView)).focus?.label,
+      '地點1',
+      reason: '點非選中的釘點要直接把 focus 換成那個地點',
+    );
+    expect(
+      tester.widget<ListView>(find.byType(ListView)).controller!.offset,
+      closeTo(StoryRail.stride, 1.0),
+      reason: '卡片列要跟著捲到那篇故事',
+    );
+    expect(pushed, isEmpty, reason: '點非選中的釘點只切換選中，不該開故事');
+  });
+
+  testWidgets('given the globe home, '
+      'when the user taps the focused pin’s label chip on the globe, '
+      'then the daily story detail is pushed with that story', (tester) async {
+    final pushed = <Object?>[];
+    await _givenHome(tester, pushed: pushed);
+
+    // 選中地點的地名同時出現在地球 chip 與底部卡片上，限定在 GlobeView
+    // 底下找才點得到 chip。
+    await tester.tap(
+      find.descendant(
+        of: find.byType(GlobeView),
+        matching: find.text('聖伯多祿大殿'),
+      ),
+    );
     await tester.pumpAndSettle();
 
     expect(pushed.single, isA<DailyStory>());

--- a/frontend/test/features/home/presentation/widgets/globe_view_test.dart
+++ b/frontend/test/features/home/presentation/widgets/globe_view_test.dart
@@ -23,19 +23,46 @@ const _taichung = GlobePin(
   label: '四面佛寺',
 );
 
-Future<void> _givenGlobe(WidgetTester tester, {GlobePin? focus}) async {
+/// 跟羅馬同一面（角距遠小於可見上限）的釘點，點擊測試用。
+const _paris = GlobePin(
+  id: 'louvre',
+  coordinate: LatLng(48.86, 2.35),
+  label: '羅浮宮',
+);
+
+Future<void> _givenGlobe(
+  WidgetTester tester, {
+  GlobePin? focus,
+  List<GlobePin> pins = const [_rome, _taichung],
+  ValueChanged<GlobePin>? onPinTap,
+  VoidCallback? onFocusTap,
+}) async {
   await pumpScreen(
     tester,
     child: Scaffold(
       body: Center(
         child: GlobeView(
           outline: _outline,
-          pins: const [_rome, _taichung],
+          pins: pins,
           focus: focus ?? _rome,
+          onPinTap: onPinTap,
+          onFocusTap: onFocusTap,
         ),
       ),
     ),
   );
+}
+
+/// 以預設尺寸（344）的投影換算 [coordinate] 在畫布上的位置。
+Offset _canvasOffsetOf(WidgetTester tester, LatLng focus, LatLng coordinate) {
+  const size = 344.0;
+  final projection = OrthographicProjection(
+    rotation: GlobeRotation.facing(focus),
+    center: const Offset(size / 2, size / 2),
+    radius: size / 2 - 3,
+  );
+  return tester.getTopLeft(find.byKey(GlobeView.canvasKey)) +
+      projection.project(coordinate)!;
 }
 
 void main() {
@@ -73,6 +100,51 @@ void main() {
     final expected = GlobeRotation.facing(_taichung.coordinate);
     expect(rotation.lambda, closeTo(expected.lambda, 0.01));
     expect(rotation.phi, closeTo(expected.phi, 0.01));
+  });
+
+  testWidgets('given a globe focused on one pin, '
+      'when the user taps another visible pin on the canvas, '
+      'then onPinTap fires with that pin', (tester) async {
+    GlobePin? tapped;
+    await _givenGlobe(
+      tester,
+      pins: const [_rome, _paris],
+      onPinTap: (pin) => tapped = pin,
+    );
+
+    await tester.tapAt(
+      _canvasOffsetOf(tester, _rome.coordinate, _paris.coordinate),
+    );
+
+    expect(tapped?.id, _paris.id);
+  });
+
+  testWidgets('given a globe focused on one pin, '
+      'when the user taps empty ocean far from any pin, '
+      'then onPinTap does not fire', (tester) async {
+    GlobePin? tapped;
+    await _givenGlobe(
+      tester,
+      pins: const [_rome, _paris],
+      onPinTap: (pin) => tapped = pin,
+    );
+
+    // 球的左下角落（離羅馬與巴黎的投影都遠超過命中半徑）。
+    final canvasTopLeft = tester.getTopLeft(find.byKey(GlobeView.canvasKey));
+    await tester.tapAt(canvasTopLeft + const Offset(80, 280));
+
+    expect(tapped, isNull);
+  });
+
+  testWidgets('given a focused pin with its label chip shown, '
+      'when the user taps the chip, '
+      'then onFocusTap fires', (tester) async {
+    var focusTapped = false;
+    await _givenGlobe(tester, onFocusTap: () => focusTapped = true);
+
+    await tester.tap(find.text(_rome.label));
+
+    expect(focusTapped, isTrue);
   });
 
   testWidgets('given a rendered globe, '
@@ -137,8 +209,15 @@ void main() {
       center: const Offset(narrowWidth / 2, narrowWidth / 2),
       radius: narrowWidth / 2 - 3,
     );
+    // 外框的底邊中點錨在投影點上（pin 尖端落在座標）。
     final expectedOffset = expectedProjection.project(_rome.coordinate)!;
-    expect(positioned.left, closeTo(expectedOffset.dx, 0.5));
-    expect(positioned.top, closeTo(expectedOffset.dy, 0.5));
+    expect(
+      positioned.left,
+      closeTo(expectedOffset.dx - GlobeView.focusMarkerWidth / 2, 0.5),
+    );
+    expect(
+      positioned.top,
+      closeTo(expectedOffset.dy - GlobeView.focusMarkerHeight, 0.5),
+    );
   });
 }

--- a/frontend/test/features/home/presentation/widgets/story_rail_test.dart
+++ b/frontend/test/features/home/presentation/widgets/story_rail_test.dart
@@ -108,6 +108,24 @@ void main() {
   );
 
   testWidgets(
+    'given the rail resting on the first card, '
+    'when activeIndex changes from outside (a globe pin tap), '
+    'then the rail scrolls that card to its boundary',
+    (tester) async {
+      await _givenRail(tester, count: 8);
+
+      await _givenRail(tester, count: 8, activeIndex: 3);
+      await tester.pumpAndSettle();
+
+      final offset = tester
+          .widget<ListView>(find.byType(ListView))
+          .controller!
+          .offset;
+      expect(offset, closeTo(3 * StoryRail.stride, 1.0));
+    },
+  );
+
+  testWidgets(
     'given the story rail at the first card, '
     'when the user flicks quickly but drags less than half a card, '
     'then it still advances to the next card instead of springing back',


### PR DESCRIPTION
## 摘要
- 首頁地球儀：點非選中的釘點直接把該篇故事切成選中（地球飛過去、卡片列跟著捲）；點選中地點的地名 chip 直接進該篇每日故事
- 探索頁地圖：每個標註上方常駐顯示地名 chip（與地球儀 focus chip 同視覺語言），點 chip 或 pin 都進地點設定頁

## 測試
- `fvm flutter analyze --fatal-infos` 無問題
- `fvm flutter test` 全數通過（648）

🤖 Generated with [Claude Code](https://claude.com/claude-code)